### PR TITLE
Very small update to use SparkBundleContext for some Spark Ops

### DIFF
--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathBinaryOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathBinaryOp.scala
@@ -4,27 +4,27 @@ import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.mleap.core.feature.{BinaryOperation, MathBinaryModel}
-import ml.combust.mleap.runtime.MleapContext
+import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.mleap.feature.MathBinary
 
 /**
   * Created by hollinwilkins on 12/27/16.
   */
-class MathBinaryOp extends OpNode[MleapContext, MathBinary, MathBinaryModel] {
-  override val Model: OpModel[MleapContext, MathBinaryModel] = new OpModel[MleapContext, MathBinaryModel] {
+class MathBinaryOp extends OpNode[SparkBundleContext, MathBinary, MathBinaryModel] {
+  override val Model: OpModel[SparkBundleContext, MathBinaryModel] = new OpModel[SparkBundleContext, MathBinaryModel] {
     override val klazz: Class[MathBinaryModel] = classOf[MathBinaryModel]
 
     override def opName: String = Bundle.BuiltinOps.feature.math_binary
 
     override def store(model: Model, obj: MathBinaryModel)
-                      (implicit context: BundleContext[MleapContext]): Model = {
+                      (implicit context: BundleContext[SparkBundleContext]): Model = {
       model.withAttr("operation", Value.string(obj.operation.name)).
         withAttr("da", obj.da.map(Value.double)).
         withAttr("db", obj.db.map(Value.double))
     }
 
     override def load(model: Model)
-                     (implicit context: BundleContext[MleapContext]): MathBinaryModel = {
+                     (implicit context: BundleContext[SparkBundleContext]): MathBinaryModel = {
       MathBinaryModel(operation = BinaryOperation.forName(model.value("operation").getString),
         da = model.getValue("da").map(_.getDouble),
         db = model.getValue("db").map(_.getDouble))
@@ -38,7 +38,7 @@ class MathBinaryOp extends OpNode[MleapContext, MathBinary, MathBinaryModel] {
   override def model(node: MathBinary): MathBinaryModel = node.model
 
   override def load(node: Node, model: MathBinaryModel)
-                   (implicit context: BundleContext[MleapContext]): MathBinary = {
+                   (implicit context: BundleContext[SparkBundleContext]): MathBinary = {
     val mb = new MathBinary(uid = node.name,
       model = model).setOutputCol(node.shape.standardOutput.name)
     node.shape.getInput("input_a").foreach(a => mb.setInputA(a.name))

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathUnaryOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathUnaryOp.scala
@@ -4,25 +4,25 @@ import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.mleap.core.feature.{MathUnaryModel, UnaryOperation}
-import ml.combust.mleap.runtime.MleapContext
+import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.mleap.feature.MathUnary
 
 /**
   * Created by hollinwilkins on 12/27/16.
   */
-class MathUnaryOp extends OpNode[MleapContext, MathUnary, MathUnaryModel] {
-  override val Model: OpModel[MleapContext, MathUnaryModel] = new OpModel[MleapContext, MathUnaryModel] {
+class MathUnaryOp extends OpNode[SparkBundleContext, MathUnary, MathUnaryModel] {
+  override val Model: OpModel[SparkBundleContext, MathUnaryModel] = new OpModel[SparkBundleContext, MathUnaryModel] {
     override val klazz: Class[MathUnaryModel] = classOf[MathUnaryModel]
 
     override def opName: String = Bundle.BuiltinOps.feature.math_unary
 
     override def store(model: Model, obj: MathUnaryModel)
-                      (implicit context: BundleContext[MleapContext]): Model = {
+                      (implicit context: BundleContext[SparkBundleContext]): Model = {
       model.withAttr("operation", Value.string(obj.operation.name))
     }
 
     override def load(model: Model)
-                     (implicit context: BundleContext[MleapContext]): MathUnaryModel = {
+                     (implicit context: BundleContext[SparkBundleContext]): MathUnaryModel = {
       MathUnaryModel(UnaryOperation.forName(model.value("operation").getString))
     }
   }
@@ -34,7 +34,7 @@ class MathUnaryOp extends OpNode[MleapContext, MathUnary, MathUnaryModel] {
   override def model(node: MathUnary): MathUnaryModel = node.model
 
   override def load(node: Node, model: MathUnaryModel)
-                   (implicit context: BundleContext[MleapContext]): MathUnary = {
+                   (implicit context: BundleContext[SparkBundleContext]): MathUnary = {
     new MathUnary(uid = node.name,
       model = model).setInputCol(node.shape.standardInput.name).
       setOutputCol(node.shape.standardOutput.name)

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/MultiLayerPerceptronClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/MultiLayerPerceptronClassifierOp.scala
@@ -3,27 +3,27 @@ package org.apache.spark.ml.bundle.ops.classification
 import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
-import ml.combust.mleap.runtime.MleapContext
+import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.classification.MultilayerPerceptronClassificationModel
 import org.apache.spark.ml.linalg.Vectors
 
 /**
   * Created by hollinwilkins on 12/25/16.
   */
-class MultiLayerPerceptronClassifierOp extends OpNode[MleapContext, MultilayerPerceptronClassificationModel, MultilayerPerceptronClassificationModel] {
-  override val Model: OpModel[MleapContext, MultilayerPerceptronClassificationModel] = new OpModel[MleapContext, MultilayerPerceptronClassificationModel] {
+class MultiLayerPerceptronClassifierOp extends OpNode[SparkBundleContext, MultilayerPerceptronClassificationModel, MultilayerPerceptronClassificationModel] {
+  override val Model: OpModel[SparkBundleContext, MultilayerPerceptronClassificationModel] = new OpModel[SparkBundleContext, MultilayerPerceptronClassificationModel] {
     override def opName: String = Bundle.BuiltinOps.classification.multi_layer_perceptron_classifier
 
     override val klazz: Class[MultilayerPerceptronClassificationModel] = classOf[MultilayerPerceptronClassificationModel]
 
     override def store(model: Model, obj: MultilayerPerceptronClassificationModel)
-                      (implicit context: BundleContext[MleapContext]): Model = {
+                      (implicit context: BundleContext[SparkBundleContext]): Model = {
       model.withAttr("layers", Value.longList(obj.layers.map(_.toLong))).
         withAttr("weights", Value.vector(obj.weights.toArray))
     }
 
     override def load(model: Model)
-                     (implicit context: BundleContext[MleapContext]): MultilayerPerceptronClassificationModel = {
+                     (implicit context: BundleContext[SparkBundleContext]): MultilayerPerceptronClassificationModel = {
       new MultilayerPerceptronClassificationModel(uid = "",
         layers = model.value("layers").getLongList.map(_.toInt).toArray,
         weights = Vectors.dense(model.value("weights").getTensor[Double].toArray))
@@ -37,7 +37,7 @@ class MultiLayerPerceptronClassifierOp extends OpNode[MleapContext, MultilayerPe
   override def model(node: MultilayerPerceptronClassificationModel): MultilayerPerceptronClassificationModel = node
 
   override def load(node: Node, model: MultilayerPerceptronClassificationModel)
-                   (implicit context: BundleContext[MleapContext]): MultilayerPerceptronClassificationModel = {
+                   (implicit context: BundleContext[SparkBundleContext]): MultilayerPerceptronClassificationModel = {
     new MultilayerPerceptronClassificationModel(uid = node.name,
       layers = model.layers,
       weights = model.weights).setFeaturesCol(node.shape.input("features").name).

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/GaussianMixtureOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/GaussianMixtureOp.scala
@@ -3,8 +3,8 @@ package org.apache.spark.ml.bundle.ops.clustering
 import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
-import ml.combust.mleap.runtime.MleapContext
 import ml.combust.mleap.tensor.{DenseTensor, Tensor}
+import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.clustering.GaussianMixtureModel
 import org.apache.spark.ml.linalg.{Matrices, Vectors}
 import org.apache.spark.ml.stat.distribution.MultivariateGaussian
@@ -12,14 +12,14 @@ import org.apache.spark.ml.stat.distribution.MultivariateGaussian
 /**
   * Created by hollinwilkins on 9/30/16.
   */
-class GaussianMixtureOp extends OpNode[MleapContext, GaussianMixtureModel, GaussianMixtureModel] {
-  override val Model: OpModel[MleapContext, GaussianMixtureModel] = new OpModel[MleapContext, GaussianMixtureModel] {
+class GaussianMixtureOp extends OpNode[SparkBundleContext, GaussianMixtureModel, GaussianMixtureModel] {
+  override val Model: OpModel[SparkBundleContext, GaussianMixtureModel] = new OpModel[SparkBundleContext, GaussianMixtureModel] {
     override val klazz: Class[GaussianMixtureModel] = classOf[GaussianMixtureModel]
 
     override def opName: String = Bundle.BuiltinOps.clustering.gaussian_mixture
 
     override def store(model: Model, obj: GaussianMixtureModel)
-                      (implicit context: BundleContext[MleapContext]): Model = {
+                      (implicit context: BundleContext[SparkBundleContext]): Model = {
       val (rows, cols) = obj.gaussians.headOption.
         map(g => (g.cov.numRows, g.cov.numCols)).
         getOrElse((-1, -1))
@@ -31,7 +31,7 @@ class GaussianMixtureOp extends OpNode[MleapContext, GaussianMixtureModel, Gauss
     }
 
     override def load(model: Model)
-                     (implicit context: BundleContext[MleapContext]): GaussianMixtureModel = {
+                     (implicit context: BundleContext[SparkBundleContext]): GaussianMixtureModel = {
       val means = model.value("means").getTensorList[Double].map(values => Vectors.dense(values.toArray))
       val covs = model.value("covs").getTensorList[Double].map(values => Matrices.dense(values.dimensions.head, values.dimensions(1), values.toArray))
       val gaussians = means.zip(covs).map {
@@ -52,7 +52,7 @@ class GaussianMixtureOp extends OpNode[MleapContext, GaussianMixtureModel, Gauss
   override def model(node: GaussianMixtureModel): GaussianMixtureModel = node
 
   override def load(node: Node, model: GaussianMixtureModel)
-                   (implicit context: BundleContext[MleapContext]): GaussianMixtureModel = {
+                   (implicit context: BundleContext[SparkBundleContext]): GaussianMixtureModel = {
     val gmm = new GaussianMixtureModel(uid = node.name,
       gaussians = model.gaussians,
       weights = model.weights)


### PR DESCRIPTION
Update these four spark ops that I found while looking at the data type feature to use SparkBundleContext instead of MleapContext.