### PR TITLE
Adding datatype to input/output socket as a first step needed for issue 38, providing schema of the deployed model

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/BundleContext.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/BundleContext.scala
@@ -1,6 +1,5 @@
 package ml.combust.bundle
 
-import java.io.File
 import java.nio.file.{FileSystem, Path}
 
 import ml.combust.bundle.serializer.{ConcreteSerializationFormat, SerializationContext, SerializationFormat}

--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Shape.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Shape.scala
@@ -175,6 +175,16 @@ case class Shape private (inputs: Seq[Socket],
     name.map(n => withOutput(n, port)).getOrElse(this)
   }
 
+  /** Add an optional typed output socket to the shape.
+    *
+    * @param name name of optional output socket
+    * @param port port of output socket
+    * @return copy of the shape with output socket optionally added
+    */
+  def withOutput(name: Option[String], port: String, dataType: Option[DataType]): Shape = {
+    name.map(n => withOutput(n, port, dataType)).getOrElse(this)
+  }
+
   /** Get the bundle protobuf shape.
     *
     * @return bundle protobuf shape

--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Shape.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Shape.scala
@@ -1,5 +1,6 @@
 package ml.combust.bundle.dsl
 
+import ml.bundle.DataType.DataType
 import ml.bundle.Socket.Socket
 
 /** Companion object for holding constant values.
@@ -109,6 +110,21 @@ case class Shape private (inputs: Seq[Socket],
     withStandardInput(nameInput).withStandardOutput(nameOutput)
   }
 
+  /** Add typed standard input/output sockets to the shape.
+    *
+    * This is the same as calling [[Shape#withStandardInput]] and
+    * [[Shape#withStandardOutput]].
+    *
+    * @param nameInput name of the input socket
+    * @param inputType type of the input socket
+    * @param nameOutput name of the output socket
+    * @param outputType type of the output socket
+    * @return copy of the shape with standard input/output sockets added
+    */
+  def withStandardIO(nameInput: String, inputType: DataType, nameOutput: String, outputType: DataType): Shape = {
+    withStandardInput(nameInput, inputType).withStandardOutput(nameOutput, outputType)
+  }
+
   /** Add standard input socket to the shape.
     *
     * @param name name of standard input socket
@@ -116,12 +132,28 @@ case class Shape private (inputs: Seq[Socket],
     */
   def withStandardInput(name: String): Shape = withInput(name, Shape.standardInputPort)
 
+  /** Add typed standard input socket to the shape.
+    *
+    * @param name name of standard input socket
+    * @param dataType type of standard input socket
+    * @return copy of the shape with standard input socket added
+    */
+  def withStandardInput(name: String, dataType: DataType): Shape = withInput(name, Shape.standardInputPort, dataType)
+
   /** Add standard output socket to the shape.
     *
     * @param name name of standard output socket
     * @return copy of the shape with standard output socket added
     */
   def withStandardOutput(name: String): Shape = withOutput(name, Shape.standardOutputPort)
+
+  /** Add typed standard output socket to the shape.
+    *
+    * @param name name of standard output socket
+    * @param dataType type of standard output socket
+    * @return copy of the shape with standard output socket added
+    */
+  def withStandardOutput(name: String, dataType: DataType): Shape = withOutput(name, Shape.standardOutputPort, dataType)
 
   /** Add an optional input socket to the shape.
     *
@@ -191,6 +223,20 @@ case class Shape private (inputs: Seq[Socket],
     copy(inputs = inputs :+ socket, inputLookup = inputLookup2)
   }
 
+  /** Add a typed input socket to the shape. 
+    *
+    * @param name name of input socket 
+    * @param port port of input socket 
+    * @param dataType type of input socket
+    * @return copy of the shape with input socket added 
+    */
+  def withInput(name: String, port: String, dataType: DataType): Shape = {
+    require(!inputLookup.contains(port), s"input already exists for port: $port")
+    val socket = Socket(name, port, Some(dataType))
+    val inputLookup2 = inputLookup + (port -> socket)
+    copy(inputs = inputs :+ socket, inputLookup = inputLookup2)
+  }
+
   /** Add an output socket to the shape. 
     *
     * @param name name of output socket 
@@ -200,6 +246,20 @@ case class Shape private (inputs: Seq[Socket],
   def withOutput(name: String, port: String): Shape = {
     require(!outputLookup.contains(port), s"output already exists for port: $port")
     val socket = Socket(name, port)
+    val outputLookup2 = outputLookup + (port -> socket)
+    copy(outputs = outputs :+ socket, outputLookup = outputLookup2)
+  }
+
+  /** Add a typed output socket to the shape. 
+    *
+    * @param name name of output socket 
+    * @param port port of output socket 
+    * @param dataType type of output socket
+    * @return copy of the shape with output socket added 
+    */
+  def withOutput(name: String, port: String, dataType: DataType): Shape = {
+    require(!outputLookup.contains(port), s"output already exists for port: $port")
+    val socket = Socket(name, port, Some(dataType))
     val outputLookup2 = outputLookup + (port -> socket)
     copy(outputs = outputs :+ socket, outputLookup = outputLookup2)
   }

