### PR TITLE
Enable option values for string indexing.

### DIFF
--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringIndexerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringIndexerModel.scala
@@ -14,7 +14,10 @@ case class StringIndexerModel(labels: Seq[String]) extends Serializable {
     * @param value label to index
     * @return index of label
     */
-  def apply(value: String): Double = stringToIndex(value)
+  def apply(value: Any): Double = value match {
+    case opt: Option[_] => stringToIndex(opt.get.toString)
+    case _ => stringToIndex(value.toString)
+  }
 
   /** Create a [[ml.combust.mleap.core.feature.ReverseStringIndexerModel]] from this model.
     *

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/StringIndexer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/StringIndexer.scala
@@ -11,7 +11,7 @@ case class StringIndexer(override val uid: String = Transformer.uniqueName("stri
                          override val inputCol: String,
                          override val outputCol: String,
                          model: StringIndexerModel) extends FeatureTransformer {
-  val exec: UserDefinedFunction = (value: Any) => model(value.toString)
+  val exec: UserDefinedFunction = (value: Any) => model(value)
 
   def toReverse: ReverseStringIndexer = ReverseStringIndexer(inputCol = inputCol,
     outputCol = outputCol,


### PR DESCRIPTION
This enables string indexer to accept:

1. Option[Any]
2. Any

Convert it to a string, then attempt to index it.