### PR TITLE
conflict resolution for scalatest between mleap-core and spark-mllib-local

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,7 +51,7 @@ object Dependencies {
 
   val base = l ++= Seq()
 
-  val core = l ++= Seq(sparkMllibLocal, jTransform, Test.scalaTest)
+  val core = l ++= Seq(sparkMllibLocal, jTransform, scalaTest)
 
   def runtime(scalaVersion: SettingKey[String]) = l ++= (Seq(Test.scalaTest) ++ scalaReflect.modules(scalaVersion.value))
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val akkaHttpVersion = "10.0.3"
 
   object Compile {
-    val sparkMllibLocal = "org.apache.spark" %% "spark-mllib-local" % sparkVersion
+    val sparkMllibLocal = "org.apache.spark" %% "spark-mllib-local" % sparkVersion excludeAll(ExclusionRule(organization = "org.scalatest"))
     val spark = Seq("org.apache.spark" %% "spark-core" % sparkVersion,
       "org.apache.spark" %% "spark-sql" % sparkVersion,
       "org.apache.spark" %% "spark-mllib" % sparkVersion,
@@ -51,7 +51,7 @@ object Dependencies {
 
   val base = l ++= Seq()
 
-  val core = l ++= Seq(sparkMllibLocal, jTransform, scalaTest)
+  val core = l ++= Seq(sparkMllibLocal, jTransform, Test.scalaTest)
 
   def runtime(scalaVersion: SettingKey[String]) = l ++= (Seq(Test.scalaTest) ++ scalaReflect.modules(scalaVersion.value))
 
@@ -63,7 +63,7 @@ object Dependencies {
 
   val sparkExtension = l ++= Provided.spark ++ Seq(Test.scalaTest)
 
-  val avro = l ++= Seq(avroDep)
+  val avro = l ++= Seq(avroDep, Test.scalaTest)
 
   val tensorflow = l ++= Seq(tensorflowDep)
 


### PR DESCRIPTION
Fixes #142 by including scalatest 3.0.0 at compile time in mleap-core because spark-mllib-local requires the scalatest at compile time due to its dependency on spark-tags. However, the only scalatest bit that's used in spark-tags is "import org.scalatest.TagAnnotation;" so this works the same in versions 2.2.6 and 3.0.0.

Alternatively, in Dependencies.scala, we could exclude the scalatest version brought by spark-mllib-local, if not having scalatest as a compile dependency is more preferable 

```
val sparkMllibLocal = "org.apache.spark" %% "spark-mllib-local" % sparkVersion excludeAll(ExclusionRule(organization = "org.scalatest"))
```

and the tests and build still pass.