--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Shape.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Shape.scala
@@ -121,7 +121,7 @@ case class Shape private (inputs: Seq[Socket],
     * @param outputType type of the output socket
     * @return copy of the shape with standard input/output sockets added
     */
-  def withStandardIO(nameInput: String, inputType: DataType, nameOutput: String, outputType: DataType): Shape = {
+  def withStandardIO(nameInput: String, inputType: Option[DataType], nameOutput: String, outputType: Option[DataType]): Shape = {
     withStandardInput(nameInput, inputType).withStandardOutput(nameOutput, outputType)
   }
 
@@ -138,7 +138,7 @@ case class Shape private (inputs: Seq[Socket],
     * @param dataType type of standard input socket
     * @return copy of the shape with standard input socket added
     */
-  def withStandardInput(name: String, dataType: DataType): Shape = withInput(name, Shape.standardInputPort, dataType)
+  def withStandardInput(name: String, dataType: Option[DataType]): Shape = withInput(name, Shape.standardInputPort, dataType)
 
   /** Add standard output socket to the shape.
     *
@@ -153,7 +153,7 @@ case class Shape private (inputs: Seq[Socket],
     * @param dataType type of standard output socket
     * @return copy of the shape with standard output socket added
     */
-  def withStandardOutput(name: String, dataType: DataType): Shape = withOutput(name, Shape.standardOutputPort, dataType)
+  def withStandardOutput(name: String, dataType: Option[DataType]): Shape = withOutput(name, Shape.standardOutputPort, dataType)
 
   /** Add an optional input socket to the shape.
     *
@@ -230,9 +230,9 @@ case class Shape private (inputs: Seq[Socket],
     * @param dataType type of input socket
     * @return copy of the shape with input socket added 
     */
-  def withInput(name: String, port: String, dataType: DataType): Shape = {
+  def withInput(name: String, port: String, dataType: Option[DataType]): Shape = {
     require(!inputLookup.contains(port), s"input already exists for port: $port")
-    val socket = Socket(name, port, Some(dataType))
+    val socket = Socket(name, port, dataType)
     val inputLookup2 = inputLookup + (port -> socket)
     copy(inputs = inputs :+ socket, inputLookup = inputLookup2)
   }
@@ -257,9 +257,9 @@ case class Shape private (inputs: Seq[Socket],
     * @param dataType type of output socket
     * @return copy of the shape with output socket added 
     */
-  def withOutput(name: String, port: String, dataType: DataType): Shape = {
+  def withOutput(name: String, port: String, dataType: Option[DataType]): Shape = {
     require(!outputLookup.contains(port), s"output already exists for port: $port")
-    val socket = Socket(name, port, Some(dataType))
+    val socket = Socket(name, port, dataType)
     val outputLookup2 = outputLookup + (port -> socket)
     copy(outputs = outputs :+ socket, outputLookup = outputLookup2)
   }

--- a/bundle-ml/src/main/scala/ml/combust/bundle/op/OpNode.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/op/OpNode.scala
@@ -37,7 +37,7 @@ trait OpNode[Context, N, M] {
     * @param node node object
     * @return shape of the node
     */
-  def shape(node: N): Shape
+  def shape(node: N)(implicit context: BundleContext[Context]): Shape
 
   /** Get the children of the node.
     *

--- a/bundle-ml/src/main/scala/ml/combust/bundle/serializer/NodeSerializer.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/serializer/NodeSerializer.scala
@@ -86,7 +86,7 @@ case class NodeSerializer[Context](bundleContext: BundleContext[Context]) {
     modelSerializer.write(op.model(obj)).map {
       _ =>
         val name = op.name(obj)
-        val shape = op.shape(obj)
+        val shape = op.shape(obj)(bundleContext)
         Node(name = name, shape = shape)
     }
   }.flatMap(identity).flatMap {

--- a/bundle-ml/src/test/scala/ml/combust/bundle/test/ops/DecisionTreeRegressionOp.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/test/ops/DecisionTreeRegressionOp.scala
@@ -111,5 +111,7 @@ class DecisionTreeRegressionOp extends OpNode[Any, DecisionTreeRegression, Decis
       model = model)
   }
 
-  override def shape(node: DecisionTreeRegression): Shape = Shape().withStandardIO(node.input, node.output)
+  override def shape(node: DecisionTreeRegression)(implicit context: BundleContext[Any]): Shape = {
+    Shape().withStandardIO(node.input, node.output)
+  }
 }

--- a/bundle-ml/src/test/scala/ml/combust/bundle/test/ops/LinearRegressionOp.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/test/ops/LinearRegressionOp.scala
@@ -49,5 +49,7 @@ class LinearRegressionOp extends OpNode[Any, LinearRegression, LinearModel] {
       model = model)
   }
 
-  override def shape(node: LinearRegression): Shape = Shape().withStandardIO(node.input, node.output)
+  override def shape(node: LinearRegression)(implicit context: BundleContext[Any]): Shape = {
+    Shape().withStandardIO(node.input, node.output)
+  }
 }

--- a/bundle-ml/src/test/scala/ml/combust/bundle/test/ops/MyCustomOp.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/test/ops/MyCustomOp.scala
@@ -43,5 +43,5 @@ class MyCustomOp extends OpNode[Any, MyCustomTransformer, MyCustomTransformer] {
     MyCustomTransformer(model.custom)
   }
 
-  override def shape(node: MyCustomTransformer): Shape = Shape()
+  override def shape(node: MyCustomTransformer)(implicit context: BundleContext[Any]): Shape = Shape()
 }

--- a/bundle-ml/src/test/scala/ml/combust/bundle/test/ops/PipelineOp.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/test/ops/PipelineOp.scala
@@ -43,7 +43,7 @@ class PipelineOp extends OpNode[Any, Pipeline, PipelineModel] {
     Pipeline(node.name, model)
   }
 
-  override def shape(node: Pipeline): Shape = Shape()
+  override def shape(node: Pipeline)(implicit context: BundleContext[Any]): Shape = Shape()
 
   override def children(node: Pipeline): Option[Array[Any]] = Some(node.model.stages.toArray)
 }

--- a/bundle-ml/src/test/scala/ml/combust/bundle/test/ops/StringIndexerOp.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/test/ops/StringIndexerOp.scala
@@ -47,5 +47,7 @@ class StringIndexerOp extends OpNode[Any, StringIndexer, StringIndexerModel] {
       model = model)
   }
 
-  override def shape(node: StringIndexer): Shape = Shape().withStandardIO(node.input, node.output)
+  override def shape(node: StringIndexer)(implicit context: BundleContext[Any]): Shape = {
+    Shape().withStandardIO(node.input, node.output)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/PipelineOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/PipelineOp.scala
@@ -41,5 +41,5 @@ class PipelineOp extends OpNode[MleapContext, Pipeline, Pipeline] {
     model.copy(uid = node.name)
   }
 
-  override def shape(node: Pipeline): Shape = Shape()
+  override def shape(node: Pipeline)(implicit context: BundleContext[MleapContext]): Shape = Shape()
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/DecisionTreeClassifierOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/DecisionTreeClassifierOp.scala
@@ -53,8 +53,10 @@ class DecisionTreeClassifierOp extends OpNode[MleapContext, DecisionTreeClassifi
       model = model)
   }
 
-  override def shape(node: DecisionTreeClassifier): Shape = Shape().withInput(node.featuresCol, "features").
-    withOutput(node.predictionCol, "prediction").
-    withOutput(node.rawPredictionCol, "raw_prediction").
-    withOutput(node.probabilityCol, "probability")
+  override def shape(node: DecisionTreeClassifier)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").
+      withOutput(node.predictionCol, "prediction").
+      withOutput(node.rawPredictionCol, "raw_prediction").
+      withOutput(node.probabilityCol, "probability")
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/GBTClassifierOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/GBTClassifierOp.scala
@@ -67,6 +67,7 @@ class GBTClassifierOp extends OpNode[MleapContext, GBTClassifier, GBTClassifierM
       model = model)
   }
 
-  override def shape(node: GBTClassifier): Shape = Shape().withInput(node.featuresCol, "features").
-    withOutput(node.predictionCol, "prediction")
+  override def shape(node: GBTClassifier)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").withOutput(node.predictionCol, "prediction")
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/LogisticRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/LogisticRegressionOp.scala
@@ -71,9 +71,10 @@ class LogisticRegressionOp extends OpNode[MleapContext, LogisticRegression, Logi
       model = model)
   }
 
-  override def shape(node: LogisticRegression): Shape = Shape().
-    withInput(node.featuresCol, "features").
-    withOutput(node.predictionCol, "prediction").
-    withOutput(node.rawPredictionCol, "raw_prediction").
-    withOutput(node.probabilityCol, "probability")
+  override def shape(node: LogisticRegression)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").
+      withOutput(node.predictionCol, "prediction").
+      withOutput(node.rawPredictionCol, "raw_prediction").
+      withOutput(node.probabilityCol, "probability")
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/MultiLayerPerceptronClassifierOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/MultiLayerPerceptronClassifierOp.scala
@@ -44,6 +44,8 @@ class MultiLayerPerceptronClassifierOp extends OpNode[MleapContext, MultiLayerPe
       model = model)
   }
 
-  override def shape(node: MultiLayerPerceptronClassifier): Shape = Shape().withInput(node.featuresCol, "features").
-    withOutput(node.predictionCol, "prediction")
+  override def shape(node: MultiLayerPerceptronClassifier)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").
+      withOutput(node.predictionCol, "prediction")
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/NaiveBayesClassifierOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/NaiveBayesClassifierOp.scala
@@ -53,8 +53,10 @@ class NaiveBayesClassifierOp extends OpNode[MleapContext, NaiveBayesClassifier, 
       probabilityCol = node.shape.getOutput("probability").map(_.name),
       model = model)
   }
-  override def shape(node: NaiveBayesClassifier): Shape = Shape().withInput(node.featuresCol, "features").
-    withOutput(node.predictionCol, "prediction").
-    withOutput(node.rawPredictionCol, "raw_prediction").
-    withOutput(node.probabilityCol, "probability")
+  override def shape(node: NaiveBayesClassifier)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").
+      withOutput(node.predictionCol, "prediction").
+      withOutput(node.rawPredictionCol, "raw_prediction").
+      withOutput(node.probabilityCol, "probability")
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/OneVsRestOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/OneVsRestOp.scala
@@ -57,7 +57,9 @@ class OneVsRestOp extends OpNode[MleapContext, OneVsRest, OneVsRestModel] {
       model = model)
   }
 
-  override def shape(node: OneVsRest): Shape = Shape().withInput(node.featuresCol, "features").
-    withOutput(node.predictionCol, "prediction").
-    withOutput(node.probabilityCol, "probability"  )
+  override def shape(node: OneVsRest)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").
+      withOutput(node.predictionCol, "prediction").
+      withOutput(node.probabilityCol, "probability"  )
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/RandomForestClassifierOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/RandomForestClassifierOp.scala
@@ -69,8 +69,10 @@ class RandomForestClassifierOp extends OpNode[MleapContext, RandomForestClassifi
       model = model)
   }
 
-  override def shape(node: RandomForestClassifier): Shape = Shape().withInput(node.featuresCol, "features").
-    withOutput(node.predictionCol, "prediction").
-    withOutput(node.rawPredictionCol, "raw_prediction").
-    withOutput(node.probabilityCol, "probability")
+  override def shape(node: RandomForestClassifier)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").
+      withOutput(node.predictionCol, "prediction").
+      withOutput(node.rawPredictionCol, "raw_prediction").
+      withOutput(node.probabilityCol, "probability")
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/SupportVectorMachineOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/SupportVectorMachineOp.scala
@@ -52,7 +52,7 @@ class SupportVectorMachineOp extends OpNode[MleapContext, SupportVectorMachine, 
       model = model)
   }
 
-  override def shape(node: SupportVectorMachine): Shape = Shape().withInput(node.featuresCol, "features").
+  override def shape(node: SupportVectorMachine)(implicit context: BundleContext[MleapContext]): Shape = Shape().withInput(node.featuresCol, "features").
     withOutput(node.predictionCol, "prediction").
     withOutput(node.rawPredictionCol, "raw_prediction").
     withOutput(node.probabilityCol, "probability")

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/clustering/BisectingKMeansOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/clustering/BisectingKMeansOp.scala
@@ -47,6 +47,7 @@ class BisectingKMeansOp extends OpNode[MleapContext, BisectingKMeans, BisectingK
       model = model)
   }
 
-  override def shape(node: BisectingKMeans): Shape = Shape().withInput(node.featuresCol, "features").
-    withOutput(node.predictionCol, "prediction")
+  override def shape(node: BisectingKMeans)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").withOutput(node.predictionCol, "prediction")
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/clustering/GaussianMixtureOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/clustering/GaussianMixtureOp.scala
@@ -56,7 +56,9 @@ class GaussianMixtureOp extends OpNode[MleapContext, GaussianMixture, GaussianMi
       model = model)
   }
 
-  override def shape(node: GaussianMixture): Shape = Shape().withInput(node.featuresCol, "features").
-    withOutput(node.predictionCol, "prediction").
-    withOutput(node.probabilityCol, "probability")
+  override def shape(node: GaussianMixture)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").
+      withOutput(node.predictionCol, "prediction").
+      withOutput(node.probabilityCol, "probability")
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/clustering/KMeansOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/clustering/KMeansOp.scala
@@ -44,6 +44,7 @@ class KMeansOp extends OpNode[MleapContext, KMeans, KMeansModel] {
       model = model)
   }
 
-  override def shape(node: KMeans): Shape = Shape().withInput(node.featuresCol, "features").
-    withOutput(node.predictionCol, "prediction")
+  override def shape(node: KMeans)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").withOutput(node.predictionCol, "prediction")
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/clustering/LDAModelOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/clustering/LDAModelOp.scala
@@ -49,9 +49,8 @@ class LDAModelOp extends OpNode[MleapContext, LDAModel, LocalLDAModel] {
 
   override def model(node: LDAModel): LocalLDAModel = node.model
 
-  override def shape(node: LDAModel): Shape = {
-    Shape().
-      withInput(node.featureCol, "features").
+  override def shape(node: LDAModel)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featureCol, "features").
       withOutput(node.topicDistributionCol, "topicDistribution")
   }
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/BinarizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/BinarizerOp.scala
@@ -42,5 +42,7 @@ class BinarizerOp extends OpNode[MleapContext, Binarizer, BinarizerModel] {
       model = model)
   }
 
-  override def shape(node: Binarizer): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: Binarizer)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/BucketedRandomProjectionLSHOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/BucketedRandomProjectionLSHOp.scala
@@ -46,5 +46,7 @@ class BucketedRandomProjectionLSHOp extends OpNode[MleapContext, BucketedRandomP
       model = model)
   }
 
-  override def shape(node: BucketedRandomProjectionLSH): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: BucketedRandomProjectionLSH)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/BucketizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/BucketizerOp.scala
@@ -42,5 +42,7 @@ class BucketizerOp extends OpNode[MleapContext, Bucketizer, BucketizerModel]{
       model = model)
   }
 
-  override def shape(node: Bucketizer): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: Bucketizer)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/ChiSqSelectorOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/ChiSqSelectorOp.scala
@@ -41,6 +41,7 @@ class ChiSqSelectorOp extends OpNode[MleapContext, ChiSqSelector, ChiSqSelectorM
       model = model)
   }
 
-  override def shape(node: ChiSqSelector): Shape = Shape().withInput(node.featuresCol, "features").
-    withStandardOutput(node.outputCol)
+  override def shape(node: ChiSqSelector)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").withStandardOutput(node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/CoalesceOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/CoalesceOp.scala
@@ -36,7 +36,7 @@ class CoalesceOp extends OpNode[MleapContext, Coalesce, CoalesceModel] {
       model = model)
   }
 
-  override def shape(node: Coalesce): Shape = {
+  override def shape(node: Coalesce)(implicit context: BundleContext[MleapContext]): Shape = {
     var i = 0
     node.inputCols.foldLeft(Shape()) {
       case (shape, inputCol) =>

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/CountVectorizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/CountVectorizerOp.scala
@@ -45,5 +45,7 @@ class CountVectorizerOp extends OpNode[MleapContext, CountVectorizer, CountVecto
       model = model)
   }
 
-  override def shape(node: CountVectorizer): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: CountVectorizer)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/DCTOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/DCTOp.scala
@@ -41,5 +41,7 @@ class DCTOp extends OpNode[MleapContext, DCT, DCTModel] {
       model = model)
   }
 
-  override def shape(node: DCT): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: DCT)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/ElementwiseProductOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/ElementwiseProductOp.scala
@@ -43,6 +43,8 @@ class ElementwiseProductOp extends OpNode[MleapContext, ElementwiseProduct, Elem
     )
   }
 
-  override def shape(node: ElementwiseProduct): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: ElementwiseProduct)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/HashingTermFrequencyOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/HashingTermFrequencyOp.scala
@@ -41,5 +41,7 @@ class HashingTermFrequencyOp extends OpNode[MleapContext, HashingTermFrequency, 
       model = model)
   }
 
-  override def shape(node: HashingTermFrequency): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: HashingTermFrequency)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/IDFOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/IDFOp.scala
@@ -42,5 +42,7 @@ class IDFOp extends OpNode[MleapContext, IDF, IDFModel] {
       model = model)
   }
 
-  override def shape(node: IDF): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: IDF)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/ImputerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/ImputerOp.scala
@@ -46,5 +46,7 @@ class ImputerOp extends OpNode[MleapContext, Imputer, ImputerModel] {
       model = model)
   }
 
-  override def shape(node: Imputer): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: Imputer)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/MathBinaryOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/MathBinaryOp.scala
@@ -46,7 +46,9 @@ class MathBinaryOp extends OpNode[MleapContext, MathBinary, MathBinaryModel] {
       model = model)
   }
 
-  override def shape(node: MathBinary): Shape = Shape().withInput(node.inputA, "input_a").
-    withInput(node.inputB, "input_b").
-    withStandardOutput(node.outputCol)
+  override def shape(node: MathBinary)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.inputA, "input_a").
+      withInput(node.inputB, "input_b").
+      withStandardOutput(node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/MathUnaryOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/MathUnaryOp.scala
@@ -41,5 +41,7 @@ class MathUnaryOp extends OpNode[MleapContext, MathUnary, MathUnaryModel] {
       model = model)
   }
 
-  override def shape(node: MathUnary): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: MathUnary)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/MaxAbsScalerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/MaxAbsScalerOp.scala
@@ -42,5 +42,7 @@ class MaxAbsScalerOp extends OpNode[MleapContext, MaxAbsScaler, MaxAbsScalerMode
       model = model)
   }
 
-  override def shape(node: MaxAbsScaler): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: MaxAbsScaler)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/MinHashLSHOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/MinHashLSHOp.scala
@@ -47,5 +47,7 @@ class MinHashLSHOp extends OpNode[MleapContext, MinHashLSH, MinHashLSHModel] {
       model = model)
   }
 
-  override def shape(node: MinHashLSH): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: MinHashLSH)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/MinMaxScalerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/MinMaxScalerOp.scala
@@ -44,5 +44,7 @@ class MinMaxScalerOp extends OpNode[MleapContext, MinMaxScaler, MinMaxScalerMode
       model = model)
   }
 
-  override def shape(node: MinMaxScaler): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: MinMaxScaler)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/MultinomialLabelerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/MultinomialLabelerOp.scala
@@ -44,7 +44,9 @@ class MultinomialLabelerOp extends OpNode[MleapContext, MultinomialLabeler, Mult
       model = model)
   }
 
-  override def shape(node: MultinomialLabeler): Shape = Shape().withInput(node.featuresCol, "features").
-    withOutput(node.probabilitiesCol, "probabilities").
-    withOutput(node.labelsCol, "labels")
+  override def shape(node: MultinomialLabeler)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").
+      withOutput(node.probabilitiesCol, "probabilities").
+      withOutput(node.labelsCol, "labels")
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/NGramOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/NGramOp.scala
@@ -41,5 +41,7 @@ class NGramOp extends OpNode[MleapContext, NGram, NGramModel]{
       model = model)
   }
 
-  override def shape(node: NGram): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: NGram)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/NormalizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/NormalizerOp.scala
@@ -41,5 +41,7 @@ class NormalizerOp extends OpNode[MleapContext, Normalizer, NormalizerModel] {
       model = model)
   }
 
-  override def shape(node: Normalizer): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: Normalizer)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/OneHotEncoderOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/OneHotEncoderOp.scala
@@ -43,5 +43,7 @@ class OneHotEncoderOp extends OpNode[MleapContext, OneHotEncoder, OneHotEncoderM
       model = model)
   }
 
-  override def shape(node: OneHotEncoder): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: OneHotEncoder)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/PcaOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/PcaOp.scala
@@ -45,5 +45,7 @@ class PcaOp extends OpNode[MleapContext, Pca, PcaModel] {
       model = model)
   }
 
-  override def shape(node: Pca): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: Pca)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/PolynomialExpansionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/PolynomialExpansionOp.scala
@@ -41,5 +41,7 @@ class PolynomialExpansionOp extends OpNode[MleapContext, PolynomialExpansion, Po
       model = model)
   }
 
-  override def shape(node: PolynomialExpansion): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: PolynomialExpansion)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/RegexTokenizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/RegexTokenizerOp.scala
@@ -55,5 +55,7 @@ class RegexTokenizerOp extends OpNode[MleapContext, RegexTokenizer, RegexTokeniz
       model = model)
   }
 
-  override def shape(node: RegexTokenizer): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: RegexTokenizer)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/ReverseStringIndexerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/ReverseStringIndexerOp.scala
@@ -41,5 +41,7 @@ class ReverseStringIndexerOp extends OpNode[MleapContext, ReverseStringIndexer, 
       model = model)
   }
 
-  override def shape(node: ReverseStringIndexer): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: ReverseStringIndexer)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/StandardScalerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/StandardScalerOp.scala
@@ -45,5 +45,7 @@ class StandardScalerOp extends OpNode[MleapContext, StandardScaler, StandardScal
       model = model)
   }
 
-  override def shape(node: StandardScaler): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: StandardScaler)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/StopWordsRemoverOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/StopWordsRemoverOp.scala
@@ -45,5 +45,7 @@ class StopWordsRemoverOp extends OpNode[MleapContext, StopWordsRemover, StopWord
     )
   }
 
-  override def shape(node: StopWordsRemover): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: StopWordsRemover)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/StringIndexerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/StringIndexerOp.scala
@@ -41,5 +41,7 @@ class StringIndexerOp extends OpNode[MleapContext, StringIndexer, StringIndexerM
       model = model)
   }
 
-  override def shape(node: StringIndexer): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: StringIndexer)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/StringMapOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/StringMapOp.scala
@@ -70,5 +70,7 @@ class StringMapOp extends OpNode[MleapContext, StringMap, StringMapModel] {
   // a node. shapes can get fairly complicated and may be confusing at first
   // but all they do is connect fields from a data frame to certain input/output
   // locations of the node itself
-  override def shape(node: StringMap): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: StringMap)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/TokenizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/TokenizerOp.scala
@@ -36,5 +36,7 @@ class TokenizerOp extends OpNode[MleapContext, Tokenizer, TokenizerModel] {
       outputCol = node.shape.standardOutput.name)
   }
 
-  override def shape(node: Tokenizer): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: Tokenizer)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/VectorAssemblerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/VectorAssemblerOp.scala
@@ -36,7 +36,7 @@ class VectorAssemblerOp extends OpNode[MleapContext, VectorAssembler, VectorAsse
       outputCol = node.shape.standardOutput.name)
   }
 
-  override def shape(node: VectorAssembler): Shape = {
+  override def shape(node: VectorAssembler)(implicit context: BundleContext[MleapContext]): Shape = {
     var i = 0
     node.inputCols.foldLeft(Shape()) {
       case (shape, inputCol) =>

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/VectorIndexerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/VectorIndexerOp.scala
@@ -62,5 +62,7 @@ class VectorIndexerOp extends OpNode[MleapContext, VectorIndexer, VectorIndexerM
       model = model)
   }
 
-  override def shape(node: VectorIndexer): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: VectorIndexer)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/VectorSlicerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/VectorSlicerOp.scala
@@ -41,5 +41,7 @@ class VectorSlicerOp extends OpNode[MleapContext, VectorSlicer, VectorSlicerMode
       model = model)
   }
 
-  override def shape(node: VectorSlicer): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+  override def shape(node: VectorSlicer)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.inputCol, node.outputCol)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/WordLengthFilterOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/WordLengthFilterOp.scala
@@ -44,7 +44,7 @@ class WordLengthFilterOp extends OpNode[MleapContext, WordLengthFilter, WordLeng
   // a node. shapes can get fairly complicated and may be confusing at first
   // but all they do is connect fields from a data frame to certain input/output
   // locations of the node itself
-  override def shape(node: WordLengthFilter): Shape =
+  override def shape(node: WordLengthFilter)(implicit context: BundleContext[MleapContext]): Shape =
   Shape().withStandardIO(node.inputCol, node.outputCol)
 
   // reconstruct our MLeap transformer from the

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/WordToVectorOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/WordToVectorOp.scala
@@ -49,7 +49,7 @@ class WordToVectorOp extends OpNode[MleapContext, WordToVector, WordToVectorMode
       model = model)
   }
 
-  override def shape(node: WordToVector): Shape = {
+  override def shape(node: WordToVector)(implicit context: BundleContext[MleapContext]): Shape = {
     Shape().withStandardIO(node.inputCol, node.outputCol)
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/AFTSurvivalRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/AFTSurvivalRegressionOp.scala
@@ -49,7 +49,9 @@ class AFTSurvivalRegressionOp extends OpNode[MleapContext, AFTSurvivalRegression
       model = model)
   }
 
-  override def shape(node: AFTSurvivalRegression): Shape = Shape().withInput(node.featuresCol, "features").
-    withOutput(node.predictionCol, "prediction").
-    withOutput(node.quantilesCol, "quantiles")
+  override def shape(node: AFTSurvivalRegression)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").
+      withOutput(node.predictionCol, "prediction").
+      withOutput(node.quantilesCol, "quantiles")
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/DecisionTreeRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/DecisionTreeRegressionOp.scala
@@ -48,6 +48,7 @@ class DecisionTreeRegressionOp extends OpNode[MleapContext, DecisionTreeRegressi
       model = model)
   }
 
-  override def shape(node: DecisionTreeRegression): Shape = Shape().withInput(node.featuresCol, "features").
-    withOutput(node.predictionCol, "prediction")
+  override def shape(node: DecisionTreeRegression)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").withOutput(node.predictionCol, "prediction")
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/GBTRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/GBTRegressionOp.scala
@@ -66,6 +66,7 @@ class GBTRegressionOp extends OpNode[MleapContext, GBTRegression, GBTRegressionM
     * @param node node object
     * @return shape of the node
     */
-  override def shape(node: GBTRegression): Shape = Shape().withInput(node.featuresCol, "features").
-    withOutput(node.predictionCol, "prediction")
+  override def shape(node: GBTRegression)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").withOutput(node.predictionCol, "prediction")
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/GeneralizedLinearRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/GeneralizedLinearRegressionOp.scala
@@ -50,7 +50,9 @@ class GeneralizedLinearRegressionOp extends OpNode[MleapContext, GeneralizedLine
       model = model)
   }
 
-  override def shape(node: GeneralizedLinearRegression): Shape = Shape().withInput(node.featuresCol, "features").
-    withOutput(node.predictionCol, "prediction").
-    withOutput(node.linkPredictionCol, "link_prediction")
+  override def shape(node: GeneralizedLinearRegression)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").
+      withOutput(node.predictionCol, "prediction").
+      withOutput(node.linkPredictionCol, "link_prediction")
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/IsotonicRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/IsotonicRegressionOp.scala
@@ -47,6 +47,7 @@ class IsotonicRegressionOp extends OpNode[MleapContext, IsotonicRegression, Isot
       model = model)
   }
 
-  override def shape(node: IsotonicRegression): Shape = Shape().withInput(node.featuresCol, "features").
-    withOutput(node.predictionCol, "prediction")
+  override def shape(node: IsotonicRegression)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").withOutput(node.predictionCol, "prediction")
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/LinearRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/LinearRegressionOp.scala
@@ -44,6 +44,7 @@ class LinearRegressionOp extends OpNode[MleapContext, LinearRegression, LinearRe
       model = model)
   }
 
-  override def shape(node: LinearRegression): Shape = Shape().withInput(node.featuresCol, "features").
-    withOutput(node.predictionCol, "prediction")
+  override def shape(node: LinearRegression)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").withOutput(node.predictionCol, "prediction")
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/RandomForestRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/RandomForestRegressionOp.scala
@@ -64,6 +64,8 @@ class RandomForestRegressionOp extends OpNode[MleapContext, RandomForestRegressi
       model = model)
   }
 
-  override def shape(node: RandomForestRegression): Shape = Shape().withInput(node.featuresCol, "features").
-    withOutput(node.predictionCol, "prediction")
+  override def shape(node: RandomForestRegression)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.featuresCol, "features").
+      withOutput(node.predictionCol, "prediction")
+  }
 }

