### PR TITLE
Allow for multiple outputs from a transformer

### DIFF
--- a/mleap-runtime/src/main/scala/ml/combust/mleap/json/DatasetFormat.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/json/DatasetFormat.scala
@@ -54,7 +54,7 @@ object DatasetFormat {
     case tt: TensorType => tensorSerializer(tt)
     case ct: CustomType => ct.format
     case AnyType(_) => serializationError("AnyType unsupported for serialization")
-    case _: TupleDataType => serializationError("DataTypeSeq only used for UDFs with multiple outputs")
+    case _: TupleType => serializationError("DataTypeSeq only used for UDFs with multiple outputs")
   }
 }
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/json/DatasetFormat.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/json/DatasetFormat.scala
@@ -54,6 +54,7 @@ object DatasetFormat {
     case tt: TensorType => tensorSerializer(tt)
     case ct: CustomType => ct.format
     case AnyType(_) => serializationError("AnyType unsupported for serialization")
+    case _: TupleDataType => serializationError("DataTypeSeq only used for UDFs with multiple outputs")
   }
 }
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/json/JsonSupport.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/json/JsonSupport.scala
@@ -109,7 +109,7 @@ trait JsonSupport extends ml.combust.mleap.tensor.JsonSupport {
       case lt: ListType => mleapListTypeWriterFormat.write(lt)
       case tt: TensorType => mleapTensorTypeFormat.write(tt)
       case ct: CustomType => mleapCustomTypeWriterFormat.write(ct)
-      case AnyType(_) => serializationError("AnyType not supported for JSON serialization")
+      case _ => serializationError(s"$obj not supported for JSON serialization")
     }
   }
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Dataset.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Dataset.scala
@@ -31,6 +31,9 @@ trait Dataset extends Serializable with Iterable[Row] {
   def withValue(selectors: RowSelector *)
                (udf: UserDefinedFunction): Dataset = update(_.withValue(selectors: _*)(udf))
 
+  def withValues(selectors: RowSelector *)
+                (udf: UserDefinedFunction): Dataset = update(_.withValues(selectors: _*)(udf))
+
   /** Select given indices of every row.
     *
     * @param indices indices to select

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/LeapFrame.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/LeapFrame.scala
@@ -81,7 +81,7 @@ trait LeapFrame[LF <: LeapFrame[LF]] extends TransformBuilder[LF] with Serializa
                 (udf: UserDefinedFunction): Try[LF] = {
     RowUtil.createRowSelectors(schema, udf.inputs, selectors: _*).flatMap {
       rowSelectors =>
-        val fields = names.zip(udf.returnType.asInstanceOf[TupleDataType].dts).map {
+        val fields = names.zip(udf.returnType.asInstanceOf[TupleType].dts).map {
           case (name, dt) => StructField(name, dt)
         }
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Row.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Row.scala
@@ -165,7 +165,7 @@ trait Row extends Iterable[Any] {
 
   def withValues(selectors: RowSelector *)(udf: UserDefinedFunction): Row = {
     udfValue(selectors: _*)(udf) match {
-      case s: Seq[_] => withValues(s)
+      case s: Product => withValues(s.productIterator.toSeq)
       case _ => throw new IllegalArgumentException("Output of udf must be a Seq for multiple outputs")
     }
   }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Row.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Row.scala
@@ -163,6 +163,13 @@ trait Row extends Iterable[Any] {
     withValue(udfValue(selectors: _*)(udf))
   }
 
+  def withValues(selectors: RowSelector *)(udf: UserDefinedFunction): Row = {
+    udfValue(selectors: _*)(udf) match {
+      case s: Seq[_] => withValues(s)
+      case _ => throw new IllegalArgumentException("Output of udf must be a Seq for multiple outputs")
+    }
+  }
+
   def udfValue(selectors: RowSelector *)(udf: UserDefinedFunction): Any = {
     udf.inputs.length match {
       case 0 =>
@@ -186,6 +193,8 @@ trait Row extends Iterable[Any] {
     * @return row with the new value
     */
   def withValue(value: Any): Row
+
+  def withValues(values: Seq[Any]): Row
 
   /** Create a new row from specified indices.
     *
@@ -223,6 +232,7 @@ case class ArrayRow(values: mutable.WrappedArray[Any]) extends Row {
   override def iterator: Iterator[Any] = values.iterator
 
   override def withValue(value: Any): Row = ArrayRow(values :+ value)
+  override def withValues(values: Seq[Any]): Row = ArrayRow(this.values ++ values)
 
   override def selectIndices(indices: Int*): Row = ArrayRow(indices.toArray.map(values))
   override def dropIndex(index: Int): Row = ArrayRow(values.take(index) ++ values.drop(index + 1))

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/reflection/MleapReflection.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/reflection/MleapReflection.scala
@@ -43,7 +43,7 @@ trait MleapReflection {
       case t if t <:< mirrorType[Product] =>
         val TypeRef(_, _, sdts) = t
         val dts = sdts.map(dataTypeFor)
-        TupleDataType(dts: _*)
+        TupleType(dts: _*)
       case t => throw new IllegalArgumentException(s"unknown type $t")
     }
   }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/reflection/MleapReflection.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/reflection/MleapReflection.scala
@@ -40,6 +40,9 @@ trait MleapReflection {
         val TypeRef(_, _, Seq(elementType)) = t
         val baseType = dataTypeFor(elementType)
         baseType.asNullable
+      case t if t <:< mirrorType[Product] =>
+        val dts = t.typeArgs.map(dataTypeFor)
+        TupleDataType(dts: _*)
       case t => throw new IllegalArgumentException(s"unknown type $t")
     }
   }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/reflection/MleapReflection.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/reflection/MleapReflection.scala
@@ -41,7 +41,8 @@ trait MleapReflection {
         val baseType = dataTypeFor(elementType)
         baseType.asNullable
       case t if t <:< mirrorType[Product] =>
-        val dts = t.typeArgs.map(dataTypeFor)
+        val TypeRef(_, _, sdts) = t
+        val dts = sdts.map(dataTypeFor)
         TupleDataType(dts: _*)
       case t => throw new IllegalArgumentException(s"unknown type $t")
     }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/RowTransformBuilder.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/RowTransformBuilder.scala
@@ -2,7 +2,7 @@ package ml.combust.mleap.runtime.transformer.builder
 
 import ml.combust.mleap.runtime.{ArrayRow, Row, RowUtil}
 import ml.combust.mleap.runtime.function.{Selector, UserDefinedFunction}
-import ml.combust.mleap.runtime.types.{StructField, StructType, TupleDataType}
+import ml.combust.mleap.runtime.types.{StructField, StructType, TupleType}
 
 import scala.util.Try
 
@@ -22,9 +22,9 @@ case class RowTransformBuilder private (inputSchema: StructType,
 
   override def withOutputs(outputs: Seq[String], inputs: Selector *)
                           (udf: UserDefinedFunction): Try[RowTransformBuilder] = {
-    val count = udf.returnType.asInstanceOf[TupleDataType].dts.size
+    val count = udf.returnType.asInstanceOf[TupleType].dts.size
     val indices = outputSchema.fields.length until outputSchema.fields.length + count
-    val fields = outputs.zip(udf.returnType.asInstanceOf[TupleDataType].dts).map {
+    val fields = outputs.zip(udf.returnType.asInstanceOf[TupleType].dts).map {
       case (name, dt) => StructField(name, dt)
     }
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/RowTransformBuilder.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/RowTransformBuilder.scala
@@ -20,6 +20,9 @@ case class RowTransformBuilder private (inputSchema: StructType,
 
   override def schema: StructType = outputSchema
 
+  override def withOutputs(outputs: Seq[String], inputs: Selector *)
+                          (udf: UserDefinedFunction): Try[RowTransformBuilder] = ???
+
   override def withOutput(name: String, selectors: Selector *)
                          (udf: UserDefinedFunction): Try[RowTransformBuilder] = {
     val index = outputSchema.fields.length

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/RowTransformBuilder.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/RowTransformBuilder.scala
@@ -1,8 +1,8 @@
 package ml.combust.mleap.runtime.transformer.builder
 
-import ml.combust.mleap.runtime.{Row, RowUtil, ArrayRow}
+import ml.combust.mleap.runtime.{ArrayRow, Row, RowUtil}
 import ml.combust.mleap.runtime.function.{Selector, UserDefinedFunction}
-import ml.combust.mleap.runtime.types.StructType
+import ml.combust.mleap.runtime.types.{StructField, StructType, TupleDataType}
 
 import scala.util.Try
 
@@ -21,7 +21,30 @@ case class RowTransformBuilder private (inputSchema: StructType,
   override def schema: StructType = outputSchema
 
   override def withOutputs(outputs: Seq[String], inputs: Selector *)
-                          (udf: UserDefinedFunction): Try[RowTransformBuilder] = ???
+                          (udf: UserDefinedFunction): Try[RowTransformBuilder] = {
+    val count = udf.returnType.asInstanceOf[TupleDataType].dts.size
+    val indices = outputSchema.fields.length until outputSchema.fields.length + count
+    val fields = outputs.zip(udf.returnType.asInstanceOf[TupleDataType].dts).map {
+      case (name, dt) => StructField(name, dt)
+    }
+
+    RowUtil.createRowSelectors(outputSchema, udf.inputs, inputs: _*).flatMap {
+      rowSelectors =>
+        outputSchema.withFields(fields).map {
+          schema2 =>
+            val transform = {
+              (row: ArrayRow) =>
+                val values = row.udfValue(rowSelectors: _*)(udf).asInstanceOf[Product].productIterator.toSeq
+                indices.zip(values).foreach {
+                  case (index, value) => row.set(index, value)
+                }
+
+                row
+            }
+            copy(outputSchema = schema2, transforms = transforms :+ transform)
+        }
+    }
+  }
 
   override def withOutput(name: String, selectors: Selector *)
                          (udf: UserDefinedFunction): Try[RowTransformBuilder] = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/TransformBuilder.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/TransformBuilder.scala
@@ -18,4 +18,12 @@ trait TransformBuilder[B <: TransformBuilder[B]] extends Serializable {
   }
 
   def schema: StructType
+
+  def withOutputs(outputs: Seq[String], inputs: Selector *)
+                 (udf: UserDefinedFunction): Try[B]
+
+  def withOutputs(outputs: Seq[String], input: String, inputs: String *)
+                 (udf: UserDefinedFunction): Try[B] = {
+    withOutputs(outputs, Selector(input) +: inputs.map(Selector.apply): _*)(udf)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/types/DataType.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/types/DataType.scala
@@ -97,7 +97,7 @@ case class CustomType private (ct: bundle.custom.CustomType[Any],
   override def fromBytes(bytes: Array[Byte]): Any = ct.fromBytes(bytes)
 }
 
-case class TupleDataType(dts: DataType *) extends DataType {
+case class TupleType(dts: DataType *) extends DataType {
   override val isNullable: Boolean = false
   override def asNullable: DataType = ???
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/types/DataType.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/types/DataType.scala
@@ -97,7 +97,7 @@ case class CustomType private (ct: bundle.custom.CustomType[Any],
   override def fromBytes(bytes: Array[Byte]): Any = ct.fromBytes(bytes)
 }
 
-case class TupleDataType(dts: Seq[DataType]) extends DataType {
+case class TupleDataType(dts: DataType *) extends DataType {
   override val isNullable: Boolean = false
   override def asNullable: DataType = ???
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/types/DataType.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/types/DataType.scala
@@ -96,3 +96,16 @@ case class CustomType private (ct: bundle.custom.CustomType[Any],
   override def toBytes(obj: Any): Array[Byte] = ct.toBytes(obj)
   override def fromBytes(bytes: Array[Byte]): Any = ct.fromBytes(bytes)
 }
+
+case class TupleDataType(dts: Seq[DataType]) extends DataType {
+  override val isNullable: Boolean = false
+  override def asNullable: DataType = ???
+
+  override def simpleString: String = {
+    val sb = StringBuilder.newBuilder
+    sb.append("TupleDataType(")
+    sb.append(dts.map(_.simpleString).mkString(","))
+    sb.append(")")
+    sb.toString
+  }
+}

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/DatasetSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/DatasetSpec.scala
@@ -37,6 +37,21 @@ trait DatasetSpec[D <: Dataset] extends FunSpec {
         }
       }
 
+      describe("#withValues") {
+        describe("with a user defined function") {
+          it("created a new dataset with the calculated value from the user defined function") {
+            val dataset2 = dataset.withValues(r => r.get(1), r => r.get(0)) {
+              (v1: String, v2: Int) => (s"$v1:$v2", v2 + 10)
+            }
+            val data = dataset2.toSeq.map(r => r.getString(2))
+            val dataDoubles = dataset2.toSeq.map(r => r.getInt(3))
+
+            assert(data == Seq("hey:42", "there:13"))
+            assert(dataDoubles == Seq(52, 23))
+          }
+        }
+      }
+
       describe("#selectIndices") {
         it("creates a new dataset with the selected indices") {
           val dataset2 = dataset.selectIndices(0)

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/LeapFrameSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/LeapFrameSpec.scala
@@ -92,6 +92,23 @@ trait LeapFrameSpec[LF <: LeapFrame[LF]] extends FunSpec {
         }
       }
 
+      describe("#withFields") {
+        it("creates a new LeapFrame with fields added") {
+          val frame2 = frame.withFields(Seq("test_double_2", "test_double_string"), "test_double") {
+            (r: Double) => (r + 10, r.toString)
+          }.get
+          val data = frame2.dataset.toArray
+
+          assert(frame2.schema.fields.length == 4)
+          assert(frame2.schema.indexOf("test_double_2").get == 2)
+          assert(frame2.schema.indexOf("test_double_string").get == 3)
+          assert(data(0).getDouble(2) == 52.13)
+          assert(data(1).getDouble(2) == 23.42)
+          assert(data(0).getString(3) == "42.13")
+          assert(data(1).getString(3) == "13.42")
+        }
+      }
+
       describe("#dropField") {
         it("creates a new LeapFrame with field dropped") {
           val frame2 = frame.dropField("test_string").get

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/RowSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/RowSpec.scala
@@ -182,6 +182,27 @@ trait RowSpec[R <: Row] extends FunSpec {
       }
     }
 
+    describe("#withValues") {
+      describe("user defined function") {
+        it("adds a value using a user defined function") {
+          val r2 = row.withValues(r => r.get(1), r => r.get(2)) {
+            (v1: Int, v2: Seq[Int]) => (v1 + v2.head, v1 - v2.head)
+          }
+
+          assert(r2.getInt(6) == 98)
+          assert(r2.getInt(7) == -14)
+        }
+      }
+
+      describe("value arg") {
+        it("adds the value to the row") {
+          val r = row.withValue(789)
+
+          assert(r.getInt(6) == 789)
+        }
+      }
+    }
+
     describe("#selectIndices") {
       it("creates a new row from the selected indices") {
         val r = row.selectIndices(3, 0)

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/UserDefinedFunctionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/UserDefinedFunctionSpec.scala
@@ -32,7 +32,7 @@ class UserDefinedFunctionSpec extends FunSpec {
   }
 
   private def assertUdfForm(udf: UserDefinedFunction, returnType: DataType, argTypes: DataType *): Unit = {
-    assert(udf.returnType == returnType)
+    assert(udf.returnTypes == returnType)
     assert(udf.inputs.length == argTypes.length)
     udf.inputs.zip(argTypes).foreach {
       case (inputType, argType) => assert(inputType == argType)

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/UserDefinedFunctionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/UserDefinedFunctionSpec.scala
@@ -32,7 +32,7 @@ class UserDefinedFunctionSpec extends FunSpec {
   }
 
   private def assertUdfForm(udf: UserDefinedFunction, returnType: DataType, argTypes: DataType *): Unit = {
-    assert(udf.returnTypes == returnType)
+    assert(udf.returnType == returnType)
     assert(udf.inputs.length == argTypes.length)
     udf.inputs.zip(argTypes).foreach {
       case (inputType, argType) => assert(inputType == argType)

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/reflection/MleapReflectionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/reflection/MleapReflectionSpec.scala
@@ -36,6 +36,7 @@ class MleapReflectionSpec extends FunSpec {
       assert(dataType[Option[Double]] == DoubleType(true))
       assert(dataType[Tensor[Double]] == TensorType(DoubleType()))
       assert(dataType[Any] == AnyType())
+      assert(dataType[(String, Double)] == TupleDataType(StringType(), DoubleType()))
     }
 
     describe("#with an invalid Scala type") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/reflection/MleapReflectionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/reflection/MleapReflectionSpec.scala
@@ -36,7 +36,7 @@ class MleapReflectionSpec extends FunSpec {
       assert(dataType[Option[Double]] == DoubleType(true))
       assert(dataType[Tensor[Double]] == TensorType(DoubleType()))
       assert(dataType[Any] == AnyType())
-      assert(dataType[(String, Double)] == TupleDataType(StringType(), DoubleType()))
+      assert(dataType[(String, Double)] == TupleType(StringType(), DoubleType()))
     }
 
     describe("#with an invalid Scala type") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/types/StructTypeSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/types/StructTypeSpec.scala
@@ -43,6 +43,13 @@ class StructTypeSpec extends FunSuite with GivenWhenThen with TryValues{
 
     assert(testStruct.withField(field).get.hasField(field.name))
   }
+
+  test("withFields should return a StructType with the fields added") {
+    val fields = Seq(StructField("sixth", StringType()), StructField("seventh", DoubleType()))
+
+    assert(testStruct.withFields(fields).get.hasField("sixth"))
+    assert(testStruct.withFields(fields).get.hasField("seventh"))
+  }
   
   test("Dropping a field from a StructType should remove the field") {
     assert(testStruct.dropField("first").get.getField("first").isEmpty)

--- a/mleap-spark-base/src/main/scala/ml/combust/mleap/spark/SparkTransformBuilder.scala
+++ b/mleap-spark-base/src/main/scala/ml/combust/mleap/spark/SparkTransformBuilder.scala
@@ -17,6 +17,9 @@ case class SparkTransformBuilder(dataset: DataFrame) extends TransformBuilder[Sp
   override def schema: StructType = {
     TypeConverters.mleapStructType(dataset.schema)
   }
+  
+  override def withOutputs(outputs: Seq[String], inputs: Selector*)
+                          (udf: UserDefinedFunction): Try[SparkTransformBuilder] = ???
 
   override def withOutput(name: String, selectors: Selector *)
                          (udf: UserDefinedFunction): Try[SparkTransformBuilder] = Try {

--- a/mleap-spark-base/src/main/scala/ml/combust/mleap/spark/SparkTransformBuilder.scala
+++ b/mleap-spark-base/src/main/scala/ml/combust/mleap/spark/SparkTransformBuilder.scala
@@ -8,7 +8,7 @@ import org.apache.spark.sql.mleap.TypeConverters
 import org.apache.spark.sql.{Column, DataFrame, expressions}
 import org.apache.spark.sql.mleap.UserDefinedFunctionConverters._
 
-import scala.util.Try
+import scala.util.{Random, Try}
 
 /**
   * Created by hollinwilkins on 10/22/16.
@@ -17,9 +17,19 @@ case class SparkTransformBuilder(dataset: DataFrame) extends TransformBuilder[Sp
   override def schema: StructType = {
     TypeConverters.mleapStructType(dataset.schema)
   }
-  
-  override def withOutputs(outputs: Seq[String], inputs: Selector*)
-                          (udf: UserDefinedFunction): Try[SparkTransformBuilder] = ???
+
+  override def withOutputs(outputs: Seq[String], inputs: Selector *)
+                          (udf: UserDefinedFunction): Try[SparkTransformBuilder] = Try {
+    val structUdf: expressions.UserDefinedFunction = udf
+    val sparkSelectors = inputs.map(sparkSelector)
+    val tmpName = s"tmp_${Random.nextInt()}"
+    val dataset2 = dataset.withColumn(tmpName, structUdf(sparkSelectors: _*))
+    val dataset3 = outputs.zipWithIndex.foldLeft(dataset2) {
+      case (d, (name, index)) =>
+        d.withColumn(name, d.col(s"$tmpName._$index"))
+    }.drop(tmpName)
+    copy(dataset = dataset3)
+  }
 
   override def withOutput(name: String, selectors: Selector *)
                          (udf: UserDefinedFunction): Try[SparkTransformBuilder] = Try {

--- a/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
+++ b/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
@@ -19,6 +19,12 @@ trait TypeConverters {
     case types.LongType(_) => Some(LongType)
     case types.FloatType(_) => Some(FloatType)
     case types.DoubleType(_) => Some(DoubleType)
+    case tt: types.TupleType =>
+      val fields = tt.dts.zipWithIndex.map {
+        case (dt, index) =>
+          sparkType(dt).map(d => StructField(s"_$index", d)).get
+      }
+      Some(StructType(fields))
     case lt: types.ListType => sparkType(lt.base).map(t => ArrayType(t, containsNull = false))
     case _: types.TensorType => Some(new TensorUDT)
     case ct: types.CustomType => UDTRegistration.getUDTFor(ct.klazz.getCanonicalName).

--- a/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/UserDefinedFunctionConverters.scala
+++ b/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/UserDefinedFunctionConverters.scala
@@ -18,7 +18,7 @@ trait UserDefinedFunctionConverters {
 
   implicit def udfToSpark(udf: MleapUDF): UserDefinedFunction = {
     UserDefinedFunction(f = convertFunction(udf),
-      dataType = sparkType(udf.returnTypes).get,
+      dataType = sparkType(udf.returnType).get,
       inputTypes = sparkInputs(udf.inputs))
   }
 

--- a/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/UserDefinedFunctionConverters.scala
+++ b/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/UserDefinedFunctionConverters.scala
@@ -18,7 +18,7 @@ trait UserDefinedFunctionConverters {
 
   implicit def udfToSpark(udf: MleapUDF): UserDefinedFunction = {
     UserDefinedFunction(f = convertFunction(udf),
-      dataType = sparkType(udf.returnType).get,
+      dataType = sparkType(udf.returnTypes).get,
       inputTypes = sparkInputs(udf.inputs))
   }
 

--- a/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/UserDefinedFunctionConverters.scala
+++ b/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/UserDefinedFunctionConverters.scala
@@ -3,7 +3,7 @@ package org.apache.spark.sql.mleap
 import ml.combust.mleap.runtime.function.{UserDefinedFunction => MleapUDF}
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import ml.combust.mleap.runtime.types
-import ml.combust.mleap.runtime.types.{AnyType, ListType}
+import ml.combust.mleap.runtime.types.{AnyType, ListType, TupleType}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.DataType
 

--- a/mleap-spark-base/src/test/scala/ml/combust/mleap/spark/SparkTransformBuilderSpec.scala
+++ b/mleap-spark-base/src/test/scala/ml/combust/mleap/spark/SparkTransformBuilderSpec.scala
@@ -1,0 +1,46 @@
+package ml.combust.mleap.spark
+
+import java.util.UUID
+
+import ml.combust.mleap.runtime.transformer.Transformer
+import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.types.{DoubleType, StructType}
+import SparkSupport._
+import org.scalatest.FunSpec
+
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+/**
+  * Created by hollinwilkins on 4/21/17.
+  */
+case class MyTransformer() extends Transformer {
+  override val uid: String = UUID.randomUUID().toString
+
+  override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
+    builder.withOutputs(Seq("output1", "output2"), "input") {
+      (input: Double) => (input + 23, input.toString)
+    }
+  }
+}
+
+class SparkTransformBuilderSpec extends FunSpec {
+  describe("transformer with multiple outputs") {
+    it("works with Spark as well") {
+      val spark = SparkSession.builder().
+        appName("Spark/MLeap Parity Tests").
+        master("local[2]").
+        getOrCreate()
+      val schema = new StructType().
+        add("input", DoubleType)
+      val data = Seq(Row(45.7d)).asJava
+      val dataset = spark.createDataFrame(data, schema)
+      val transformer = MyTransformer()
+      val outputDataset = transformer.sparkTransform(dataset).collect()
+
+      assert(outputDataset.head.getDouble(1) == 68.7)
+      assert(outputDataset.head.getString(2) == "45.7")
+    }
+  }
+}

--- a/mleap-tensorflow/src/main/scala/ml/combust/mleap/tensorflow/TensorflowTransformer.scala
+++ b/mleap-tensorflow/src/main/scala/ml/combust/mleap/tensorflow/TensorflowTransformer.scala
@@ -23,7 +23,7 @@ case class TensorflowTransformer(override val uid: String = Transformer.uniqueNa
   val outputUdfs: Seq[UserDefinedFunction] = outputCols.zipWithIndex.map {
     case (output, index) =>
       val udf: UserDefinedFunction = (raw: Seq[Any]) => raw(index)
-      udf.copy(returnType = model.outputs(index)._2)
+      udf.copy(returnTypes = model.outputs(index)._2)
   }
   private val outputsWithUdfs = outputCols.zip(outputUdfs)
 


### PR DESCRIPTION
This pull request allows TransformBuilders to generate multiple output columns in one shot. This can lead to goo efficiency gains for certain transformers.