### PR TITLE
Feature/issue154

### DIFF
--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/BucketizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/BucketizerOp.scala
@@ -6,6 +6,7 @@ import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.mleap.core.feature.BucketizerModel
 import ml.combust.mleap.runtime.MleapContext
 import ml.combust.mleap.runtime.transformer.feature.Bucketizer
+import ml.combust.mleap.runtime.transformer.feature.BucketizerUtil._
 
 /**
   * Created by mikhail on 9/19/16.
@@ -23,7 +24,7 @@ class BucketizerOp extends OpNode[MleapContext, Bucketizer, BucketizerModel]{
 
     override def load(model: Model)
                      (implicit context: BundleContext[MleapContext]): BucketizerModel = {
-      BucketizerModel(splits = model.value("splits").getDoubleList.toArray)
+      BucketizerModel(splits = restoreSplits(model.value("splits").getDoubleList.toArray))
     }
   }
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Bucketizer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Bucketizer.scala
@@ -13,3 +13,14 @@ case class Bucketizer(override val uid: String = Transformer.uniqueName("bucketi
                       model: BucketizerModel) extends FeatureTransformer {
   override val exec: UserDefinedFunction = (value: Double) => model(value)
 }
+
+object BucketizerUtil {
+
+  def restoreSplits(splits : Array[Double]) = {
+    splits.update(0, update(splits.head, Double.NegativeInfinity))
+    splits.update(splits.length - 1, update(splits.last, Double.PositiveInfinity))
+    splits
+  }
+
+  private def update(orig: Double, updated: Double) = if (orig.isNaN) updated else orig
+}

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketizerOp.scala
@@ -3,6 +3,7 @@ package org.apache.spark.ml.bundle.ops.feature
 import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
+import ml.combust.mleap.runtime.transformer.feature.BucketizerUtil._
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.Bucketizer
 
@@ -22,7 +23,7 @@ class BucketizerOp extends OpNode[SparkBundleContext, Bucketizer, Bucketizer] {
 
     override def load(model: Model)
                      (implicit context: BundleContext[SparkBundleContext]): Bucketizer = {
-      new Bucketizer(uid = "").setSplits(model.value("splits").getDoubleList.toArray)
+      new Bucketizer(uid = "").setSplits(restoreSplits(model.value("splits").getDoubleList.toArray))
     }
   }
 

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/BucketizerParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/BucketizerParitySpec.scala
@@ -13,5 +13,5 @@ class BucketizerParitySpec extends SparkParityBase {
   override val sparkTransformer: Transformer = new Bucketizer().
     setInputCol("loan_amount").
     setOutputCol("loan_amount_bucket").
-    setSplits(Array(0.0, 1000.0, 10000.0, 9999999.0))
+    setSplits(Array(Double.NegativeInfinity, 1000.0, 10000.0, Double.PositiveInfinity))
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
   }
 
   object Provided {
-    val spark = Compile.spark.map(_ % "provided")
+    val spark = Compile.spark.map(_.excludeAll(ExclusionRule(organization = "org.scalatest"))).map(_ % "provided")
   }
 
   import Compile._


### PR DESCRIPTION
Code to fix #154 issue which is caused by the fact that by design, spray-json serializes Double.NegativeInfinity and Double.PositiveInfinity to null. 

https://github.com/spray/spray-json/blob/master/src/test/scala/spray/json/BasicFormatsSpec.scala#L70

Added checks when loading the bucketizer model to replace a first null with Double.NegativeInfinity and a last null with Double.PositiveInfinity.