--- a/mleap-spark-base/src/main/scala/ml/combust/mleap/spark/SparkSupport.scala
+++ b/mleap-spark-base/src/main/scala/ml/combust/mleap/spark/SparkSupport.scala
@@ -6,7 +6,6 @@ import ml.combust.mleap.runtime.transformer.{Transformer => MleapTransformer}
 import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.mleap.TensorUDT
 
 import scala.util.Try
 

--- a/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
+++ b/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
@@ -41,11 +41,6 @@ trait TypeConverters {
     case DoubleType => Some(types.DoubleType())
     case vt:VectorUDT => Some(types.ListType(types.DoubleType()))
     case at: ArrayType =>  Some(types.ListType(mleapType(at.elementType).get))
-//    case lt: types.ListType => sparkType(lt.base).map(t => ArrayType(t, containsNull = false))
-//    case tt: types.TensorType => Some(new TensorUDT)
-//    case ct: types.CustomType => UDTRegistration.getUDTFor(ct.klazz.getCanonicalName).
-//      map(_.newInstance().asInstanceOf[UserDefinedType[_]])
-//    case types.AnyType(_) => None
     case _ => throw new RuntimeException(s"unsupported data type: $dataType")
   }
 

--- a/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
+++ b/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
@@ -39,8 +39,8 @@ trait TypeConverters {
     case LongType => Some(types.LongType())
     case FloatType => Some(types.FloatType())
     case DoubleType => Some(types.DoubleType())
-    case at: VectorUDT => Some(types.ListType(types.DoubleType()))
-
+    case vt:VectorUDT => Some(types.ListType(types.DoubleType()))
+    case at: ArrayType =>  Some(types.ListType(mleapType(at.elementType).get))
 //    case lt: types.ListType => sparkType(lt.base).map(t => ArrayType(t, containsNull = false))
 //    case tt: types.TensorType => Some(new TensorUDT)
 //    case ct: types.CustomType => UDTRegistration.getUDTFor(ct.klazz.getCanonicalName).

--- a/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
+++ b/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
@@ -2,7 +2,6 @@ package org.apache.spark.sql.mleap
 
 import ml.combust.mleap.runtime.types
 import org.apache.spark.sql.types._
-import org.apache.spark.ml.linalg.VectorUDT
 
 import scala.language.implicitConversions
 

--- a/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
+++ b/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
@@ -1,6 +1,10 @@
 package org.apache.spark.sql.mleap
 
+import ml.bundle
 import ml.combust.mleap.runtime.types
+import ml.combust.mleap.runtime.types.BundleTypeConverters.mleapTypeToBundleType
+import org.apache.spark.ml.linalg.VectorUDT
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types._
 
 import scala.language.implicitConversions
@@ -24,6 +28,36 @@ trait TypeConverters {
       map(_.newInstance().asInstanceOf[UserDefinedType[_]])
     case types.AnyType(_) => None
     case _ => throw new RuntimeException(s"unsupported data type: $dataType")
+  }
+
+  implicit def mleapType(dataType: DataType): Option[types.DataType] = dataType match {
+    case BooleanType => Some(types.BooleanType())
+    case StringType => Some(types.StringType())
+    case ByteType => Some(types.ByteType())
+    case ShortType => Some(types.ShortType())
+    case IntegerType => Some(types.IntegerType())
+    case LongType => Some(types.LongType())
+    case FloatType => Some(types.FloatType())
+    case DoubleType => Some(types.DoubleType())
+    case at: VectorUDT => Some(types.ListType(types.DoubleType()))
+
+//    case lt: types.ListType => sparkType(lt.base).map(t => ArrayType(t, containsNull = false))
+//    case tt: types.TensorType => Some(new TensorUDT)
+//    case ct: types.CustomType => UDTRegistration.getUDTFor(ct.klazz.getCanonicalName).
+//      map(_.newInstance().asInstanceOf[UserDefinedType[_]])
+//    case types.AnyType(_) => None
+    case _ => throw new RuntimeException(s"unsupported data type: $dataType")
+  }
+
+  implicit def fieldType(name: String, dataset: Option[DataFrame]): Option[bundle.DataType.DataType] = {
+    dataset match {
+      case Some(_) => {
+          val schema = dataset.get.schema
+          val index = schema.fieldIndex(name)
+          Some(mleapTypeToBundleType(mleapType(schema.fields.apply(index).dataType).get))
+      }
+      case None => None
+    }
   }
 }
 object TypeConverters extends TypeConverters

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/classification/OneVsRestOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/classification/OneVsRestOp.scala
@@ -68,7 +68,9 @@ class OneVsRestOp extends OpNode[SparkBundleContext, OneVsRestModel, OneVsRestMo
     ovr
   }
 
