### PR TITLE
Add Spark RegexTokenizer as FeatureTransformer

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
@@ -71,6 +71,7 @@ object Bundle {
       val stopwords_remover = "stopwords_remover"
       val word_to_vector = "word_to_vector"
       val multinomial_labeler = "multinomial_labeler"
+      val regex_tokenizer = "regex_tokenizer"
     }
 
     object classification {

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/RegexTokenizerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/RegexTokenizerModel.scala
@@ -1,0 +1,13 @@
+package ml.combust.mleap.core.feature
+
+import scala.util.matching.Regex
+
+case class RegexTokenizerModel(regex: Regex, matchGaps: Boolean = true, tokenMinLength: Int = 1, lowercaseText: Boolean = true) extends Serializable {
+
+  def apply(raw: String): Seq[String] = {
+    val text = if (lowercaseText) raw.toLowerCase else raw
+    val tokens = if (matchGaps) regex.split(text).toSeq else regex.findAllIn(text).toSeq
+
+    tokens.filter(_.length >= tokenMinLength)
+  }
+}

--- a/mleap-runtime/src/main/resources/reference.conf
+++ b/mleap-runtime/src/main/resources/reference.conf
@@ -50,6 +50,7 @@ ml.combust.mleap.builtin-ops = [
   "ml.combust.mleap.bundle.ops.feature.VectorIndexerOp",
   "ml.combust.mleap.bundle.ops.feature.VectorSlicerOp",
   "ml.combust.mleap.bundle.ops.feature.WordToVectorOp",
+  "ml.combust.mleap.bundle.ops.feature.RegexTokenizerOp",
 
   "ml.combust.mleap.bundle.ops.regression.AFTSurvivalRegressionOp",
   "ml.combust.mleap.bundle.ops.regression.DecisionTreeRegressionOp",

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/RegexTokenizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/RegexTokenizerOp.scala
@@ -24,7 +24,7 @@ class RegexTokenizerOp extends OpNode[MleapContext, RegexTokenizer, RegexTokeniz
     override def store(model: Model, obj: RegexTokenizerModel)
                       (implicit context: BundleContext[MleapContext]): Model = {
       model
-        .withAttr(RegexIdentifier, Value.string(obj.regex.regex))
+        .withAttr(RegexIdentifier, Value.string(obj.regex.toString()))
         .withAttr(MatchGapsIdentifier, Value.boolean(obj.matchGaps))
         .withAttr(MinTokenLengthIdentifer, Value.int(obj.tokenMinLength))
         .withAttr(LowercaseText, Value.boolean(obj.lowercaseText))

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/RegexTokenizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/RegexTokenizerOp.scala
@@ -1,0 +1,59 @@
+package ml.combust.mleap.bundle.ops.feature
+
+import ml.combust.bundle.BundleContext
+import ml.combust.bundle.dsl._
+import ml.combust.bundle.op.{OpModel, OpNode}
+import ml.combust.mleap.core.feature.RegexTokenizerModel
+import ml.combust.mleap.runtime.MleapContext
+import ml.combust.mleap.runtime.transformer.feature.RegexTokenizer
+
+import scala.util.matching.Regex
+
+class RegexTokenizerOp extends OpNode[MleapContext, RegexTokenizer, RegexTokenizerModel] {
+  override val Model: OpModel[MleapContext, RegexTokenizerModel] = new OpModel[MleapContext, RegexTokenizerModel] {
+
+    val RegexIdentifier = "regex"
+    val MatchGapsIdentifier = "match_gaps"
+    val MinTokenLengthIdentifer = "token_min_length"
+    val LowercaseText = "lowercase_text"
+
+    override val klazz: Class[RegexTokenizerModel] = classOf[RegexTokenizerModel]
+
+    override def opName: String = Bundle.BuiltinOps.feature.regex_tokenizer
+
+    override def store(model: Model, obj: RegexTokenizerModel)
+                      (implicit context: BundleContext[MleapContext]): Model = {
+      model
+        .withAttr(RegexIdentifier, Value.string(obj.regex.regex))
+        .withAttr(MatchGapsIdentifier, Value.boolean(obj.matchGaps))
+        .withAttr(MinTokenLengthIdentifer, Value.int(obj.tokenMinLength))
+        .withAttr(LowercaseText, Value.boolean(obj.lowercaseText))
+    }
+
+    override def load(model: Model)
+                     (implicit context: BundleContext[MleapContext]): RegexTokenizerModel = {
+      RegexTokenizerModel(
+        regex = new Regex(model.value(RegexIdentifier).getString),
+        matchGaps = model.value(MatchGapsIdentifier).getBoolean,
+        tokenMinLength = model.value(MinTokenLengthIdentifer).getInt,
+        lowercaseText = model.value(LowercaseText).getBoolean
+      )
+    }
+  }
+
+  override val klazz: Class[RegexTokenizer] = classOf[RegexTokenizer]
+
+  override def name(node: RegexTokenizer): String = node.uid
+
+  override def model(node: RegexTokenizer): RegexTokenizerModel = node.model
+
+  override def load(node: Node, model: RegexTokenizerModel)
+                   (implicit context: BundleContext[MleapContext]): RegexTokenizer = {
+    RegexTokenizer(uid = node.name,
+      inputCol = node.shape.standardInput.name,
+      outputCol = node.shape.standardOutput.name,
+      model = model)
+  }
+
+  override def shape(node: RegexTokenizer): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/RegexTokenizer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/RegexTokenizer.scala
@@ -1,0 +1,14 @@
+package ml.combust.mleap.runtime.transformer.feature
+
+import ml.combust.mleap.core.feature.RegexTokenizerModel
+import ml.combust.mleap.runtime.function.UserDefinedFunction
+import ml.combust.mleap.runtime.transformer.{FeatureTransformer, Transformer}
+
+case class RegexTokenizer(override val uid: String = Transformer.uniqueName("regex_tokenizer"),
+                          override val inputCol: String,
+                          override val outputCol: String,
+                          model: RegexTokenizerModel
+                         ) extends FeatureTransformer {
+
+  override val exec: UserDefinedFunction = (value: String) => model(value)
+}

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/RegexTokenizerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/RegexTokenizerSpec.scala
@@ -1,0 +1,50 @@
+package ml.combust.mleap.runtime.transformer.feature
+
+import ml.combust.mleap.core.feature.{RegexTokenizerModel, StringIndexerModel}
+import ml.combust.mleap.runtime.types.{StringType, StructField, StructType}
+import ml.combust.mleap.runtime.{LeapFrame, LocalDataset, Row}
+import org.scalatest.FunSpec
+
+class RegexTokenizerSpec extends FunSpec {
+  val schema = StructType(Seq(StructField("test_string", StringType()))).get
+  val dataset = LocalDataset(Seq(Row("dies isT Ein TEST text te")))
+  val frame = LeapFrame(schema, dataset)
+
+  val gapRegexTokenizer = RegexTokenizer(
+    inputCol = "test_string",
+    outputCol = "test_tokens",
+    model = RegexTokenizerModel(
+      regex = """\s""".r,
+      matchGaps = true,
+      tokenMinLength = 3,
+      lowercaseText = true
+    )
+  )
+
+  val wordRegexTokenizer = RegexTokenizer(
+    inputCol = "test_string",
+    outputCol = "test_tokens",
+    model = RegexTokenizerModel(
+      regex = """\w+""".r,
+      matchGaps = false,
+      tokenMinLength = 4,
+      lowercaseText = false
+    )
+  )
+
+  describe("#transform") {
+    it("converts input string into tokens by matching the gap") {
+      val frame2 = gapRegexTokenizer.transform(frame).get
+      val data = frame2.dataset.toArray
+
+      assert(data(0).getSeq(1) == Seq("dies", "ist", "ein", "test", "text"))
+    }
+
+    it("converts input string into tokens by matching the words") {
+      val frame2 = wordRegexTokenizer.transform(frame).get
+      val data = frame2.dataset.toArray
+
+      assert(data(0).getSeq(1) == Seq("dies", "TEST", "text"))
+    }
+  }
+}

--- a/mleap-spark/src/main/resources/reference.conf
+++ b/mleap-spark/src/main/resources/reference.conf
@@ -58,6 +58,7 @@ ml.combust.mleap.spark.registry.base-ops = [
   "org.apache.spark.ml.bundle.ops.feature.VectorIndexerOp",
   "org.apache.spark.ml.bundle.ops.feature.VectorSlicerOp",
   "org.apache.spark.ml.bundle.ops.feature.WordToVectorOp",
+  "org.apache.spark.ml.bundle.ops.feature.RegexTokenizerOp",
 
   "org.apache.spark.ml.bundle.ops.regression.AFTSurvivalRegressionOp",
   "org.apache.spark.ml.bundle.ops.regression.DecisionTreeRegressionOp",

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/RegexTokenizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/RegexTokenizerOp.scala
@@ -1,0 +1,60 @@
+package org.apache.spark.ml.bundle.ops.feature
+
+import ml.combust.bundle.BundleContext
+import ml.combust.bundle.dsl._
+import ml.combust.bundle.op.{OpModel, OpNode}
+import org.apache.spark.ml.bundle.SparkBundleContext
+import org.apache.spark.ml.feature.RegexTokenizer
+
+class RegexTokenizerOp extends OpNode[SparkBundleContext, RegexTokenizer, RegexTokenizer] {
+  override val Model: OpModel[SparkBundleContext, RegexTokenizer] = new OpModel[SparkBundleContext, RegexTokenizer] {
+
+    val RegexIdentifier = "regex"
+    val MatchGapsIdentifier = "match_gaps"
+    val MinTokenLengthIdentifer = "token_min_length"
+    val LowercaseText = "lowercase_text"
+
+    override val klazz: Class[RegexTokenizer] = classOf[RegexTokenizer]
+
+    override def opName: String = Bundle.BuiltinOps.feature.regex_tokenizer
+
+    override def store(model: Model, obj: RegexTokenizer)
+                      (implicit context: BundleContext[SparkBundleContext]): Model = {
+
+      model
+        .withAttr(RegexIdentifier, Value.string(obj.getPattern))
+        .withAttr(MatchGapsIdentifier, Value.boolean(obj.getGaps))
+        .withAttr(MinTokenLengthIdentifer, Value.int(obj.getMinTokenLength))
+        .withAttr(LowercaseText, Value.boolean(obj.getToLowercase))
+    }
+
+    override def load(model: Model)
+                     (implicit context: BundleContext[SparkBundleContext]): RegexTokenizer = {
+
+      new RegexTokenizer(uid = "")
+        .setPattern(model.value(RegexIdentifier).getString)
+        .setGaps(model.value(MatchGapsIdentifier).getBoolean)
+        .setMinTokenLength(model.value(MinTokenLengthIdentifer).getInt)
+        .setToLowercase(model.value(LowercaseText).getBoolean)
+    }
+  }
+
+  override val klazz: Class[RegexTokenizer] = classOf[RegexTokenizer]
+
+  override def name(node: RegexTokenizer): String = node.uid
+
+  override def model(node: RegexTokenizer): RegexTokenizer = node
+
+  override def load(node: Node, model: RegexTokenizer)
+                   (implicit context: BundleContext[SparkBundleContext]): RegexTokenizer = {
+    new RegexTokenizer(uid = node.name)
+      .setInputCol(node.shape.standardInput.name)
+      .setOutputCol(node.shape.standardOutput.name)
+      .setPattern(model.getPattern)
+      .setGaps(model.getGaps)
+      .setMinTokenLength(model.getMinTokenLength)
+      .setToLowercase(model.getToLowercase)
+  }
+
+  override def shape(node: RegexTokenizer): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+}

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/RegexTokenizerParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/RegexTokenizerParitySpec.scala
@@ -1,0 +1,17 @@
+package org.apache.spark.ml.parity.feature
+
+import org.apache.spark.ml.parity.SparkParityBase
+import org.apache.spark.ml.Transformer
+import org.apache.spark.ml.feature.RegexTokenizer
+import org.apache.spark.sql.DataFrame
+
+class RegexTokenizerParitySpec extends SparkParityBase {
+  override val dataset: DataFrame = baseDataset.select("loan_title")
+  override val sparkTransformer: Transformer = new RegexTokenizer()
+    .setInputCol("loan_title")
+    .setOutputCol("loan_title_tokens")
+    .setGaps(true)
+    .setToLowercase(true)
+    .setMinTokenLength(2)
+    .setPattern("\\s")
+}


### PR DESCRIPTION
I have integrated the RegexTokenizer of Spark as Feature Transformer according to the documentation because I use it in my pipelines and would like to use mleap for pipeline execution.
A merge would be very much appreciated, hope I forgot nothing...