### PR TITLE
scikit-v2 serialization updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,16 +137,16 @@ from mleap.sklearn.preprocessing.data import NDArrayToDataFrame
 # Load scikit-learn transformers and models
 from sklearn.preprocessing import LabelEncoder, Binarizer
 
-# Define the Label Encoder (minit method adds a unique `name` to the transformer as well as explicit input/output features)
+# Define the Label Encoder (mlinit method adds a unique `name` to the transformer as well as explicit input/output features)
 label_encoder_tf = LabelEncoder()
-label_encoder_tf.minit(input_features = 'col_a', output_features='col_a_label_le')
+label_encoder_tf.mlinit(input_features = 'col_a', output_features='col_a_label_le')
 
 # Convert output of Label Encoder to Data Frame instead of 1d-array
 n_dim_array_to_df_tf = NDArrayToDataFrame(label_encoder_tf.output_features)
 
 # Define our binarizer
 binarizer = Binarizer(0.5)
-binarizer.minit(input_features=n_dim_array_to_df_tf.output_features, output_features="{}_binarized".format(n_dim_array_to_df_tf.output_features))
+binarizer.mlinit(input_features=n_dim_array_to_df_tf.output_features, output_features="{}_binarized".format(n_dim_array_to_df_tf.output_features))
 
 data = pd.DataFrame(['a', 'b', 'c'], columns=['col_a'])
 
@@ -158,7 +158,7 @@ steps = [
 ]
 
 pipeline = Pipeline(steps)
-pipeline.minit()
+pipeline.mlinit()
 
 # Fit the pipeline
 pipeline.fit(data)

--- a/python/README.md
+++ b/python/README.md
@@ -38,21 +38,25 @@ A simple example is the `StandardScaler` transformer that normalizes the data gi
             "type": {
                 "type": "tensor",
                 "tensor": {
-                   "base": "double",
-                   "dimensions": [-1]
+                   "base": "double"
                 }
              },
-             "value": [0.2354223, 1.34502332]
+             "value": {
+                "values": [0.2354223, 1.34502332],
+                 "dimensions": [2]
+             }
         },
         "std": {
             "type": {
                 "type": "tensor",
                 "tensor": {
-                   "base": "double",
-                   "dimensions": [-1]
+                   "base": "double"
                 }
              },
-             "value": [0.13842223, 0.78320249]
+             "value": {
+                "values": [0.13842223, 0.78320249],
+                "dimensions": [2]
+             }
         }
     }
 }

--- a/python/mleap/bundle/serialize.py
+++ b/python/mleap/bundle/serialize.py
@@ -79,11 +79,13 @@ class MLeapSerializer(object):
                     "type": {
                       "type": "tensor",
                       "tensor": {
-                        "base": _type_map[base],
-                        "dimensions": [-1]
+                        "base": _type_map[base]
                       }
                     },
-                    "value": value
+                    "value": {
+                        "values": value,
+                        "dimensions": [len(value)]
+                        }
                 }
 
             elif isinstance(value, list) and isinstance(value[0], str):

--- a/python/mleap/sklearn/decomposition/pca.py
+++ b/python/mleap/sklearn/decomposition/pca.py
@@ -32,7 +32,7 @@ def mleap_init(self, input_features, prediction_column):
 
 
 setattr(PCA, 'op', 'pca')
-setattr(PCA, 'minit', mleap_init)
+setattr(PCA, 'mlinit', mleap_init)
 setattr(PCA, 'serialize_to_bundle', serialize_to_bundle)
 setattr(PCA, 'serializable', True)
 

--- a/python/mleap/sklearn/ensemble/forest.py
+++ b/python/mleap/sklearn/ensemble/forest.py
@@ -36,12 +36,12 @@ def serialize_to_bundle(self, path, model_name):
 
 
 setattr(RandomForestRegressor, 'op', 'random_forest_regression')
-setattr(RandomForestRegressor, 'minit', mleap_init)
+setattr(RandomForestRegressor, 'mlinit', mleap_init)
 setattr(RandomForestRegressor, 'serialize_to_bundle', serialize_to_bundle)
 setattr(RandomForestRegressor, 'serializable', True)
 
 setattr(RandomForestClassifier, 'op', 'random_forest_classifier')