-  override def shape(node: OneVsRestModel): Shape = Shape().withInput(node.getFeaturesCol, "features").
-    withOutput(node.getPredictionCol, "prediction").
-    withOutput(node.get(node.probabilityCol), "probability")
+  override def shape(node: OneVsRestModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withInput(node.getFeaturesCol, "features").
+      withOutput(node.getPredictionCol, "prediction").
+      withOutput(node.get(node.probabilityCol), "probability")
+  }
 }

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/classification/OneVsRestOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/classification/OneVsRestOp.scala
@@ -8,6 +8,7 @@ import org.apache.spark.ml.attribute.NominalAttribute
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.classification.ClassificationModel
 import org.apache.spark.ml.mleap.classification.OneVsRestModel
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 8/21/16.
@@ -69,8 +70,11 @@ class OneVsRestOp extends OpNode[SparkBundleContext, OneVsRestModel, OneVsRestMo
   }
 
   override def shape(node: OneVsRestModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withInput(node.getFeaturesCol, "features").
-      withOutput(node.getPredictionCol, "prediction").
-      withOutput(node.get(node.probabilityCol), "probability")
+    val dataset = context.context.dataset
+    val probabilityType = if(node.isDefined(node.probabilityCol)) fieldType(node.getProbabilityCol, dataset) else None
+
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset)).
+      withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset)).
+      withOutput(node.get(node.probabilityCol), "probability", probabilityType)
   }
 }

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/classification/SupportVectorMachineOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/classification/SupportVectorMachineOp.scala
@@ -7,6 +7,7 @@ import org.apache.spark.ml.bundle.util.ParamUtil
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.mleap.classification.SVMModel
 import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 8/21/16.
@@ -61,12 +62,15 @@ class SupportVectorMachineOp extends OpNode[SparkBundleContext, SVMModel, SVMMod
   }
 
   override def shape(node: SVMModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    val dataset = context.context.dataset
     val rawPrediction = if(node.isDefined(node.rawPredictionCol)) Some(node.getRawPredictionCol) else None
+    val rawPredictionType = if(node.isDefined(node.rawPredictionCol)) fieldType(node.getRawPredictionCol, dataset) else None
     val probability = if(node.isDefined(node.probabilityCol)) Some(node.getProbabilityCol) else None
+    val probabilityType = if(node.isDefined(node.probabilityCol)) fieldType(node.getProbabilityCol, dataset) else None
 
-    Shape().withInput(node.getFeaturesCol, "features").
-      withOutput(node.getPredictionCol, "prediction").
-      withOutput(rawPrediction, "raw_prediction").
-      withOutput(probability, "probability")
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset)).
+      withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset)).
+      withOutput(rawPrediction, "raw_prediction", rawPredictionType).
+      withOutput(probability, "probability", probabilityType)
   }
 }

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/classification/SupportVectorMachineOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/classification/SupportVectorMachineOp.scala
@@ -60,7 +60,7 @@ class SupportVectorMachineOp extends OpNode[SparkBundleContext, SVMModel, SVMMod
     node.shape.getOutput("probability").map(s => svm.setProbabilityCol(s.name)).getOrElse(svm)
   }
 
