### PR TITLE
IndexToString labels parameter should be optional

### DIFF
--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ReverseStringIndexerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ReverseStringIndexerOp.scala
@@ -24,7 +24,7 @@ object ReverseStringIndexerOp {
         } else {
           Failure(new RuntimeException(s"invalid nominal value for field ${field.name}"))
         }
-      case binary: BinaryAttribute =>
+      case _: BinaryAttribute =>
         Failure(new RuntimeException(s"invalid binary attribute for field ${field.name}"))
       case _: NumericAttribute =>
         Failure(new RuntimeException(s"invalid numeric attribute for field ${field.name}"))

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ReverseStringIndexerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ReverseStringIndexerOp.scala
@@ -3,13 +3,37 @@ package org.apache.spark.ml.bundle.ops.feature
 import ml.combust.bundle.BundleContext
 import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.bundle.dsl._
+import org.apache.spark.ml.attribute.{Attribute, BinaryAttribute, NominalAttribute, NumericAttribute}
 import org.apache.spark.ml.bundle.SparkBundleContext
-import org.apache.spark.ml.bundle.util.ParamUtil
 import org.apache.spark.ml.feature.IndexToString
+import org.apache.spark.sql.types.StructField
+
+import scala.util.{Failure, Try}
 
 /**
   * Created by hollinwilkins on 8/21/16.
   */
+object ReverseStringIndexerOp {
+  def labelsForField(field: StructField): Array[String] = {
+    val attr = Attribute.fromStructField(field)
+
+    (attr match {
+      case nominal: NominalAttribute =>
+        if (nominal.values.isDefined) {
+          Try(nominal.values.get)
+        } else {
+          Failure(new RuntimeException(s"invalid nominal value for field ${field.name}"))
+        }
+      case binary: BinaryAttribute =>
+        Failure(new RuntimeException(s"invalid binary attribute for field ${field.name}"))
+      case _: NumericAttribute =>
+        Failure(new RuntimeException(s"invalid numeric attribute for field ${field.name}"))
+      case _ =>
+        Failure(new RuntimeException(s"unsupported attribute for field ${field.name}")) // optimistic about unknown attributes
+    }).get
+  }
+}
+
 class ReverseStringIndexerOp extends OpNode[SparkBundleContext, IndexToString, IndexToString] {
   override val Model: OpModel[SparkBundleContext, IndexToString] = new OpModel[SparkBundleContext, IndexToString] {
     override val klazz: Class[IndexToString] = classOf[IndexToString]
@@ -18,15 +42,18 @@ class ReverseStringIndexerOp extends OpNode[SparkBundleContext, IndexToString, I
 
     override def store(model: Model, obj: IndexToString)
                       (implicit context: BundleContext[SparkBundleContext]): Model = {
-      model.withAttr("labels", obj.get(obj.labels).map(l => Value.stringList(l)))
+      val labels = obj.get(obj.labels).getOrElse {
+        assert(context.context.dataset.isDefined, "must supply a transformed data frame to serialize IndexToString if labels parameter is not set")
+        val df = context.context.dataset.get
+        ReverseStringIndexerOp.labelsForField(df.schema(obj.getInputCol))
+      }
+
+      model.withAttr("labels", Value.stringList(labels))
     }
 
     override def load(model: Model)
                      (implicit context: BundleContext[SparkBundleContext]): IndexToString = {
-      val idxToStr = new IndexToString(uid = "")
-      model.getValue("labels").
-        map(l => idxToStr.setLabels(l.getStringList.toArray)).
-        getOrElse(idxToStr)
+      new IndexToString(uid = "").setLabels(model.value("labels").getStringList.toArray)
     }
   }
 
@@ -38,9 +65,7 @@ class ReverseStringIndexerOp extends OpNode[SparkBundleContext, IndexToString, I
 
   override def load(node: Node, model: IndexToString)
                    (implicit context: BundleContext[SparkBundleContext]): IndexToString = {
-    val idxToStr = new IndexToString(uid = node.name)
-    ParamUtil.setOptional(idxToStr, model, idxToStr.labels, model.labels)
-    idxToStr
+    new IndexToString(uid = node.name).setLabels(model.getLabels)
   }
 
   override def shape(node: IndexToString): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)


### PR DESCRIPTION
When I use `IndexToString`, I do not set the `labels` parameter so the MLeap serialization fails. Spark documentation agrees that this is an optional parameter: https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala#L321. I'm thinking there should be a test case for this, but wasn't sure how to do this without creating another `ReverseStringIndexerParitySpec` class.