-setattr(RandomForestClassifier, 'minit', mleap_init)
+setattr(RandomForestClassifier, 'mlinit', mleap_init)
 setattr(RandomForestClassifier, 'serialize_to_bundle', serialize_to_bundle)
 setattr(RandomForestClassifier, 'serializable', True)
 
@@ -100,7 +100,7 @@ class SimpleSerializer(MLeapSerializer):
 
         i = 0
         for estimator in estimators:
-            estimator.minit(input_features = transformer.input_features, prediction_column = transformer.prediction_column, feature_names=transformer.feature_names)
+            estimator.mlinit(input_features = transformer.input_features, prediction_column = transformer.prediction_column, feature_names=transformer.feature_names)
             model_name = "tree{}".format(i)
             estimator.serialize_to_bundle(rf_path, model_name, serialize_node=False)
 

--- a/python/mleap/sklearn/feature_extraction/text.py
+++ b/python/mleap/sklearn/feature_extraction/text.py
@@ -32,7 +32,7 @@ def mleap_init(self, input_features, prediction_column):
 
 
 setattr(CountVectorizer, 'op', 'tokenizer')
-setattr(CountVectorizer, 'minit', mleap_init)
+setattr(CountVectorizer, 'mlinit', mleap_init)
 setattr(CountVectorizer, 'serialize_to_bundle', serialize_to_bundle)
 setattr(CountVectorizer, 'serializable', True)
 

--- a/python/mleap/sklearn/pipeline.py
+++ b/python/mleap/sklearn/pipeline.py
@@ -144,14 +144,15 @@ class SimpleSerializer(object):
     def get_model(self, transformer):
         js = {
           "op": transformer.op,
-          "attributes": [{
-            "name": "nodes",
-            "type": {
-              "type": "list",
-              "base": "string"
-            },
-            "value": self._extract_nodes(transformer.steps)
-          }]
+            "attributes": {
+                "nodes": {
+                    "type": {
+                        "type": "list",
+                        "base": "string"
+                    },
+                    "value": self._extract_nodes(transformer.steps)
+                }
+            }
         }
         return js
 

--- a/python/mleap/sklearn/preprocessing/data.py
+++ b/python/mleap/sklearn/preprocessing/data.py
@@ -616,12 +616,12 @@ class MathUnary(BaseEstimator, TransformerMixin, MLeapSerializer):
 
         # define node inputs and outputs
         inputs = [{
-                  "name": self.input_features,
+                  "name": self.input_features[0],
                   "port": "input"
                 }]
 
         outputs = [{
-                  "name": self.output_features,
+                  "name": self.output_features[0],
                   "port": "output"
                 }]
 

--- a/python/mleap/sklearn/preprocessing/data.py
+++ b/python/mleap/sklearn/preprocessing/data.py
@@ -709,12 +709,16 @@ class MathBinary(BaseEstimator, TransformerMixin, MLeapSerializer):
 
         # define node inputs and outputs
         inputs = [{
-                  "name": self.input_features,
-                  "port": "input"
+                  "name": self.input_features[0],
+                  "port": "input_a"
+                },
+                {
+                    "name": self.input_features[1],
+                    "port": "input_b"
                 }]
 
         outputs = [{
-                  "name": self.output_features,
+                  "name": self.output_features[0],
                   "port": "output"
                 }]
 

--- a/python/mleap/sklearn/preprocessing/data.py
+++ b/python/mleap/sklearn/preprocessing/data.py
@@ -547,7 +547,7 @@ class ToDense(BaseEstimator, TransformerMixin):
 
 class MathUnary(BaseEstimator, TransformerMixin, MLeapSerializer):
     """
-    Performs basic math opperations on a single feature (column of a DataFrame). Supported opperations include:
+    Performs basic math operations on a single feature (column of a DataFrame). Supported operations include:
         - log
         - exp
         - sqrt
@@ -564,6 +564,7 @@ class MathUnary(BaseEstimator, TransformerMixin, MLeapSerializer):
         self.input_features = input_features
         self.output_features = output_features
         self.transform_type = transform_type
+        self.serializable = True
 
     def fit(self, y):
         """
@@ -607,29 +608,29 @@ class MathUnary(BaseEstimator, TransformerMixin, MLeapSerializer):
 
         return self.transform(X)
 
-    def serialize_to_bundle(self, transformer, path, model_name):
+    def serialize_to_bundle(self, path, model_name):
 
         # compile tuples of model attributes to serialize
         attributes = list()
