### PR TITLE
Update "/transform" path in mleap-serving module to only accept POST method

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 import ml.combust.mleap.MleapProject
 
+enablePlugins(CrossPerProjectPlugin)
+
 lazy val root = MleapProject.root
 lazy val base = MleapProject.baseProject
 lazy val bundleMl = MleapProject.bundleMl

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,5 @@
 import ml.combust.mleap.MleapProject
 
-enablePlugins(CrossPerProjectPlugin)
-
 lazy val root = MleapProject.root
 lazy val base = MleapProject.baseProject
 lazy val bundleMl = MleapProject.bundleMl

--- a/mleap-serving/src/main/resources/application.conf
+++ b/mleap-serving/src/main/resources/application.conf
@@ -6,5 +6,3 @@ ml.combust.mleap.serving {
     bind-port = ${ml.combust.mleap.serving.http.port}
   }
 }
-
-ml.blah=hey

--- a/mleap-serving/src/main/scala/ml/combust/mleap/serving/MleapResource.scala
+++ b/mleap-serving/src/main/scala/ml/combust/mleap/serving/MleapResource.scala
@@ -45,8 +45,10 @@ class MleapResource(service: MleapService)
             complete(service.unloadModel(UnloadModelRequest()))
           }
         } ~ path("transform") {
-          entity(as[DefaultLeapFrame]) {
-            frame => complete(service.transform(frame))
+          post {
+            entity(as[DefaultLeapFrame]) {
+              frame => complete(service.transform(frame))
+            }
           }
         }
       }