-  override def shape(node: SVMModel): Shape = {
+  override def shape(node: SVMModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
     val rawPrediction = if(node.isDefined(node.rawPredictionCol)) Some(node.getRawPredictionCol) else None
     val probability = if(node.isDefined(node.probabilityCol)) Some(node.getProbabilityCol) else None
 

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/ImputerOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/ImputerOp.scala
@@ -48,6 +48,8 @@ class ImputerOp extends OpNode[SparkBundleContext, ImputerModel, ImputerModel] {
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: ImputerModel): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: ImputerModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 
 }

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/ImputerOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/ImputerOp.scala
@@ -5,6 +5,7 @@ import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.mleap.feature.ImputerModel
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by mikhail on 12/18/16.
@@ -49,7 +50,9 @@ class ImputerOp extends OpNode[SparkBundleContext, ImputerModel, ImputerModel] {
   }
 
   override def shape(node: ImputerModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 
 }

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathBinaryOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathBinaryOp.scala
@@ -4,27 +4,28 @@ import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.mleap.core.feature.{BinaryOperation, MathBinaryModel}
-import ml.combust.mleap.runtime.MleapContext
+import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.mleap.feature.MathBinary
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 12/27/16.
   */
-class MathBinaryOp extends OpNode[MleapContext, MathBinary, MathBinaryModel] {
-  override val Model: OpModel[MleapContext, MathBinaryModel] = new OpModel[MleapContext, MathBinaryModel] {
+class MathBinaryOp extends OpNode[SparkBundleContext, MathBinary, MathBinaryModel] {
+  override val Model: OpModel[SparkBundleContext, MathBinaryModel] = new OpModel[SparkBundleContext, MathBinaryModel] {
     override val klazz: Class[MathBinaryModel] = classOf[MathBinaryModel]
 
     override def opName: String = Bundle.BuiltinOps.feature.math_binary
 
     override def store(model: Model, obj: MathBinaryModel)
-                      (implicit context: BundleContext[MleapContext]): Model = {
+                      (implicit context: BundleContext[SparkBundleContext]): Model = {
       model.withAttr("operation", Value.string(obj.operation.name)).
         withAttr("da", obj.da.map(Value.double)).
         withAttr("db", obj.db.map(Value.double))
     }
 
     override def load(model: Model)
-                     (implicit context: BundleContext[MleapContext]): MathBinaryModel = {
+                     (implicit context: BundleContext[SparkBundleContext]): MathBinaryModel = {
       MathBinaryModel(operation = BinaryOperation.forName(model.value("operation").getString),
         da = model.getValue("da").map(_.getDouble),
         db = model.getValue("db").map(_.getDouble))
@@ -38,7 +39,7 @@ class MathBinaryOp extends OpNode[MleapContext, MathBinary, MathBinaryModel] {
   override def model(node: MathBinary): MathBinaryModel = node.model
 
   override def load(node: Node, model: MathBinaryModel)
-                   (implicit context: BundleContext[MleapContext]): MathBinary = {
+                   (implicit context: BundleContext[SparkBundleContext]): MathBinary = {
     val mb = new MathBinary(uid = node.name,
       model = model).setOutputCol(node.shape.standardOutput.name)
     node.shape.getInput("input_a").foreach(a => mb.setInputA(a.name))
@@ -46,15 +47,16 @@ class MathBinaryOp extends OpNode[MleapContext, MathBinary, MathBinaryModel] {
     mb
   }
 
-  override def shape(node: MathBinary)(implicit context: BundleContext[MleapContext]): Shape = {
-    var shape = Shape().withStandardOutput(node.getOutputCol)
+  override def shape(node: MathBinary)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    val dataset = context.context.dataset
+    var shape = Shape().withStandardOutput(node.getOutputCol, fieldType(node.getOutputCol, dataset))
 
     if(node.isSet(node.inputA)) {
-      shape = shape.withInput(node.getInputA, "input_a")
+      shape = shape.withInput(node.getInputA, "input_a", fieldType(node.getInputA, dataset))
     }
 
     if(node.isSet(node.inputB)) {
-      shape = shape.withInput(node.getInputB, "input_b")
+      shape = shape.withInput(node.getInputB, "input_b", fieldType(node.getInputB, dataset))
     }
 
     shape

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathBinaryOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathBinaryOp.scala
@@ -46,7 +46,7 @@ class MathBinaryOp extends OpNode[MleapContext, MathBinary, MathBinaryModel] {
     mb
   }
 
-  override def shape(node: MathBinary): Shape = {
+  override def shape(node: MathBinary)(implicit context: BundleContext[MleapContext]): Shape = {
     var shape = Shape().withStandardOutput(node.getOutputCol)
 
     if(node.isSet(node.inputA)) {

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathUnaryOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathUnaryOp.scala
@@ -4,25 +4,26 @@ import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.mleap.core.feature.{MathUnaryModel, UnaryOperation}
-import ml.combust.mleap.runtime.MleapContext
+import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.mleap.feature.MathUnary
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 12/27/16.
   */
-class MathUnaryOp extends OpNode[MleapContext, MathUnary, MathUnaryModel] {
-  override val Model: OpModel[MleapContext, MathUnaryModel] = new OpModel[MleapContext, MathUnaryModel] {
+class MathUnaryOp extends OpNode[SparkBundleContext, MathUnary, MathUnaryModel] {
+  override val Model: OpModel[SparkBundleContext, MathUnaryModel] = new OpModel[SparkBundleContext, MathUnaryModel] {
     override val klazz: Class[MathUnaryModel] = classOf[MathUnaryModel]
 
     override def opName: String = Bundle.BuiltinOps.feature.math_unary
 
     override def store(model: Model, obj: MathUnaryModel)
-                      (implicit context: BundleContext[MleapContext]): Model = {
+                      (implicit context: BundleContext[SparkBundleContext]): Model = {
       model.withAttr("operation", Value.string(obj.operation.name))
     }
 
     override def load(model: Model)
-                     (implicit context: BundleContext[MleapContext]): MathUnaryModel = {
+                     (implicit context: BundleContext[SparkBundleContext]): MathUnaryModel = {
       MathUnaryModel(UnaryOperation.forName(model.value("operation").getString))
     }
   }
@@ -34,13 +35,15 @@ class MathUnaryOp extends OpNode[MleapContext, MathUnary, MathUnaryModel] {
   override def model(node: MathUnary): MathUnaryModel = node.model
 
   override def load(node: Node, model: MathUnaryModel)
-                   (implicit context: BundleContext[MleapContext]): MathUnary = {
+                   (implicit context: BundleContext[SparkBundleContext]): MathUnary = {
     new MathUnary(uid = node.name,
       model = model).setInputCol(node.shape.standardInput.name).
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: MathUnary)(implicit context: BundleContext[MleapContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: MathUnary)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathUnaryOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathUnaryOp.scala
@@ -40,5 +40,7 @@ class MathUnaryOp extends OpNode[MleapContext, MathUnary, MathUnaryModel] {
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: MathUnary): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: MathUnary)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MultinomialLabelerOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MultinomialLabelerOp.scala
@@ -44,7 +44,9 @@ class MultinomialLabelerOp extends OpNode[SparkBundleContext, MultinomialLabeler
       setLabelsCol(node.shape.output("labels").name)
   }
 
-  override def shape(node: MultinomialLabeler): Shape = Shape().withInput(node.getFeaturesCol, "features").
-    withOutput(node.getProbabilitiesCol, "probabilities").
-    withOutput(node.getLabelsCol, "labels")
+  override def shape(node: MultinomialLabeler)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withInput(node.getFeaturesCol, "features").
+      withOutput(node.getProbabilitiesCol, "probabilities").
+      withOutput(node.getLabelsCol, "labels")
+  }
 }

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MultinomialLabelerOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MultinomialLabelerOp.scala
@@ -6,6 +6,7 @@ import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.mleap.core.feature.{MultinomialLabelerModel, ReverseStringIndexerModel}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.mleap.feature.MultinomialLabeler
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 1/18/17.
@@ -45,8 +46,9 @@ class MultinomialLabelerOp extends OpNode[SparkBundleContext, MultinomialLabeler
   }
 
   override def shape(node: MultinomialLabeler)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withInput(node.getFeaturesCol, "features").
-      withOutput(node.getProbabilitiesCol, "probabilities").
-      withOutput(node.getLabelsCol, "labels")
+    val dataset = context.context.dataset
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset)).
+      withOutput(node.getProbabilitiesCol, "probabilities", fieldType(node.getProbabilitiesCol, dataset)).
+      withOutput(node.getLabelsCol, "labels", fieldType(node.getLabelsCol, dataset))
   }
 }

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/OneHotEncoderOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/OneHotEncoderOp.scala
@@ -43,5 +43,7 @@ class OneHotEncoderOp extends OpNode[SparkBundleContext, OneHotEncoderModel, One
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: OneHotEncoderModel): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: OneHotEncoderModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/OneHotEncoderOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/OneHotEncoderOp.scala
@@ -5,6 +5,7 @@ import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.mleap.feature.OneHotEncoderModel
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 import scala.util.{Failure, Try}
 
@@ -44,6 +45,8 @@ class OneHotEncoderOp extends OpNode[SparkBundleContext, OneHotEncoderModel, One
   }
 
   override def shape(node: OneHotEncoderModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/StringMapOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/StringMapOp.scala
@@ -4,9 +4,9 @@ import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.mleap.core.feature.StringMapModel
-import ml.combust.mleap.runtime.MleapContext
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.mleap.feature.StringMap
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 2/5/17.
@@ -59,6 +59,8 @@ class StringMapOp extends OpNode[SparkBundleContext, StringMap, StringMapModel] 
   }
 
   override def shape(node: StringMap)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/StringMapOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/StringMapOp.scala
@@ -58,5 +58,7 @@ class StringMapOp extends OpNode[SparkBundleContext, StringMap, StringMapModel] 
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: StringMap): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: StringMap)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/WordLengthFilterOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/WordLengthFilterOp.scala
@@ -6,6 +6,7 @@ import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.mleap.core.feature.WordLengthFilterModel
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.mleap.feature.WordFilter
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by mageswarand on 14/2/17.
@@ -32,7 +33,9 @@ class WordLengthFilterOp extends OpNode[SparkBundleContext, WordFilter, WordLeng
   override def model(node: WordFilter): WordLengthFilterModel = node.model
 
   override def shape(node: WordFilter)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 
   override def load(node: Node, model: WordLengthFilterModel)(implicit context: BundleContext[SparkBundleContext]): WordFilter = {

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/WordLengthFilterOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/WordLengthFilterOp.scala
@@ -31,7 +31,9 @@ class WordLengthFilterOp extends OpNode[SparkBundleContext, WordFilter, WordLeng
 
   override def model(node: WordFilter): WordLengthFilterModel = node.model
 
-  override def shape(node: WordFilter): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: WordFilter)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 
   override def load(node: Node, model: WordLengthFilterModel)(implicit context: BundleContext[SparkBundleContext]): WordFilter = {
     new WordFilter(uid = node.name, model = model).

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/PipelineOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/PipelineOp.scala
@@ -41,7 +41,7 @@ class PipelineOp extends OpNode[SparkBundleContext, PipelineModel, PipelineModel
     new PipelineModel(uid = node.name, stages = model.stages)
   }
 
-  override def shape(node: PipelineModel): Shape = Shape()
+  override def shape(node: PipelineModel)(implicit context: BundleContext[SparkBundleContext]): Shape = Shape()
 
   override def children(node: PipelineModel): Option[Array[Any]] = Some(node.stages.toArray)
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/DecisionTreeClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/DecisionTreeClassifierOp.scala
@@ -8,6 +8,7 @@ import ml.combust.bundle.tree.decision.TreeSerializer
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.bundle.tree.decision.SparkNodeWrapper
 import org.apache.spark.ml.classification.DecisionTreeClassificationModel
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 8/22/16.
@@ -56,12 +57,15 @@ class DecisionTreeClassifierOp extends OpNode[SparkBundleContext, DecisionTreeCl
   }
 
   override def shape(node: DecisionTreeClassificationModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    val dataset = context.context.dataset
     val rawPrediction = if(node.isDefined(node.rawPredictionCol)) Some(node.getRawPredictionCol) else None
+    val rawPredictionType = if(node.isDefined(node.rawPredictionCol)) fieldType(node.getRawPredictionCol, dataset) else None
     val probability = if(node.isDefined(node.probabilityCol)) Some(node.getProbabilityCol) else None
+    val probabilityType = if(node.isDefined(node.probabilityCol)) fieldType(node.getProbabilityCol, dataset) else None
 
-    Shape().withInput(node.getFeaturesCol, "features").
-      withOutput(node.getPredictionCol, "prediction").
-      withOutput(rawPrediction, "raw_prediction").
-      withOutput(probability, "probability")
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset)).
+      withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset)).
+      withOutput(rawPrediction, "raw_prediction", rawPredictionType).
+      withOutput(probability, "probability", probabilityType)
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/DecisionTreeClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/DecisionTreeClassifierOp.scala
@@ -55,7 +55,7 @@ class DecisionTreeClassifierOp extends OpNode[SparkBundleContext, DecisionTreeCl
     node.shape.getOutput("raw_prediction").map(rp => dt.setRawPredictionCol(rp.name)).getOrElse(dt)
   }
 
-  override def shape(node: DecisionTreeClassificationModel): Shape = {
+  override def shape(node: DecisionTreeClassificationModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
     val rawPrediction = if(node.isDefined(node.rawPredictionCol)) Some(node.getRawPredictionCol) else None
     val probability = if(node.isDefined(node.probabilityCol)) Some(node.getProbabilityCol) else None
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/GBTClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/GBTClassifierOp.scala
@@ -69,6 +69,7 @@ class GBTClassifierOp extends OpNode[SparkBundleContext, GBTClassificationModel,
       setPredictionCol(node.shape.output("prediction").name)
   }
 
-  override def shape(node: GBTClassificationModel): Shape = Shape().withInput(node.getFeaturesCol, "features").
-    withOutput(node.getPredictionCol, "prediction")
+  override def shape(node: GBTClassificationModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withInput(node.getFeaturesCol, "features").withOutput(node.getPredictionCol, "prediction")
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/GBTClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/GBTClassifierOp.scala
@@ -7,6 +7,7 @@ import ml.combust.bundle.serializer.ModelSerializer
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.classification.GBTClassificationModel
 import org.apache.spark.ml.regression.DecisionTreeRegressionModel
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 9/24/16.
@@ -70,6 +71,8 @@ class GBTClassifierOp extends OpNode[SparkBundleContext, GBTClassificationModel,
   }
 
   override def shape(node: GBTClassificationModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withInput(node.getFeaturesCol, "features").withOutput(node.getPredictionCol, "prediction")
+    val dataset = context.context.dataset
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset))
+      .withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOpV20.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOpV20.scala
@@ -62,7 +62,7 @@ class LogisticRegressionOpV20 extends OpNode[SparkBundleContext, LogisticRegress
     node.shape.getOutput("raw_prediction").map(rp => lr.setRawPredictionCol(rp.name)).getOrElse(lr)
   }
 
-  override def shape(node: LogisticRegressionModel): Shape = {
+  override def shape(node: LogisticRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
     val rawPrediction = if(node.isDefined(node.rawPredictionCol)) Some(node.getRawPredictionCol) else None
     val probability = if(node.isDefined(node.probabilityCol)) Some(node.getProbabilityCol) else None
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOpV20.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOpV20.scala
@@ -8,6 +8,7 @@ import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.classification.LogisticRegressionModel
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.bundle.util.ParamUtil
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 8/21/16.
@@ -63,12 +64,15 @@ class LogisticRegressionOpV20 extends OpNode[SparkBundleContext, LogisticRegress
   }
 
   override def shape(node: LogisticRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    val dataset = context.context.dataset
     val rawPrediction = if(node.isDefined(node.rawPredictionCol)) Some(node.getRawPredictionCol) else None
+    val rawPredictionType = if(node.isDefined(node.rawPredictionCol)) fieldType(node.getRawPredictionCol, dataset) else None
     val probability = if(node.isDefined(node.probabilityCol)) Some(node.getProbabilityCol) else None
+    val probabilityType = if(node.isDefined(node.probabilityCol)) fieldType(node.getProbabilityCol, dataset) else None
 
-    Shape().withInput(node.getFeaturesCol, "features").
-      withOutput(node.getPredictionCol, "prediction").
-      withOutput(rawPrediction, "raw_prediction").
-      withOutput(probability, "probability")
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset)).
+      withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset)).
+      withOutput(rawPrediction, "raw_prediction", rawPredictionType).
+      withOutput(probability, "probability", probabilityType)
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOpV21.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOpV21.scala
@@ -77,7 +77,7 @@ class LogisticRegressionOpV21 extends OpNode[SparkBundleContext, LogisticRegress
     node.shape.getOutput("raw_prediction").map(rp => lr.setRawPredictionCol(rp.name)).getOrElse(lr)
   }
 
-  override def shape(node: LogisticRegressionModel): Shape = {
+  override def shape(node: LogisticRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
     val rawPrediction = if(node.isDefined(node.rawPredictionCol)) Some(node.getRawPredictionCol) else None
     val probability = if(node.isDefined(node.probabilityCol)) Some(node.getProbabilityCol) else None
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOpV21.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOpV21.scala
@@ -8,6 +8,7 @@ import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.classification.LogisticRegressionModel
 import org.apache.spark.ml.linalg.{Matrices, Vectors}
 import org.apache.spark.ml.bundle.util.ParamUtil
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 8/21/16.
@@ -78,12 +79,15 @@ class LogisticRegressionOpV21 extends OpNode[SparkBundleContext, LogisticRegress
   }
 
   override def shape(node: LogisticRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    val dataset = context.context.dataset
     val rawPrediction = if(node.isDefined(node.rawPredictionCol)) Some(node.getRawPredictionCol) else None
+    val rawPredictionType = if(node.isDefined(node.rawPredictionCol)) fieldType(node.getRawPredictionCol, dataset) else None
     val probability = if(node.isDefined(node.probabilityCol)) Some(node.getProbabilityCol) else None
+    val probabilityType = if(node.isDefined(node.probabilityCol)) fieldType(node.getProbabilityCol, dataset) else None
 
-    Shape().withInput(node.getFeaturesCol, "features").
-      withOutput(node.getPredictionCol, "prediction").
-      withOutput(rawPrediction, "raw_prediction").
-      withOutput(probability, "probability")
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset)).
+      withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset)).
+      withOutput(rawPrediction, "raw_prediction", rawPredictionType).
+      withOutput(probability, "probability", probabilityType)
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/MultiLayerPerceptronClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/MultiLayerPerceptronClassifierOp.scala
@@ -44,7 +44,8 @@ class MultiLayerPerceptronClassifierOp extends OpNode[MleapContext, MultilayerPe
       setPredictionCol(node.shape.output("prediction").name)
   }
 
-  override def shape(node: MultilayerPerceptronClassificationModel): Shape = Shape().withInput(node.getFeaturesCol, "features").
-    withOutput(node.getPredictionCol, "prediction")
+  override def shape(node: MultilayerPerceptronClassificationModel)(implicit context: BundleContext[MleapContext]): Shape = {
+    Shape().withInput(node.getFeaturesCol, "features").withOutput(node.getPredictionCol, "prediction")
+  }
 }
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/NaiveBayesClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/NaiveBayesClassifierOp.scala
@@ -7,6 +7,7 @@ import ml.combust.mleap.tensor.DenseTensor
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.classification.NaiveBayesModel
 import org.apache.spark.ml.linalg.{Matrices, Vectors}
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by fshabbir on 12/25/16.
@@ -54,12 +55,15 @@ class NaiveBayesClassifierOp extends OpNode[SparkBundleContext, NaiveBayesModel,
   }
 
   override def shape(node: NaiveBayesModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    val dataset = context.context.dataset
     val rawPrediction = if(node.isDefined(node.rawPredictionCol)) Some(node.getRawPredictionCol) else None
+    val rawPredictionType = if(node.isDefined(node.rawPredictionCol)) fieldType(node.getRawPredictionCol, dataset) else None
     val probability = if(node.isDefined(node.probabilityCol)) Some(node.getProbabilityCol) else None
+    val probabilityType = if(node.isDefined(node.probabilityCol)) fieldType(node.getProbabilityCol, dataset) else None
 
-    Shape().withInput(node.getFeaturesCol, "features").
-      withOutput(node.getPredictionCol, "prediction").
-      withOutput(rawPrediction, "raw_prediction").
-      withOutput(probability, "probability")
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset)).
+      withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset)).
+      withOutput(rawPrediction, "raw_prediction", rawPredictionType).
+      withOutput(probability, "probability", probabilityType)
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/NaiveBayesClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/NaiveBayesClassifierOp.scala
@@ -53,7 +53,7 @@ class NaiveBayesClassifierOp extends OpNode[SparkBundleContext, NaiveBayesModel,
     node.shape.getOutput("raw_prediction").map(rp => nb.setRawPredictionCol(rp.name)).getOrElse(nb)
   }
 
-  override def shape(node: NaiveBayesModel): Shape = {
+  override def shape(node: NaiveBayesModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
     val rawPrediction = if(node.isDefined(node.rawPredictionCol)) Some(node.getRawPredictionCol) else None
     val probability = if(node.isDefined(node.probabilityCol)) Some(node.getProbabilityCol) else None
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/OneVsRestOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/OneVsRestOp.scala
@@ -66,6 +66,7 @@ class OneVsRestOp extends OpNode[SparkBundleContext, OneVsRestModel, OneVsRestMo
     m
   }
 
-  override def shape(node: OneVsRestModel): Shape = Shape().withInput(node.getFeaturesCol, "features").
-    withOutput(node.getPredictionCol, "prediction")
+  override def shape(node: OneVsRestModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withInput(node.getFeaturesCol, "features").withOutput(node.getPredictionCol, "prediction")
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/OneVsRestOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/OneVsRestOp.scala
@@ -7,6 +7,7 @@ import ml.combust.bundle.dsl._
 import org.apache.spark.ml.attribute.NominalAttribute
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.classification.{ClassificationModel, OneVsRestModel}
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 8/21/16.
@@ -67,6 +68,8 @@ class OneVsRestOp extends OpNode[SparkBundleContext, OneVsRestModel, OneVsRestMo
   }
 
   override def shape(node: OneVsRestModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withInput(node.getFeaturesCol, "features").withOutput(node.getPredictionCol, "prediction")
+    val dataset = context.context.dataset
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset))
+      .withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/RandomForestClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/RandomForestClassifierOp.scala
@@ -7,6 +7,7 @@ import ml.combust.bundle.dsl._
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.bundle.tree.decision.SparkNodeWrapper
 import org.apache.spark.ml.classification.{DecisionTreeClassificationModel, RandomForestClassificationModel}
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 8/22/16.
@@ -74,12 +75,15 @@ class RandomForestClassifierOp extends OpNode[SparkBundleContext, RandomForestCl
   }
 
   override def shape(node: RandomForestClassificationModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    val dataset = context.context.dataset
     val rawPrediction = if(node.isDefined(node.rawPredictionCol)) Some(node.getRawPredictionCol) else None
+    val rawPredictionType = if(node.isDefined(node.rawPredictionCol)) fieldType(node.getRawPredictionCol, dataset) else None
     val probability = if(node.isDefined(node.probabilityCol)) Some(node.getProbabilityCol) else None
+    val probabilityType = if(node.isDefined(node.probabilityCol)) fieldType(node.getProbabilityCol, dataset) else None
 
-    Shape().withInput(node.getFeaturesCol, "features").
-      withOutput(node.getPredictionCol, "prediction").
-      withOutput(rawPrediction, "raw_prediction").
-      withOutput(probability, "probability")
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset)).
+      withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset)).
+      withOutput(rawPrediction, "raw_prediction", rawPredictionType).
+      withOutput(probability, "probability", probabilityType)
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/RandomForestClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/RandomForestClassifierOp.scala
@@ -73,7 +73,7 @@ class RandomForestClassifierOp extends OpNode[SparkBundleContext, RandomForestCl
     node.shape.getOutput("raw_prediction").map(rp => rf.setRawPredictionCol(rp.name)).getOrElse(rf)
   }
 
-  override def shape(node: RandomForestClassificationModel): Shape = {
+  override def shape(node: RandomForestClassificationModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
     val rawPrediction = if(node.isDefined(node.rawPredictionCol)) Some(node.getRawPredictionCol) else None
     val probability = if(node.isDefined(node.probabilityCol)) Some(node.getProbabilityCol) else None
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/BisectingKMeansOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/BisectingKMeansOp.scala
@@ -7,6 +7,7 @@ import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.clustering.BisectingKMeansModel
 import org.apache.spark.mllib.clustering
 import org.apache.spark.mllib.clustering.bundle.tree.clustering.{ClusteringTreeNodeUtil, SparkNodeWrapper}
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 import scala.util.Try
 
@@ -46,7 +47,9 @@ class BisectingKMeansOp extends OpNode[SparkBundleContext, BisectingKMeansModel,
   }
 
   override def shape(node: BisectingKMeansModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withInput(node.getFeaturesCol, "features").withOutput(node.getPredictionCol, "prediction")
+    val dataset = context.context.dataset
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset))
+      .withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset))
   }
 
   private def getParentModel(obj: BisectingKMeansModel): clustering.BisectingKMeansModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/BisectingKMeansOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/BisectingKMeansOp.scala
@@ -45,8 +45,9 @@ class BisectingKMeansOp extends OpNode[SparkBundleContext, BisectingKMeansModel,
     new BisectingKMeansModel(node.name, getParentModel(model))
   }
 
-  override def shape(node: BisectingKMeansModel): Shape = Shape().withInput(node.getFeaturesCol, "features").
-    withOutput(node.getPredictionCol, "prediction")
+  override def shape(node: BisectingKMeansModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withInput(node.getFeaturesCol, "features").withOutput(node.getPredictionCol, "prediction")
+  }
 
   private def getParentModel(obj: BisectingKMeansModel): clustering.BisectingKMeansModel = {
     // UGLY: have to use reflection to get this private field :(

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/GaussianMixtureOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/GaussianMixtureOp.scala
@@ -64,7 +64,7 @@ class GaussianMixtureOp extends OpNode[MleapContext, GaussianMixtureModel, Gauss
     gmm
   }
 
-  override def shape(node: GaussianMixtureModel): Shape = {
+  override def shape(node: GaussianMixtureModel)(implicit context: BundleContext[MleapContext]): Shape = {
     val probability = if(node.isSet(node.probabilityCol)) Some(node.getProbabilityCol) else None
 
     Shape().withInput(node.getFeaturesCol, "features").

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/GaussianMixtureOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/GaussianMixtureOp.scala
@@ -3,23 +3,24 @@ package org.apache.spark.ml.bundle.ops.clustering
 import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
-import ml.combust.mleap.runtime.MleapContext
 import ml.combust.mleap.tensor.{DenseTensor, Tensor}
+import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.clustering.GaussianMixtureModel
 import org.apache.spark.ml.linalg.{Matrices, Vectors}
 import org.apache.spark.ml.stat.distribution.MultivariateGaussian
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 9/30/16.
   */
-class GaussianMixtureOp extends OpNode[MleapContext, GaussianMixtureModel, GaussianMixtureModel] {
-  override val Model: OpModel[MleapContext, GaussianMixtureModel] = new OpModel[MleapContext, GaussianMixtureModel] {
+class GaussianMixtureOp extends OpNode[SparkBundleContext, GaussianMixtureModel, GaussianMixtureModel] {
+  override val Model: OpModel[SparkBundleContext, GaussianMixtureModel] = new OpModel[SparkBundleContext, GaussianMixtureModel] {
     override val klazz: Class[GaussianMixtureModel] = classOf[GaussianMixtureModel]
 
     override def opName: String = Bundle.BuiltinOps.clustering.gaussian_mixture
 
     override def store(model: Model, obj: GaussianMixtureModel)
-                      (implicit context: BundleContext[MleapContext]): Model = {
+                      (implicit context: BundleContext[SparkBundleContext]): Model = {
       val (rows, cols) = obj.gaussians.headOption.
         map(g => (g.cov.numRows, g.cov.numCols)).
         getOrElse((-1, -1))
@@ -31,7 +32,7 @@ class GaussianMixtureOp extends OpNode[MleapContext, GaussianMixtureModel, Gauss
     }
 
     override def load(model: Model)
-                     (implicit context: BundleContext[MleapContext]): GaussianMixtureModel = {
+                     (implicit context: BundleContext[SparkBundleContext]): GaussianMixtureModel = {
       val means = model.value("means").getTensorList[Double].map(values => Vectors.dense(values.toArray))
       val covs = model.value("covs").getTensorList[Double].map(values => Matrices.dense(values.dimensions.head, values.dimensions(1), values.toArray))
       val gaussians = means.zip(covs).map {
@@ -52,7 +53,7 @@ class GaussianMixtureOp extends OpNode[MleapContext, GaussianMixtureModel, Gauss
   override def model(node: GaussianMixtureModel): GaussianMixtureModel = node
 
   override def load(node: Node, model: GaussianMixtureModel)
-                   (implicit context: BundleContext[MleapContext]): GaussianMixtureModel = {
+                   (implicit context: BundleContext[SparkBundleContext]): GaussianMixtureModel = {
     val gmm = new GaussianMixtureModel(uid = node.name,
       gaussians = model.gaussians,
       weights = model.weights)
@@ -64,11 +65,13 @@ class GaussianMixtureOp extends OpNode[MleapContext, GaussianMixtureModel, Gauss
     gmm
   }
 
-  override def shape(node: GaussianMixtureModel)(implicit context: BundleContext[MleapContext]): Shape = {
+  override def shape(node: GaussianMixtureModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    val dataset = context.context.dataset
     val probability = if(node.isDefined(node.probabilityCol)) Some(node.getProbabilityCol) else None
+    val probabilityType = if(node.isDefined(node.probabilityCol)) fieldType(node.getProbabilityCol, dataset) else None
 
-    Shape().withInput(node.getFeaturesCol, "features").
-      withOutput(node.getPredictionCol, "prediction").
-      withOutput(probability, "probability")
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset)).
+      withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset)).
+      withOutput(probability, "probability", probabilityType)
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/KMeansOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/KMeansOp.scala
@@ -54,6 +54,7 @@ class KMeansOp extends OpNode[SparkBundleContext, KMeansModel, KMeansModel] {
       setPredictionCol(node.shape.output("prediction").name)
   }
 
-  override def shape(node: KMeansModel): Shape = Shape().withInput(node.getFeaturesCol, "features").
-    withOutput(node.getPredictionCol, "prediction")
+  override def shape(node: KMeansModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withInput(node.getFeaturesCol, "features").withOutput(node.getPredictionCol, "prediction")
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/KMeansOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/KMeansOp.scala
@@ -9,6 +9,7 @@ import org.apache.spark.ml.clustering.KMeansModel
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector}
 import org.apache.spark.mllib.clustering
 import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 9/30/16.
@@ -55,6 +56,8 @@ class KMeansOp extends OpNode[SparkBundleContext, KMeansModel, KMeansModel] {
   }
 
   override def shape(node: KMeansModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withInput(node.getFeaturesCol, "features").withOutput(node.getPredictionCol, "prediction")
+    val dataset = context.context.dataset
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset))
+      .withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/LDAModelOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/LDAModelOp.scala
@@ -10,6 +10,7 @@ import org.apache.spark.mllib.clustering.{LocalLDAModel => oldLocalLDAModel}
 import ml.combust.bundle.dsl._
 import org.apache.spark.mllib.linalg.DenseMatrix
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 
 /**
@@ -55,9 +56,10 @@ class LDAModelOp extends OpNode[SparkBundleContext, LocalLDAModel, LocalLDAModel
   override def model(node: LocalLDAModel): LocalLDAModel = node
 
   override def shape(node: LocalLDAModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    val dataset = context.context.dataset
     Shape().
-      withInput("features", "features").
-      withOutput("topicDistribution", "topicDistribution")
+      withInput("features", "features", fieldType("features", dataset)).
+      withOutput("topicDistribution", "topicDistribution", fieldType("topicDistribution", dataset))
   }
 
   override def load(node: Node, model: LocalLDAModel)(implicit context: BundleContext[SparkBundleContext]): LocalLDAModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/LDAModelOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/LDAModelOp.scala
@@ -54,7 +54,7 @@ class LDAModelOp extends OpNode[SparkBundleContext, LocalLDAModel, LocalLDAModel
 
   override def model(node: LocalLDAModel): LocalLDAModel = node
 
-  override def shape(node: LocalLDAModel): Shape = {
+  override def shape(node: LocalLDAModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
     Shape().
       withInput("features", "features").
       withOutput("topicDistribution", "topicDistribution")

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BinarizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BinarizerOp.scala
@@ -5,6 +5,7 @@ import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.Binarizer
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by fshabbir on 12/1/16.
@@ -42,7 +43,8 @@ class BinarizerOp extends OpNode[SparkBundleContext, Binarizer, Binarizer] {
   }
 
   override def shape(node: Binarizer)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
-
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BinarizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BinarizerOp.scala
@@ -41,6 +41,8 @@ class BinarizerOp extends OpNode[SparkBundleContext, Binarizer, Binarizer] {
       setThreshold(model.getThreshold)
   }
 
-  override def shape(node: Binarizer): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: Binarizer)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketedRandomProjectionLSHOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketedRandomProjectionLSHOp.scala
@@ -7,6 +7,7 @@ import ml.combust.mleap.tensor.Tensor
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.BucketedRandomProjectionLSHModel
 import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 12/28/16.
@@ -52,7 +53,9 @@ class BucketedRandomProjectionLSHOp extends OpNode[SparkBundleContext, BucketedR
   }
 
   override def shape(node: BucketedRandomProjectionLSHModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketedRandomProjectionLSHOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketedRandomProjectionLSHOp.scala
@@ -51,6 +51,8 @@ class BucketedRandomProjectionLSHOp extends OpNode[SparkBundleContext, BucketedR
     m
   }
 
-  override def shape(node: BucketedRandomProjectionLSHModel): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: BucketedRandomProjectionLSHModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketizerOp.scala
@@ -6,6 +6,7 @@ import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.mleap.runtime.transformer.feature.BucketizerUtil._
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.Bucketizer
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by mikhail on 9/22/16.
@@ -42,6 +43,8 @@ class BucketizerOp extends OpNode[SparkBundleContext, Bucketizer, Bucketizer] {
   }
 
   override def shape(node: Bucketizer)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketizerOp.scala
@@ -41,5 +41,7 @@ class BucketizerOp extends OpNode[SparkBundleContext, Bucketizer, Bucketizer] {
       setSplits(model.getSplits)
   }
 
-  override def shape(node: Bucketizer): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: Bucketizer)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ChiSqSelectorOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ChiSqSelectorOp.scala
@@ -42,6 +42,7 @@ class ChiSqSelectorOp extends OpNode[SparkBundleContext, ChiSqSelectorModel, Chi
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: ChiSqSelectorModel): Shape = Shape().withInput(node.getFeaturesCol, "features").
-    withStandardOutput(node.getOutputCol)
+  override def shape(node: ChiSqSelectorModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withInput(node.getFeaturesCol, "features").withStandardOutput(node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ChiSqSelectorOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ChiSqSelectorOp.scala
@@ -6,6 +6,7 @@ import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.ChiSqSelectorModel
 import org.apache.spark.mllib.feature
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 12/27/16.
@@ -43,6 +44,8 @@ class ChiSqSelectorOp extends OpNode[SparkBundleContext, ChiSqSelectorModel, Chi
   }
 
   override def shape(node: ChiSqSelectorModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withInput(node.getFeaturesCol, "features").withStandardOutput(node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset))
+      .withStandardOutput(node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/CountVectorizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/CountVectorizerOp.scala
@@ -5,6 +5,7 @@ import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.CountVectorizerModel
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 12/28/16.
@@ -48,6 +49,8 @@ class CountVectorizerOp extends OpNode[SparkBundleContext, CountVectorizerModel,
   }
 
   override def shape(node: CountVectorizerModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/CountVectorizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/CountVectorizerOp.scala
@@ -47,5 +47,7 @@ class CountVectorizerOp extends OpNode[SparkBundleContext, CountVectorizerModel,
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: CountVectorizerModel): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: CountVectorizerModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/DCTOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/DCTOp.scala
@@ -39,5 +39,7 @@ class DCTOp extends OpNode[SparkBundleContext, DCT, DCT] {
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: DCT): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: DCT)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/DCTOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/DCTOp.scala
@@ -5,6 +5,7 @@ import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.DCT
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 12/28/16.
@@ -40,6 +41,8 @@ class DCTOp extends OpNode[SparkBundleContext, DCT, DCT] {
   }
 
   override def shape(node: DCT)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ElementwiseProductOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ElementwiseProductOp.scala
@@ -42,5 +42,7 @@ class ElementwiseProductOp extends OpNode[SparkBundleContext, ElementwiseProduct
       setScalingVec(model.getScalingVec)
   }
 
-  override def shape(node: ElementwiseProduct): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: ElementwiseProduct)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ElementwiseProductOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ElementwiseProductOp.scala
@@ -6,6 +6,7 @@ import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.ElementwiseProduct
 import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by mikhail on 9/23/16.
@@ -43,6 +44,8 @@ class ElementwiseProductOp extends OpNode[SparkBundleContext, ElementwiseProduct
   }
 
   override def shape(node: ElementwiseProduct)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/HashingTermFrequencyOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/HashingTermFrequencyOp.scala
@@ -5,6 +5,7 @@ import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.bundle.dsl._
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.HashingTF
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 8/21/16.
@@ -43,6 +44,8 @@ class HashingTermFrequencyOp extends OpNode[SparkBundleContext, HashingTF, Hashi
   }
 
   override def shape(node: HashingTF)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/HashingTermFrequencyOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/HashingTermFrequencyOp.scala
@@ -42,5 +42,7 @@ class HashingTermFrequencyOp extends OpNode[SparkBundleContext, HashingTF, Hashi
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: HashingTF): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: HashingTF)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/IDFOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/IDFOp.scala
@@ -43,5 +43,7 @@ class IDFOp extends OpNode[SparkBundleContext, IDFModel, IDFModel] {
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: IDFModel): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: IDFModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/IDFOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/IDFOp.scala
@@ -7,6 +7,7 @@ import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.IDFModel
 import org.apache.spark.mllib.feature
 import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 12/28/16.
@@ -44,6 +45,8 @@ class IDFOp extends OpNode[SparkBundleContext, IDFModel, IDFModel] {
   }
 
   override def shape(node: IDFModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MaxAbsScalerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MaxAbsScalerOp.scala
@@ -41,5 +41,7 @@ class MaxAbsScalerOp extends OpNode[SparkBundleContext, MaxAbsScalerModel, MaxAb
     new MaxAbsScalerModel(uid = node.name, maxAbs = model.maxAbs)
   }
 
-  override def shape(node: MaxAbsScalerModel): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: MaxAbsScalerModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MinHashLSHOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MinHashLSHOp.scala
@@ -47,5 +47,7 @@ class MinHashLSHOp extends OpNode[SparkBundleContext, MinHashLSHModel, MinHashLS
     m
   }
 
-  override def shape(node: MinHashLSHModel): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: MinHashLSHModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MinHashLSHOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MinHashLSHOp.scala
@@ -5,6 +5,7 @@ import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.MinHashLSHModel
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 12/28/16.
@@ -48,6 +49,8 @@ class MinHashLSHOp extends OpNode[SparkBundleContext, MinHashLSHModel, MinHashLS
   }
 
   override def shape(node: MinHashLSHModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MinMaxScalerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MinMaxScalerOp.scala
@@ -42,5 +42,7 @@ class MinMaxScalerOp extends OpNode[SparkBundleContext, MinMaxScalerModel, MinMa
     new MinMaxScalerModel(uid = node.name, originalMin = model.originalMin, originalMax = model.originalMax)
   }
 
-  override def shape(node: MinMaxScalerModel): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: MinMaxScalerModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MinMaxScalerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MinMaxScalerOp.scala
@@ -6,6 +6,7 @@ import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.MinMaxScalerModel
 import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by mikhail on 9/19/16.
@@ -43,6 +44,8 @@ class MinMaxScalerOp extends OpNode[SparkBundleContext, MinMaxScalerModel, MinMa
   }
 
   override def shape(node: MinMaxScalerModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/NGramOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/NGramOp.scala
@@ -5,6 +5,7 @@ import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.NGram
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by mikhail on 10/16/16.
@@ -42,6 +43,8 @@ class NGramOp extends OpNode[SparkBundleContext, NGram, NGram] {
   }
 
   override def shape(node: NGram)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/NGramOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/NGramOp.scala
@@ -41,5 +41,7 @@ class NGramOp extends OpNode[SparkBundleContext, NGram, NGram] {
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: NGram): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: NGram)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/NormalizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/NormalizerOp.scala
@@ -5,6 +5,7 @@ import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.Normalizer
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 9/24/16.
@@ -41,6 +42,8 @@ class NormalizerOp extends OpNode[SparkBundleContext, Normalizer, Normalizer] {
   }
 
   override def shape(node: Normalizer)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/NormalizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/NormalizerOp.scala
@@ -40,5 +40,7 @@ class NormalizerOp extends OpNode[SparkBundleContext, Normalizer, Normalizer] {
       setP(model.getP)
   }
 
-  override def shape(node: Normalizer): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: Normalizer)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/OneHotEncoderOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/OneHotEncoderOp.scala
@@ -75,5 +75,7 @@ class OneHotEncoderOp extends OpNode[SparkBundleContext, OneHotEncoder, OneHotEn
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: OneHotEncoder): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: OneHotEncoder)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/OneHotEncoderOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/OneHotEncoderOp.scala
@@ -6,6 +6,7 @@ import ml.combust.bundle.dsl._
 import org.apache.spark.ml.attribute.{Attribute, BinaryAttribute, NominalAttribute, NumericAttribute}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.OneHotEncoder
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 import org.apache.spark.sql.types.StructField
 
 import scala.util.{Failure, Try}
@@ -76,6 +77,8 @@ class OneHotEncoderOp extends OpNode[SparkBundleContext, OneHotEncoder, OneHotEn
   }
 
   override def shape(node: OneHotEncoder)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/PcaOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/PcaOp.scala
@@ -7,6 +7,7 @@ import ml.combust.mleap.tensor.DenseTensor
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.PCAModel
 import org.apache.spark.ml.linalg.{DenseMatrix, DenseVector}
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 10/12/16.
@@ -48,6 +49,8 @@ class PcaOp extends OpNode[SparkBundleContext, PCAModel, PCAModel] {
   }
 
   override def shape(node: PCAModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/PcaOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/PcaOp.scala
@@ -47,5 +47,7 @@ class PcaOp extends OpNode[SparkBundleContext, PCAModel, PCAModel] {
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: PCAModel): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: PCAModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/PolynomialExpansionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/PolynomialExpansionOp.scala
@@ -42,5 +42,7 @@ class PolynomialExpansionOp extends OpNode[SparkBundleContext, PolynomialExpansi
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: PolynomialExpansion): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: PolynomialExpansion)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/PolynomialExpansionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/PolynomialExpansionOp.scala
@@ -5,6 +5,7 @@ import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.PolynomialExpansion
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by mikhail on 10/16/16.
@@ -43,6 +44,8 @@ class PolynomialExpansionOp extends OpNode[SparkBundleContext, PolynomialExpansi
   }
 
   override def shape(node: PolynomialExpansion)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/RegexTokenizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/RegexTokenizerOp.scala
@@ -5,6 +5,7 @@ import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.RegexTokenizer
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 class RegexTokenizerOp extends OpNode[SparkBundleContext, RegexTokenizer, RegexTokenizer] {
   override val Model: OpModel[SparkBundleContext, RegexTokenizer] = new OpModel[SparkBundleContext, RegexTokenizer] {
@@ -57,6 +58,8 @@ class RegexTokenizerOp extends OpNode[SparkBundleContext, RegexTokenizer, RegexT
   }
 
   override def shape(node: RegexTokenizer)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/RegexTokenizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/RegexTokenizerOp.scala
@@ -56,5 +56,7 @@ class RegexTokenizerOp extends OpNode[SparkBundleContext, RegexTokenizer, RegexT
       .setToLowercase(model.getToLowercase)
   }
 
-  override def shape(node: RegexTokenizer): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: RegexTokenizer)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ReverseStringIndexerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ReverseStringIndexerOp.scala
@@ -6,6 +6,7 @@ import ml.combust.bundle.dsl._
 import org.apache.spark.ml.attribute.{Attribute, BinaryAttribute, NominalAttribute, NumericAttribute}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.IndexToString
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 import org.apache.spark.sql.types.StructField
 
 import scala.util.{Failure, Try}
@@ -69,6 +70,8 @@ class ReverseStringIndexerOp extends OpNode[SparkBundleContext, IndexToString, I
   }
 
   override def shape(node: IndexToString)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ReverseStringIndexerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ReverseStringIndexerOp.scala
@@ -68,5 +68,7 @@ class ReverseStringIndexerOp extends OpNode[SparkBundleContext, IndexToString, I
     new IndexToString(uid = node.name).setLabels(model.getLabels)
   }
 
-  override def shape(node: IndexToString): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: IndexToString)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StandardScalerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StandardScalerOp.scala
@@ -6,6 +6,7 @@ import ml.combust.bundle.dsl._
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.StandardScalerModel
 import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 8/21/16.
@@ -54,6 +55,8 @@ class StandardScalerOp extends OpNode[SparkBundleContext, StandardScalerModel, S
   }
 
   override def shape(node: StandardScalerModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StandardScalerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StandardScalerOp.scala
@@ -53,5 +53,7 @@ class StandardScalerOp extends OpNode[SparkBundleContext, StandardScalerModel, S
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: StandardScalerModel): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: StandardScalerModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StopWordsRemoverOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StopWordsRemoverOp.scala
@@ -44,5 +44,7 @@ class StopWordsRemoverOp extends OpNode[SparkBundleContext, StopWordsRemover, St
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: StopWordsRemover): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: StopWordsRemover)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StopWordsRemoverOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StopWordsRemoverOp.scala
@@ -5,6 +5,7 @@ import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.StopWordsRemover
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by mikhail on 10/16/16.
@@ -45,6 +46,8 @@ class StopWordsRemoverOp extends OpNode[SparkBundleContext, StopWordsRemover, St
   }
 
   override def shape(node: StopWordsRemover)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOp.scala
@@ -39,5 +39,7 @@ class StringIndexerOp extends OpNode[SparkBundleContext, StringIndexerModel, Str
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: StringIndexerModel): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: StringIndexerModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOp.scala
@@ -5,6 +5,7 @@ import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.bundle.dsl._
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.StringIndexerModel
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 8/21/16.
@@ -40,6 +41,8 @@ class StringIndexerOp extends OpNode[SparkBundleContext, StringIndexerModel, Str
   }
 
   override def shape(node: StringIndexerModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/TokenizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/TokenizerOp.scala
@@ -5,6 +5,7 @@ import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.bundle.dsl._
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.Tokenizer
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 8/21/16.
@@ -36,6 +37,8 @@ class TokenizerOp extends OpNode[SparkBundleContext, Tokenizer, Tokenizer] {
   }
 
   override def shape(node: Tokenizer)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/TokenizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/TokenizerOp.scala
@@ -35,5 +35,7 @@ class TokenizerOp extends OpNode[SparkBundleContext, Tokenizer, Tokenizer] {
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: Tokenizer): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: Tokenizer)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/VectorAssemblerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/VectorAssemblerOp.scala
@@ -35,7 +35,7 @@ class VectorAssemblerOp extends OpNode[SparkBundleContext, VectorAssembler, Vect
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: VectorAssembler): Shape = {
+  override def shape(node: VectorAssembler)(implicit context: BundleContext[SparkBundleContext]): Shape = {
     var i = 0
     node.getInputCols.foldLeft(Shape()) {
       case (shape, inputCol) =>

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/VectorAssemblerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/VectorAssemblerOp.scala
@@ -5,6 +5,7 @@ import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.bundle.dsl._
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.VectorAssembler
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 8/21/16.
@@ -37,11 +38,12 @@ class VectorAssemblerOp extends OpNode[SparkBundleContext, VectorAssembler, Vect
 
   override def shape(node: VectorAssembler)(implicit context: BundleContext[SparkBundleContext]): Shape = {
     var i = 0
+    val dataset = context.context.dataset
     node.getInputCols.foldLeft(Shape()) {
       case (shape, inputCol) =>
-        val shape2 = shape.withInput(inputCol, s"input$i")
+        val shape2 = shape.withInput(inputCol, s"input$i", fieldType(inputCol, dataset))
         i += 1
         shape2
-    }.withStandardOutput(node.getOutputCol)
+    }.withStandardOutput(node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/VectorIndexerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/VectorIndexerOp.scala
@@ -63,5 +63,7 @@ class VectorIndexerOp extends OpNode[SparkBundleContext, VectorIndexerModel, Vec
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: VectorIndexerModel): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: VectorIndexerModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/VectorIndexerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/VectorIndexerOp.scala
@@ -5,6 +5,7 @@ import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.VectorIndexerModel
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 12/28/16.
@@ -64,6 +65,8 @@ class VectorIndexerOp extends OpNode[SparkBundleContext, VectorIndexerModel, Vec
   }
 
   override def shape(node: VectorIndexerModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/VectorSlicerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/VectorSlicerOp.scala
@@ -5,6 +5,7 @@ import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.VectorSlicer
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 12/28/16.
@@ -40,6 +41,8 @@ class VectorSlicerOp extends OpNode[SparkBundleContext, VectorSlicer, VectorSlic
   }
 
   override def shape(node: VectorSlicer)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/VectorSlicerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/VectorSlicerOp.scala
@@ -39,5 +39,7 @@ class VectorSlicerOp extends OpNode[SparkBundleContext, VectorSlicer, VectorSlic
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: VectorSlicer): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: VectorSlicer)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/WordToVectorOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/WordToVectorOp.scala
@@ -50,7 +50,9 @@ class WordToVectorOp extends OpNode[SparkBundleContext, Word2VecModel, Word2VecM
       setOutputCol(node.shape.standardOutput.name)
   }
 
-  override def shape(node: Word2VecModel): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  override def shape(node: Word2VecModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+  }
 
   private def getWordVectors(obj: Word2VecModel): feature.Word2VecModel = {
     // UGLY: have to use reflection to get this private field :(

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/WordToVectorOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/WordToVectorOp.scala
@@ -6,6 +6,7 @@ import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.Word2VecModel
 import org.apache.spark.mllib.feature
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 12/28/16.
@@ -51,7 +52,9 @@ class WordToVectorOp extends OpNode[SparkBundleContext, Word2VecModel, Word2VecM
   }
 
   override def shape(node: Word2VecModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+    val dataset = context.context.dataset
+    Shape().withStandardIO(node.getInputCol, fieldType(node.getInputCol, dataset),
+      node.getOutputCol, fieldType(node.getOutputCol, dataset))
   }
 
   private def getWordVectors(obj: Word2VecModel): feature.Word2VecModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/AFTSurvivalRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/AFTSurvivalRegressionOp.scala
@@ -53,7 +53,7 @@ class AFTSurvivalRegressionOp extends OpNode[SparkBundleContext, AFTSurvivalRegr
     r
   }
 
-  override def shape(node: AFTSurvivalRegressionModel): Shape = {
+  override def shape(node: AFTSurvivalRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
     var s = Shape().withInput(node.getFeaturesCol, "features").
       withOutput(node.getPredictionCol, "prediction")
     if(node.isSet(node.quantilesCol)) { s = s.withOutput(node.getQuantilesCol, "quantiles") }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/AFTSurvivalRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/AFTSurvivalRegressionOp.scala
@@ -6,6 +6,7 @@ import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.regression.AFTSurvivalRegressionModel
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 12/28/16.
@@ -54,9 +55,12 @@ class AFTSurvivalRegressionOp extends OpNode[SparkBundleContext, AFTSurvivalRegr
   }
 
   override def shape(node: AFTSurvivalRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    var s = Shape().withInput(node.getFeaturesCol, "features").
-      withOutput(node.getPredictionCol, "prediction")
-    if(node.isSet(node.quantilesCol)) { s = s.withOutput(node.getQuantilesCol, "quantiles") }
+    val dataset = context.context.dataset
+    var s = Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset)).
+      withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset))
+    if(node.isSet(node.quantilesCol)) {
+      s = s.withOutput(node.getQuantilesCol, "quantiles", fieldType(node.getQuantilesCol, dataset))
+    }
 
     s
   }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/DecisionTreeRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/DecisionTreeRegressionOp.scala
@@ -7,6 +7,7 @@ import ml.combust.bundle.tree.decision.TreeSerializer
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.bundle.tree.decision.SparkNodeWrapper
 import org.apache.spark.ml.regression.DecisionTreeRegressionModel
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 8/22/16.
@@ -50,6 +51,8 @@ class DecisionTreeRegressionOp extends OpNode[SparkBundleContext, DecisionTreeRe
   }
 
   override def shape(node: DecisionTreeRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withInput(node.getFeaturesCol, "features").withOutput(node.getPredictionCol, "prediction")
+    val dataset = context.context.dataset
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset))
+      .withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/DecisionTreeRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/DecisionTreeRegressionOp.scala
@@ -49,6 +49,7 @@ class DecisionTreeRegressionOp extends OpNode[SparkBundleContext, DecisionTreeRe
       setPredictionCol(node.shape.output("prediction").name)
   }
 
-  override def shape(node: DecisionTreeRegressionModel): Shape = Shape().withInput(node.getFeaturesCol, "features").
-    withOutput(node.getPredictionCol, "prediction")
+  override def shape(node: DecisionTreeRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withInput(node.getFeaturesCol, "features").withOutput(node.getPredictionCol, "prediction")
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/GBTRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/GBTRegressionOp.scala
@@ -63,6 +63,7 @@ class GBTRegressionOp extends OpNode[SparkBundleContext, GBTRegressionModel, GBT
       setPredictionCol(node.shape.output("prediction").name)
   }
 
-  override def shape(node: GBTRegressionModel): Shape = Shape().withInput(node.getFeaturesCol, "features").
-    withOutput(node.getPredictionCol, "prediction")
+  override def shape(node: GBTRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withInput(node.getFeaturesCol, "features").withOutput(node.getPredictionCol, "prediction")
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/GBTRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/GBTRegressionOp.scala
@@ -6,6 +6,7 @@ import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.bundle.serializer.ModelSerializer
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.regression.{DecisionTreeRegressionModel, GBTRegressionModel}
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 9/24/16.
@@ -64,6 +65,8 @@ class GBTRegressionOp extends OpNode[SparkBundleContext, GBTRegressionModel, GBT
   }
 
   override def shape(node: GBTRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withInput(node.getFeaturesCol, "features").withOutput(node.getPredictionCol, "prediction")
+    val dataset = context.context.dataset
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset))
+      .withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/GeneralizedLinearRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/GeneralizedLinearRegressionOp.scala
@@ -54,7 +54,7 @@ class GeneralizedLinearRegressionOp extends OpNode[SparkBundleContext, Generaliz
     m
   }
 
-  override def shape(node: GeneralizedLinearRegressionModel): Shape = {
+  override def shape(node: GeneralizedLinearRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
     val s = Shape().withInput(node.getFeaturesCol, "features").
       withOutput(node.getPredictionCol, "prediction")
     if(node.isSet(node.linkPredictionCol)) { s.withOutput(node.getLinkPredictionCol, "link_prediction") }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/GeneralizedLinearRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/GeneralizedLinearRegressionOp.scala
@@ -6,6 +6,7 @@ import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.regression.GeneralizedLinearRegressionModel
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 12/28/16.
@@ -55,9 +56,12 @@ class GeneralizedLinearRegressionOp extends OpNode[SparkBundleContext, Generaliz
   }
 
   override def shape(node: GeneralizedLinearRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    val s = Shape().withInput(node.getFeaturesCol, "features").
-      withOutput(node.getPredictionCol, "prediction")
-    if(node.isSet(node.linkPredictionCol)) { s.withOutput(node.getLinkPredictionCol, "link_prediction") }
+    val dataset = context.context.dataset
+    val s = Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset)).
+      withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset))
+    if(node.isSet(node.linkPredictionCol)) {
+      s.withOutput(node.getLinkPredictionCol, "link_prediction", fieldType(node.getLinkPredictionCol, dataset))
+    }
     s
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/IsotonicRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/IsotonicRegressionOp.scala
@@ -60,6 +60,7 @@ class IsotonicRegressionOp extends OpNode[SparkBundleContext, IsotonicRegression
       setFeatureIndex(model.getFeatureIndex)
   }
 
-  override def shape(node: IsotonicRegressionModel): Shape = Shape().withInput(node.getFeaturesCol, "features").
-    withOutput(node.getPredictionCol, "prediction")
+  override def shape(node: IsotonicRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withInput(node.getFeaturesCol, "features").withOutput(node.getPredictionCol, "prediction")
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/IsotonicRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/IsotonicRegressionOp.scala
@@ -7,6 +7,7 @@ import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.linalg.VectorUDT
 import org.apache.spark.ml.regression.IsotonicRegressionModel
 import org.apache.spark.mllib.regression
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 import org.apache.spark.sql.types.DoubleType
 
 /**
@@ -61,6 +62,8 @@ class IsotonicRegressionOp extends OpNode[SparkBundleContext, IsotonicRegression
   }
 
   override def shape(node: IsotonicRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withInput(node.getFeaturesCol, "features").withOutput(node.getPredictionCol, "prediction")
+    val dataset = context.context.dataset
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset))
+      .withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/LinearRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/LinearRegressionOp.scala
@@ -6,6 +6,7 @@ import ml.combust.bundle.dsl._
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.regression.LinearRegressionModel
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 8/21/16.
@@ -46,6 +47,8 @@ class LinearRegressionOp extends OpNode[SparkBundleContext, LinearRegressionMode
   }
 
   override def shape(node: LinearRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withInput(node.getFeaturesCol, "features").withOutput(node.getPredictionCol, "prediction")
+    val dataset = context.context.dataset
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset))
+      .withOutput(node.getPredictionCol, "prediction",  fieldType(node.getPredictionCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/LinearRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/LinearRegressionOp.scala
@@ -45,7 +45,7 @@ class LinearRegressionOp extends OpNode[SparkBundleContext, LinearRegressionMode
       setPredictionCol(node.shape.output("prediction").name)
   }
 
-  override def shape(node: LinearRegressionModel): Shape = Shape().
-    withInput(node.getFeaturesCol, "features").
-    withOutput(node.getPredictionCol, "prediction")
+  override def shape(node: LinearRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withInput(node.getFeaturesCol, "features").withOutput(node.getPredictionCol, "prediction")
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/RandomForestRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/RandomForestRegressionOp.scala
@@ -7,6 +7,7 @@ import ml.combust.bundle.dsl._
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.bundle.tree.decision.SparkNodeWrapper
 import org.apache.spark.ml.regression.{DecisionTreeRegressionModel, RandomForestRegressionModel}
+import org.apache.spark.sql.mleap.TypeConverters.fieldType
 
 /**
   * Created by hollinwilkins on 8/22/16.
@@ -68,7 +69,8 @@ class RandomForestRegressionOp extends OpNode[SparkBundleContext, RandomForestRe
   }
 
   override def shape(node: RandomForestRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
-    Shape().withInput(node.getFeaturesCol, "features").
-      withOutput(node.getPredictionCol, "prediction")
+    val dataset = context.context.dataset
+    Shape().withInput(node.getFeaturesCol, "features", fieldType(node.getFeaturesCol, dataset)).
+        withOutput(node.getPredictionCol, "prediction", fieldType(node.getPredictionCol, dataset))
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/RandomForestRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/RandomForestRegressionOp.scala
@@ -67,7 +67,8 @@ class RandomForestRegressionOp extends OpNode[SparkBundleContext, RandomForestRe
       setPredictionCol(node.shape.output("prediction").name)
   }
 
-  override def shape(node: RandomForestRegressionModel): Shape = Shape().
-    withInput(node.getFeaturesCol, "features").
-    withOutput(node.getPredictionCol, "prediction")
+  override def shape(node: RandomForestRegressionModel)(implicit context: BundleContext[SparkBundleContext]): Shape = {
+    Shape().withInput(node.getFeaturesCol, "features").
+      withOutput(node.getPredictionCol, "prediction")
+  }
 }


### PR DESCRIPTION
@hollinwilkins @seme0021 

I've given it a try to add a Datatype to the node input/output socket in order to be able to provide the schema of the deployed model, updates to the protobuf messages are in [this](https://github.com/combust/bundle-protobuf/compare/develop...ancasarb:feature/issue38_socket_type?expand=1) branch.

I've used the DataFrame that some of the metadata dependent transformers require to be passed in when serializing the pipeline for setting the types. If the data frame is passed in the spark context, the datatype for the node input / output sockets is derived from it, otherwise the type is set to null. (I will add a test for this in the next commit)

When serializing a model from mleap, all datatypes will be set to null for the moment, but I can make the same changes to the MleapContext if you think this approach works.  

@hollinwilkins @seme0021 I'd appreciate your thoughts or ideas on whether you think this is feasible, thank you!

Sidenotes:
- I've added a method to convert from spark types to bundle ml / mleap types in TypeConverters.scala for all the spark types that I found to be used. 

- I've updated four of the ops (MultiLayerPerceptronClassifierOp, GaussianMixtureOp, MathBinaryOp, MathUnaryOp) in the spark subproject that were using the MleapContext when I think they should be using the SparkBundleContext instead. 