-        attributes.append(('opperation', self.transform_type))
+        attributes.append(('operation', self.transform_type))
 
         # define node inputs and outputs
         inputs = [{
-                  "name": transformer.input_features,
+                  "name": self.input_features,
                   "port": "input"
                 }]
 
         outputs = [{
-                  "name": transformer.output_features,
+                  "name": self.output_features,
                   "port": "output"
                 }]
 
-        self.serialize(transformer, path, model_name, attributes, inputs, outputs)
+        self.serialize(self, path, model_name, attributes, inputs, outputs)
 
 
 class MathBinary(BaseEstimator, TransformerMixin, MLeapSerializer):
     """
-    Performs basic math opperations on a single feature (column of a DataFrame). Supported opperations include:
+    Performs basic math operations on two features (columns of a DataFrame). Supported operations include:
         - add: Add x + y
         - sub: Subtract x - y
         - mul: Multiply x * y
@@ -647,6 +648,7 @@ class MathBinary(BaseEstimator, TransformerMixin, MLeapSerializer):
         self.input_features = input_features
         self.output_features = output_features
         self.transform_type = transform_type
+        self.serializable = True
 
     def _return(self, y):
         if type(y, np.ndarray):
@@ -699,21 +701,21 @@ class MathBinary(BaseEstimator, TransformerMixin, MLeapSerializer):
 
         return self.transform(X)
 
-    def serialize_to_bundle(self, transformer, path, model_name):
+    def serialize_to_bundle(self, path, model_name):
 
         # compile tuples of model attributes to serialize
         attributes = list()
-        attributes.append(('opperation', self.transform_type))
+        attributes.append(('operation', self.transform_type))
 
         # define node inputs and outputs
         inputs = [{
-                  "name": transformer.input_features,
+                  "name": self.input_features,
                   "port": "input"
                 }]
 
         outputs = [{
-                  "name": transformer.output_features,
+                  "name": self.output_features,
                   "port": "output"
                 }]
 
-        self.serialize(transformer, path, model_name, attributes, inputs, outputs)
+        self.serialize(self, path, model_name, attributes, inputs, outputs)

--- a/python/mleap/sklearn/preprocessing/data.py
+++ b/python/mleap/sklearn/preprocessing/data.py
@@ -206,7 +206,7 @@ class StandardScalerSerializer(MLeapSerializer):
 
     >>> data = pd.DataFrame([[1, 0], [5, 1], [6, 3], [1, 1]], columns=['col_a', 'col_b'])
     >>> standard_scaler_tf = StandardScaler()
-    >>> standard_scaler_tf.minit(input_features=['col_a', 'col_b'], output_features='scaled_cont_features')
+    >>> standard_scaler_tf.mlinit(input_features=['col_a', 'col_b'], output_features='scaled_cont_features')
     >>> standard_scaler_tf.fit_transform(data)
     >>> array([[-0.98787834, -1.14707867],
     >>>         [ 0.76834982, -0.22941573],
@@ -243,7 +243,7 @@ class MinMaxScalerSerializer(MLeapSerializer):
 
     >>> data = pd.DataFrame([[1, 0], [5, 1], [6, 3], [1, 1]], columns=['col_a', 'col_b'])
     >>> minmax_scaler_tf = MinMaxScaler()
-    >>> minmax_scaler_tf.minit(input_features=['col_a', 'col_b'], output_features='scaled_cont_features')
+    >>> minmax_scaler_tf.mlinit(input_features=['col_a', 'col_b'], output_features='scaled_cont_features')
 
     >>> minmax_scaler_tf.fit_transform(data)
     >>> array([[ 0.        ,  0.        ],
@@ -311,7 +311,7 @@ class LabelEncoderSerializer(MLeapSerializer):
     >>> data = pd.DataFrame([['a', 0], ['b', 1], ['b', 3], ['c', 1]], columns=['col_a', 'col_b'])
     >>> # Label Encoder for x1 Label
     >>> label_encoder_tf = LabelEncoder()
-    >>> label_encoder_tf.minit(input_features = ['col_a'] , output_features='col_a_label_le')
+    >>> label_encoder_tf.mlinit(input_features = ['col_a'] , output_features='col_a_label_le')
     >>> # Convert output of Label Encoder to Data Frame instead of 1d-array
     >>> n_dim_array_to_df_tf = NDArrayToDataFrame('col_a_label_le')
     >>> n_dim_array_to_df_tf.fit_transform(label_encoder_tf.fit_transform(data['col_a']))

--- a/python/mleap/sklearn/tree/tree.py
+++ b/python/mleap/sklearn/tree/tree.py
@@ -36,12 +36,12 @@ def serialize_to_bundle(self, path, model_name, serialize_node=True):
 
 
 setattr(DecisionTreeRegressor, 'op', 'decision_tree_regression')
-setattr(DecisionTreeRegressor, 'minit', mleap_init)
+setattr(DecisionTreeRegressor, 'mlinit', mleap_init)
 setattr(DecisionTreeRegressor, 'serialize_to_bundle', serialize_to_bundle)
 setattr(DecisionTreeRegressor, 'serializable', True)
 
 setattr(DecisionTreeClassifier, 'op', 'decision_tree_classifier')
-setattr(DecisionTreeClassifier, 'minit', mleap_init)
+setattr(DecisionTreeClassifier, 'mlinit', mleap_init)
 setattr(DecisionTreeClassifier, 'serialize_to_bundle', serialize_to_bundle)
 setattr(DecisionTreeClassifier, 'serializable', True)
 

--- a/python/mleap/tests.py
+++ b/python/mleap/tests.py
@@ -49,8 +49,8 @@ class TransformerTests(unittest.TestCase):
                                          with_std=True
                                          )
 
-        standard_scaler.mlinit(input_features=['a'],
-                               output_features=['a_scaled'])
+        standard_scaler.mlinit(input_features='a',
+                               output_features='a_scaled')
 
         standard_scaler.fit(self.df[['a']])
 
@@ -117,8 +117,8 @@ class TransformerTests(unittest.TestCase):
     def test_min_max_scaler(self):
 
         scaler = MinMaxScaler()
-        scaler.mlinit(input_features=['a'],
-                      output_features=['a_scaled'])
+        scaler.mlinit(input_features='a',
+                      output_features='a_scaled')
 
         scaler.fit(self.df[['a']])
 

--- a/python/mleap/tests.py
+++ b/python/mleap/tests.py
@@ -233,7 +233,7 @@ class TransformerTests(unittest.TestCase):
 
         imputer.fit(df2[['a']])
 
-        self.assertEqual(imputer.statistics_[0], df2.a.mean())
+        self.assertAlmostEqual(imputer.statistics_[0], df2.a.mean(), places = 7)
 
         imputer.serialize_to_bundle(self.tmp_dir, imputer.name)
 
@@ -256,7 +256,7 @@ class TransformerTests(unittest.TestCase):
             model = json.load(json_data)
 
         self.assertEqual(expected_model['attributes']['strategy']['value'], model['attributes']['strategy']['value'])
-        self.assertEqual(expected_model['attributes']['surrogate_value']['value'], model['attributes']['surrogate_value']['value'])
+        self.assertAlmostEqual(expected_model['attributes']['surrogate_value']['value'], model['attributes']['surrogate_value']['value'], places = 7)
 
     def binarizer_test(self):
 
@@ -341,6 +341,14 @@ class TransformerTests(unittest.TestCase):
 
         self.assertEqual(expected_model['attributes']['operation']['value'], model['attributes']['operation']['value'])
 
+        # Test node.json
+        with open("{}/{}.node/node.json".format(self.tmp_dir, math_unary_tf.name)) as json_data:
+            node = json.load(json_data)
+
+        self.assertEqual(math_unary_tf.name, node['name'])
+        self.assertEqual(math_unary_tf.input_features[0], node['shape']['inputs'][0]['name'])
+        self.assertEqual(math_unary_tf.output_features[0], node['shape']['outputs'][0]['name'])
+
     def math_unary_sin_test(self):
 
         math_unary_tf = MathUnary(input_features=['a'], output_features=['sin_a'], transform_type='sin')
@@ -366,6 +374,14 @@ class TransformerTests(unittest.TestCase):
             model = json.load(json_data)
 
         self.assertEqual(expected_model['attributes']['operation']['value'], model['attributes']['operation']['value'])
+
+        # Test node.json
+        with open("{}/{}.node/node.json".format(self.tmp_dir, math_unary_tf.name)) as json_data:
+            node = json.load(json_data)
+
+        self.assertEqual(math_unary_tf.name, node['name'])
+        self.assertEqual(math_unary_tf.input_features[0], node['shape']['inputs'][0]['name'])
+        self.assertEqual(math_unary_tf.output_features[0], node['shape']['outputs'][0]['name'])
 
     def math_binary_test(self):
 

--- a/python/mleap/tests.py
+++ b/python/mleap/tests.py
@@ -261,8 +261,8 @@ class TransformerTests(unittest.TestCase):
     def binarizer_test(self):
 
         binarizer = Binarizer(threshold=0.0)
-        binarizer.mlinit(input_features=['a'],
-                         output_features=['a_binary'])
+        binarizer.mlinit(input_features='a',
+                         output_features='a_binary')
 
         Xres = binarizer.fit_transform(self.df[['a']])
 
@@ -286,6 +286,14 @@ class TransformerTests(unittest.TestCase):
             model = json.load(json_data)
 
         self.assertEqual(expected_model['attributes']['threshold']['value'], model['attributes']['threshold']['value'])
+
+        # Test node.json
+        with open("{}/{}.node/node.json".format(self.tmp_dir, binarizer.name)) as json_data:
+            node = json.load(json_data)
+
+        self.assertEqual(binarizer.name, node['name'])
+        self.assertEqual(binarizer.input_features, node['shape']['inputs'][0]['name'])
+        self.assertEqual(binarizer.output_features, node['shape']['outputs'][0]['name'])
 
     def polynomial_expansion_test(self):
 

--- a/python/mleap/tests.py
+++ b/python/mleap/tests.py
@@ -66,41 +66,45 @@ class TransformerTests(unittest.TestCase):
                     "type": {
                         "type": "tensor",
                         "tensor": {
-                           "base": "double",
-                           "dimensions": [
-                              -1
-                           ]
+                           "base": "double"
                         }
                      },
-                     "value": [expected_mean]
+                     "value": {
+                         "values": [expected_mean],
+                         "dimensions": [
+                             1
+                         ]
+                     }
                 },
                 "std": {
                     "type": {
                         "type": "tensor",
                         "tensor": {
-                           "base": "double",
-                           "dimensions": [
-                              -1
-                           ]
+                           "base": "double"
                         }
                      },
-                     "value": [expected_std]
+                     "value": {
+                         "values": [expected_std],
+                         "dimensions": [
+                             1
+                         ]
+                     }
                 }
             }
         }
 
-        self.assertEqual(expected_mean, standard_scaler.mean_.tolist()[0])
-        self.assertEqual(expected_std, np.sqrt(standard_scaler.var_.tolist()[0]))
+        self.assertAlmostEqual(expected_mean, standard_scaler.mean_.tolist()[0], places = 7)
+        self.assertAlmostEqual(expected_std, np.sqrt(standard_scaler.var_.tolist()[0]), places = 7)
 
         # Test model.json
         with open("{}/{}.node/model.json".format(self.tmp_dir, standard_scaler.name)) as json_data:
             model = json.load(json_data)
 
         self.assertEqual(standard_scaler.op, expected_model['op'])
-        self.assertEqual(expected_model['attributes']['mean']['type']['tensor']['dimensions'][0], model['attributes']['mean']['type']['tensor']['dimensions'][0])
-        self.assertEqual(expected_model['attributes']['std']['type']['tensor']['dimensions'][0], model['attributes']['std']['type']['tensor']['dimensions'][0])
-        self.assertEqual(expected_model['attributes']['mean']['value'][0], model['attributes']['mean']['value'][0])
-        self.assertEqual(expected_model['attributes']['std']['value'][0], model['attributes']['std']['value'][0])
+        self.assertEqual(expected_model['attributes']['mean']['value']['dimensions'][0], model['attributes']['mean']['value']['dimensions'][0])
+        self.assertEqual(expected_model['attributes']['std']['value']['dimensions'][0], model['attributes']['std']['value']['dimensions'][0])
+        self.assertAlmostEqual(expected_model['attributes']['mean']['value']['values'][0], model['attributes']['mean']['value']['values'][0], places = 7)
+        self.assertAlmostEqual(expected_model['attributes']['std']['value']['values'][0], model['attributes']['std']['value']['values'][0], places = 7)
 
         # Test node.json
         with open("{}/{}.node/node.json".format(self.tmp_dir, standard_scaler.name)) as json_data:
@@ -130,40 +134,45 @@ class TransformerTests(unittest.TestCase):
                          "type": {
                             "type": "tensor",
                             "tensor": {
-                               "base": "double",
-                               "dimensions": [
-                                  -1
-                               ]
+                               "base": "double"
                             }
                          },
-                         "value": [expected_min]
+                         "value": {
+                             "values": [expected_min],
+                             "dimensions": [
+                                 1
+                             ]
+                         }
                       },
                 "max": {
                          "type": {
                             "type": "tensor",
                             "tensor": {
-                               "base": "double",
-                               "dimensions": [
-                                  -1
-                               ]
+                               "base": "double"
                             }
                          },
-                         "value": [expected_max]
+                         "value": {
+                             "values": [expected_max],
+                             "dimensions": [
+                                 1
+                             ]
+                         }
                       }
             }
         }
 
-        self.assertEqual(expected_min, scaler.data_min_.tolist()[0])
-        self.assertEqual(expected_max, scaler.data_max_.tolist()[0])
+        self.assertAlmostEqual(expected_min, scaler.data_min_.tolist()[0], places = 7)
+        self.assertAlmostEqual(expected_max, scaler.data_max_.tolist()[0], places = 7)
 
         # Test model.json
         with open("{}/{}.node/model.json".format(self.tmp_dir, scaler.name)) as json_data:
             model = json.load(json_data)
 
         self.assertEqual(scaler.op, expected_model['op'])
-        self.assertEqual(expected_model['attributes']['min']['type']['tensor']['dimensions'][0], model['attributes']['min']['type']['tensor']['dimensions'][0])
-        self.assertEqual(expected_model['attributes']['min']['value'][0], model['attributes']['min']['value'][0])
-        self.assertEqual(expected_model['attributes']['max']['value'][0], model['attributes']['max']['value'][0])
+        self.assertEqual(expected_model['attributes']['min']['value']['dimensions'][0], model['attributes']['min']['value']['dimensions'][0])
+        self.assertEqual(expected_model['attributes']['max']['value']['dimensions'][0], model['attributes']['max']['value']['dimensions'][0])
+        self.assertAlmostEqual(expected_model['attributes']['min']['value']['values'][0], model['attributes']['min']['value']['values'][0])
+        self.assertAlmostEqual(expected_model['attributes']['max']['value']['values'][0], model['attributes']['max']['value']['values'][0])
 
         # Test node.json
         with open("{}/{}.node/node.json".format(self.tmp_dir, scaler.name)) as json_data:

--- a/python/mleap/tests.py
+++ b/python/mleap/tests.py
@@ -409,6 +409,15 @@ class TransformerTests(unittest.TestCase):
 
         self.assertEqual(expected_model['attributes']['operation']['value'], model['attributes']['operation']['value'])
 
+        # Test node.json
+        with open("{}/{}.node/node.json".format(self.tmp_dir, math_binary_tf.name)) as json_data:
+            node = json.load(json_data)
+
+        self.assertEqual(math_binary_tf.name, node['name'])
+        self.assertEqual(math_binary_tf.input_features[0], node['shape']['inputs'][0]['name'])
+        self.assertEqual(math_binary_tf.input_features[1], node['shape']['inputs'][1]['name'])
+        self.assertEqual(math_binary_tf.output_features[0], node['shape']['outputs'][0]['name'])
+
     def math_binary_subtract_test(self):
 
         math_binary_tf = MathBinary(input_features=['a', 'b'], output_features=['a_less_b'], transform_type='sub')
@@ -434,6 +443,15 @@ class TransformerTests(unittest.TestCase):
             model = json.load(json_data)
 
         self.assertEqual(expected_model['attributes']['operation']['value'], model['attributes']['operation']['value'])
+
+        # Test node.json
+        with open("{}/{}.node/node.json".format(self.tmp_dir, math_binary_tf.name)) as json_data:
+            node = json.load(json_data)
+
+        self.assertEqual(math_binary_tf.name, node['name'])
+        self.assertEqual(math_binary_tf.input_features[0], node['shape']['inputs'][0]['name'])
+        self.assertEqual(math_binary_tf.input_features[1], node['shape']['inputs'][1]['name'])
+        self.assertEqual(math_binary_tf.output_features[0], node['shape']['outputs'][0]['name'])
 
     def math_binary_multiply_test(self):
 
@@ -461,6 +479,15 @@ class TransformerTests(unittest.TestCase):
 
         self.assertEqual(expected_model['attributes']['operation']['value'], model['attributes']['operation']['value'])
 
+        # Test node.json
+        with open("{}/{}.node/node.json".format(self.tmp_dir, math_binary_tf.name)) as json_data:
+            node = json.load(json_data)
+
+        self.assertEqual(math_binary_tf.name, node['name'])
+        self.assertEqual(math_binary_tf.input_features[0], node['shape']['inputs'][0]['name'])
+        self.assertEqual(math_binary_tf.input_features[1], node['shape']['inputs'][1]['name'])
+        self.assertEqual(math_binary_tf.output_features[0], node['shape']['outputs'][0]['name'])
+
     def math_binary_divide_test(self):
 
         math_binary_tf = MathBinary(input_features=['a', 'b'], output_features=['a_mul_b'], transform_type='div')
@@ -486,3 +513,12 @@ class TransformerTests(unittest.TestCase):
             model = json.load(json_data)
 
         self.assertEqual(expected_model['attributes']['operation']['value'], model['attributes']['operation']['value'])
+
+        # Test node.json
+        with open("{}/{}.node/node.json".format(self.tmp_dir, math_binary_tf.name)) as json_data:
+            node = json.load(json_data)
+
+        self.assertEqual(math_binary_tf.name, node['name'])
+        self.assertEqual(math_binary_tf.input_features[0], node['shape']['inputs'][0]['name'])
+        self.assertEqual(math_binary_tf.input_features[1], node['shape']['inputs'][1]['name'])
+        self.assertEqual(math_binary_tf.output_features[0], node['shape']['outputs'][0]['name'])

--- a/python/mleap/tests.py
+++ b/python/mleap/tests.py
@@ -323,12 +323,12 @@ class TransformerTests(unittest.TestCase):
 
         self.assertEqual(np.exp(self.df.a[0]), Xres[0])
 
-        math_unary_tf.serialize_to_bundle(math_unary_tf, self.tmp_dir, math_unary_tf.name)
+        math_unary_tf.serialize_to_bundle(self.tmp_dir, math_unary_tf.name)
 
         expected_model = {
           "op": "math_unary",
           "attributes": {
-            "opperation": {
+            "operation": {
               "type": "string",
               "value": 'exp'
             }
@@ -339,22 +339,22 @@ class TransformerTests(unittest.TestCase):
         with open("{}/{}.node/model.json".format(self.tmp_dir, math_unary_tf.name)) as json_data:
             model = json.load(json_data)
 
-        self.assertEqual(expected_model['attributes']['opperation']['value'], model['attributes']['opperation']['value'])
+        self.assertEqual(expected_model['attributes']['operation']['value'], model['attributes']['operation']['value'])
 
     def math_unary_sin_test(self):
 
-        math_unary_tf = MathUnary(input_features=['a'], output_features=['cos_a'], transform_type='sin')
+        math_unary_tf = MathUnary(input_features=['a'], output_features=['sin_a'], transform_type='sin')
 
         Xres = math_unary_tf.fit_transform(self.df.a)
 
         self.assertEqual(np.sin(self.df.a[0]), Xres[0])
 
-        math_unary_tf.serialize_to_bundle(math_unary_tf, self.tmp_dir, math_unary_tf.name)
+        math_unary_tf.serialize_to_bundle(self.tmp_dir, math_unary_tf.name)
 
         expected_model = {
           "op": "math_unary",
           "attributes": {
-            "opperation": {
+            "operation": {
               "type": "string",
               "value": 'sin'
             }
@@ -365,7 +365,7 @@ class TransformerTests(unittest.TestCase):
         with open("{}/{}.node/model.json".format(self.tmp_dir, math_unary_tf.name)) as json_data:
             model = json.load(json_data)
 
-        self.assertEqual(expected_model['attributes']['opperation']['value'], model['attributes']['opperation']['value'])
+        self.assertEqual(expected_model['attributes']['operation']['value'], model['attributes']['operation']['value'])
 
     def math_binary_test(self):
 
@@ -375,12 +375,12 @@ class TransformerTests(unittest.TestCase):
 
         self.assertEqual( self.df.a[0] + self.df.b[0], Xres[0])
 
-        math_binary_tf.serialize_to_bundle(math_binary_tf, self.tmp_dir, math_binary_tf.name)
+        math_binary_tf.serialize_to_bundle(self.tmp_dir, math_binary_tf.name)
 
         expected_model = {
           "op": "math_binary",
           "attributes": {
-            "opperation": {
+            "operation": {
               "type": "string",
               "value": 'add'
             }
@@ -391,7 +391,7 @@ class TransformerTests(unittest.TestCase):
         with open("{}/{}.node/model.json".format(self.tmp_dir, math_binary_tf.name)) as json_data:
             model = json.load(json_data)
 
-        self.assertEqual(expected_model['attributes']['opperation']['value'], model['attributes']['opperation']['value'])
+        self.assertEqual(expected_model['attributes']['operation']['value'], model['attributes']['operation']['value'])
 
     def math_binary_subtract_test(self):
 
@@ -401,12 +401,12 @@ class TransformerTests(unittest.TestCase):
 
         self.assertEqual(self.df.a[0] - self.df.b[0], Xres[0])
 
-        math_binary_tf.serialize_to_bundle(math_binary_tf, self.tmp_dir, math_binary_tf.name)
+        math_binary_tf.serialize_to_bundle(self.tmp_dir, math_binary_tf.name)
 
         expected_model = {
           "op": "math_binary",
           "attributes": {
-            "opperation": {
+            "operation": {
               "type": "string",
               "value": 'sub'
             }
@@ -417,7 +417,7 @@ class TransformerTests(unittest.TestCase):
         with open("{}/{}.node/model.json".format(self.tmp_dir, math_binary_tf.name)) as json_data:
             model = json.load(json_data)
 
-        self.assertEqual(expected_model['attributes']['opperation']['value'], model['attributes']['opperation']['value'])
+        self.assertEqual(expected_model['attributes']['operation']['value'], model['attributes']['operation']['value'])
 
     def math_binary_multiply_test(self):
 
@@ -427,12 +427,12 @@ class TransformerTests(unittest.TestCase):
 
         self.assertEqual(self.df.a[0] * self.df.b[0], Xres[0])
 
-        math_binary_tf.serialize_to_bundle(math_binary_tf, self.tmp_dir, math_binary_tf.name)
+        math_binary_tf.serialize_to_bundle(self.tmp_dir, math_binary_tf.name)
 
         expected_model = {
           "op": "math_binary",
           "attributes": {
-            "opperation": {
+            "operation": {
               "type": "string",
               "value": 'mul'
             }
@@ -443,7 +443,7 @@ class TransformerTests(unittest.TestCase):
         with open("{}/{}.node/model.json".format(self.tmp_dir, math_binary_tf.name)) as json_data:
             model = json.load(json_data)
 
-        self.assertEqual(expected_model['attributes']['opperation']['value'], model['attributes']['opperation']['value'])
+        self.assertEqual(expected_model['attributes']['operation']['value'], model['attributes']['operation']['value'])
 
     def math_binary_divide_test(self):
 
@@ -453,12 +453,12 @@ class TransformerTests(unittest.TestCase):
 
         self.assertEqual(self.df.a[0] / self.df.b[0], Xres[0])
 
-        math_binary_tf.serialize_to_bundle(math_binary_tf, self.tmp_dir, math_binary_tf.name)
+        math_binary_tf.serialize_to_bundle(self.tmp_dir, math_binary_tf.name)
 
         expected_model = {
           "op": "math_binary",
           "attributes": {
-            "opperation": {
+            "operation": {
               "type": "string",
               "value": 'div'
             }
@@ -469,4 +469,4 @@ class TransformerTests(unittest.TestCase):
         with open("{}/{}.node/model.json".format(self.tmp_dir, math_binary_tf.name)) as json_data:
             model = json.load(json_data)
 
-        self.assertEqual(expected_model['attributes']['opperation']['value'], model['attributes']['opperation']['value'])
+        self.assertEqual(expected_model['attributes']['operation']['value'], model['attributes']['operation']['value'])


### PR DESCRIPTION
Serialization updates for:
 - StandardScaler
 - MinMaxScaler
 - MathBinary
 - MathUnary
 - pipelines

Also, I removed all remaining references to minit() instead of mlinit(). I've updated the tests to cover the changes. 