--- a/mleap-serving/src/main/scala/ml/combust/mleap/serving/MleapServer.scala
+++ b/mleap-serving/src/main/scala/ml/combust/mleap/serving/MleapServer.scala
@@ -3,7 +3,7 @@ package ml.combust.mleap.serving
 import akka.actor.{ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.Config
 import ml.combust.mleap.serving.domain.v1.LoadModelRequest
 
 

--- a/mleap-serving/src/main/scala/ml/combust/mleap/serving/marshalling/ApiMarshalling.scala
+++ b/mleap-serving/src/main/scala/ml/combust/mleap/serving/marshalling/ApiMarshalling.scala
@@ -15,5 +15,6 @@ trait ApiMarshalling {
 
   implicit val mleapLoadModelResponseEntityMarshaller: ToEntityMarshaller[LoadModelResponse] = mleapLoadModelResponseFormat
   implicit val mleapUnloadModelResponseEntitytMarshaller: ToEntityMarshaller[UnloadModelResponse] = mleapUnloadModelResponseFormat
+  implicit val mleapLoadModelRequestEntityMarshaller: ToEntityMarshaller[LoadModelRequest] = mleapLoadModelRequestFormat
 }
 object ApiMarshalling extends ApiMarshalling

--- a/mleap-serving/src/test/resources/application.conf
+++ b/mleap-serving/src/test/resources/application.conf
@@ -1,0 +1,4 @@
+akka {
+  stdout-loglevel = "OFF"
+  loglevel = "OFF"
+}

--- a/mleap-serving/src/test/scala/ml/combust/mleap/serving/MleapResourceSpec.scala
+++ b/mleap-serving/src/test/scala/ml/combust/mleap/serving/MleapResourceSpec.scala
@@ -1,0 +1,85 @@
+package ml.combust.mleap.serving
+
+import akka.http.javadsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
+import ml.combust.mleap.serving.domain.v1.LoadModelRequest
+import ml.combust.mleap.serving.marshalling.{ApiMarshalling, LeapFrameMarshalling}
+import org.scalatest.{FunSpec, Matchers}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import ml.combust.mleap.runtime.DefaultLeapFrame
+
+class MleapResourceSpec extends FunSpec with Matchers with ScalatestRouteTest with LeapFrameMarshalling with ApiMarshalling {
+
+  val resource = new MleapResource(new MleapService())
+
+  describe("/model path") {
+    it("returns OK for PUT requests") {
+      val bundlePath = TestUtil.serializeModelInJsonFormatToZipFile
+      Put("/model", LoadModelRequest(Some(bundlePath))) ~> resource.routes ~> check {
+        status shouldEqual StatusCodes.OK
+      }
+    }
+
+    it("returns INTERNAL_SERVER_ERROR for PUT requests with no model provided") {
+      Put("/model", LoadModelRequest(None)) ~> resource.routes ~> check {
+        status shouldEqual StatusCodes.INTERNAL_SERVER_ERROR
+      }
+    }
+
+    it("returns INTERNAL_SERVER_ERROR for PUT requests with unknown model provided") {
+      Put("/model", LoadModelRequest(Some("/tmp/unknown.json.zip"))) ~> resource.routes ~> check {
+        status shouldEqual StatusCodes.INTERNAL_SERVER_ERROR
+      }
+    }
+
+    it("returns OK for DELETE requests") {
+      Delete("/model") ~> resource.routes ~> check {
+        status shouldEqual StatusCodes.OK
+      }
+    }
+
+    it("returns a METHOD_NOT_ALLOWED error for GET requests") {
+      Get("/model") ~> Route.seal(resource.routes) ~> check {
+        status shouldEqual StatusCodes.METHOD_NOT_ALLOWED
+        responseAs[String] shouldEqual "HTTP method not allowed, supported methods: PUT, DELETE"
+      }
+    }
+  }
+
+  describe("/transform path") {
+    it("returns INTERNAL_SERVER_ERROR for POST requests if no model has been loaded yet") {
+      Post("/transform", TestUtil.getLeapFrame) ~> resource.routes ~> check {
+        status shouldEqual StatusCodes.INTERNAL_SERVER_ERROR
+      }
+    }
+
+    it("transforms the leap frame for POST requests if model has been previously loaded") {
+      val bundlePath = TestUtil.serializeModelInJsonFormatToZipFile
+      Put("/model", LoadModelRequest(Some(bundlePath))) ~> resource.routes ~> check {
+        status shouldEqual StatusCodes.OK
+      }
+      Post("/transform", TestUtil.getLeapFrame) ~> resource.routes ~> check {
+        status shouldEqual StatusCodes.OK
+        val outputLeapFrame = responseAs[DefaultLeapFrame]
+        val data = outputLeapFrame.dataset.toArray
+        assert(data(0).getDouble(4) == 24.0)
+        assert(data(1).getDouble(4) == 19.0)
+        assert(data(2).getDouble(4) == 23.0)
+      }
+    }
+
+    it("returns a METHOD_NOT_ALLOWED error for GET requests") {
+      Get("/transform", TestUtil.getLeapFrame) ~> Route.seal(resource.routes) ~> check {
+        status shouldEqual StatusCodes.METHOD_NOT_ALLOWED
+        responseAs[String] shouldEqual "HTTP method not allowed, supported methods: POST"
+      }
+    }
+
+    it("returns a METHOD_NOT_ALLOWED error for PUT requests") {
+      Put("/transform", TestUtil.getLeapFrame) ~> Route.seal(resource.routes) ~> check {
+        status shouldEqual StatusCodes.METHOD_NOT_ALLOWED
+        responseAs[String] shouldEqual "HTTP method not allowed, supported methods: POST"
+      }
+    }
+  }
+}

--- a/mleap-serving/src/test/scala/ml/combust/mleap/serving/MleapServiceSpec.scala
+++ b/mleap-serving/src/test/scala/ml/combust/mleap/serving/MleapServiceSpec.scala
@@ -1,0 +1,77 @@
+package ml.combust.mleap.serving
+
+import java.nio.file.NoSuchFileException
+
+import ml.combust.mleap.serving.domain.v1._
+import org.scalatest.{AsyncFunSpec, Matchers}
+
+import scala.concurrent.Future
+import scala.util.Failure
+
+class MleapServiceSpec extends AsyncFunSpec with Matchers {
+
+  val service = new MleapService()
+
+  describe("MleapService") {
+    it("loads the model successfully") {
+      val bundlePath = TestUtil.serializeModelInJsonFormatToZipFile
+      val modelLoaded = service.loadModel(LoadModelRequest(Some(bundlePath)))
+      modelLoaded map { response => response shouldBe a [LoadModelResponse] }
+    }
+
+    it("throws NoSuchFileException when it cannot find model to load") {
+      val modelLoaded = recoverToExceptionIf[NoSuchFileException] {
+        service.loadModel(LoadModelRequest(Some("test/unknown_bundle.json.zip")))
+      }
+      modelLoaded map { ex => ex shouldBe a [NoSuchFileException] }
+    }
+
+    it("throws NoSuchElementException when not provided with model to load") {
+      val modelLoaded = recoverToExceptionIf[NoSuchElementException] {
+        service.loadModel(LoadModelRequest(None))
+      }
+      modelLoaded map { ex => ex shouldBe a [NoSuchElementException] }
+    }
+
+    it("unloads previously loaded model successfully") {
+      val bundlePath = TestUtil.serializeModelInJsonFormatToZipFile
+      val modelUnloaded: Future[UnloadModelResponse] =
+        for {
+          _ <- service.loadModel(LoadModelRequest(Some(bundlePath)))
+          unloadModel <- service.unloadModel(UnloadModelRequest())
+        } yield unloadModel
+
+      modelUnloaded map { response => response shouldBe a [UnloadModelResponse] }
+    }
+
+    it("does not fail when trying to unload the model if no model previously loaded") {
+      val modelUnloaded = service.unloadModel(UnloadModelRequest())
+      modelUnloaded map { response => response shouldBe a [UnloadModelResponse] }
+    }
+
+    it("returns a failure if no model has been loaded when transform request is received") {
+      val result = service.transform(TestUtil.getLeapFrame)
+      assert(result.isFailure)
+      result match {
+        case Failure(error) =>
+          assert(error.isInstanceOf[IllegalStateException])
+          assert(error.getMessage == "no transformer loaded")
+        case _ => fail("Expected a failure to be returned")
+      }
+    }
+
+    it("transforms a leap frame successfully") {
+      val bundlePath = TestUtil.serializeModelInJsonFormatToZipFile
+      val modelLoaded = service.loadModel(LoadModelRequest(Some(bundlePath)))
+      modelLoaded.map(response => {
+        response shouldBe a [LoadModelResponse]
+
+        val result = service.transform(TestUtil.getLeapFrame)
+        val data = result.get.dataset.toArray
+        assert(data(0).getDouble(4) == 24.0)
+        assert(data(1).getDouble(4) == 19.0)
+        assert(data(2).getDouble(4) == 23.0)
+      })
+    }
+  }
+}

--- a/mleap-serving/src/test/scala/ml/combust/mleap/serving/TestUtil.scala
+++ b/mleap-serving/src/test/scala/ml/combust/mleap/serving/TestUtil.scala
@@ -1,0 +1,55 @@
+package ml.combust.mleap.serving
+
+import java.io.File
+import java.net.URI
+import java.util.UUID
+
+import ml.combust.bundle.BundleFile
+import ml.combust.bundle.serializer.SerializationFormat
+import ml.combust.mleap.core.regression.LinearRegressionModel
+import ml.combust.mleap.runtime.transformer.Pipeline
+import ml.combust.mleap.runtime.transformer.feature.VectorAssembler
+import ml.combust.mleap.runtime.transformer.regression.LinearRegression
+import ml.combust.mleap.runtime.types.{DoubleType, StructField, StructType}
+import ml.combust.mleap.runtime.{DefaultLeapFrame, LeapFrame, LocalDataset, Row}
+import org.apache.spark.ml.linalg.Vectors
+import resource.managed
+import ml.combust.mleap.runtime.MleapSupport._
+
+object TestUtil {
+  val baseDir = new File("/tmp/mleap-serving")
+  TestUtil.delete(baseDir)
+  baseDir.mkdirs()
+
+  def delete(file: File): Array[(String, Boolean)] = {
+    Option(file.listFiles).map(_.flatMap(f => delete(f))).getOrElse(Array()) :+ (file.getPath -> file.delete)
+  }
+
+  def getLeapFrame : DefaultLeapFrame = {
+    LeapFrame(StructType(
+      StructField("first_double", DoubleType()),
+      StructField("second_double", DoubleType()),
+      StructField("third_double", DoubleType())).get,
+      LocalDataset(Row(5d, 1.0, 4.0), Row(2.0, 2.0, 4.0),
+        Row(3.0, 2.0, 5.0)))
+  }
+
+  def serializeModelInJsonFormatToZipFile : String = {
+    val bundleName = UUID.randomUUID().toString
+
+    val featureAssembler = VectorAssembler(inputCols = Array("first_double", "second_double", "third_double"),
+      outputCol = "features")
+    val linearRegression = LinearRegression(featuresCol = "features", predictionCol = "prediction",
+      model = LinearRegressionModel(Vectors.dense(2.0, 1.0, 2.0), 5d))
+    val pipeline = Pipeline("pipeline", Seq(featureAssembler, linearRegression))
+
+    val uri = new URI(s"jar:file:${TestUtil.baseDir}/${bundleName}.json.zip")
+    for (file <- managed(BundleFile(uri))) {
+      pipeline.writeBundle.name("bundle")
+        .format(SerializationFormat.Json)
+        .save(file)
+    }
+
+    s"${baseDir}/${bundleName}.json.zip"
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,6 +36,7 @@ object Dependencies {
 
   object Test {
     val scalaTest = "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
+    val akkaHttpTestkit =  "com.typesafe.akka" % "akka-http-testkit_2.11" % akkaHttpVersion % "test"
   }
 
   object Provided {
@@ -67,7 +68,7 @@ object Dependencies {
 
   val tensorflow = l ++= Seq(tensorflowDep)
 
-  val serving = l ++= Seq(akkaHttp, akkaHttpSprayJson, config)
+  val serving = l ++= Seq(akkaHttp, akkaHttpSprayJson, config, Test.scalaTest, Test.akkaHttpTestkit)
 
   val benchmark = l ++= Seq(scalameter, scopt, sparkAvro) ++ Compile.spark
 

--- a/project/MleapProject.scala
+++ b/project/MleapProject.scala
@@ -11,7 +11,6 @@ object MleapProject {
       core,
       runtime,
       avro,
-      serving,
       sparkBase,
       sparkTestkit,
       spark,

--- a/project/MleapProject.scala
+++ b/project/MleapProject.scala
@@ -11,6 +11,7 @@ object MleapProject {
       core,
       runtime,
       avro,
+      serving,
       sparkBase,
       sparkTestkit,
       spark,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.0-M8")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
+addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 
 libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.5.47"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.0-M8")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
-addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 
 libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.5.47"

--- a/travis/travis.sh
+++ b/travis/travis.sh
@@ -3,7 +3,7 @@
 if [[ $TRAVIS_BRANCH == 'master' ]] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
   source travis/extract.sh
   source travis/docker.sh
-  sbt "+ test" "+ publishSigned" "mleap-serving/docker:publish"
+  sbt "+ test" "mleap-serving/test" "+ publishSigned" "mleap-serving/docker:publish"
 else
-  sbt "+ test"
+  sbt "+ test" "mleap-serving/test"
 fi


### PR DESCRIPTION
Changes to update "/transform" path in MleapResource (mleap-serving module) to only accept POST method as documented in the README.md.

While reading about how mleap-serving module works, I've also added scalatest and akka-http-testkit as testing dependencies to mleap-serving module and tests for MleapService and MleapResource.