### PR TITLE
Store named fields with vector slicer.

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Value.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Value.scala
@@ -639,6 +639,12 @@ case class Value(bundleDataType: DataType, value: Any) {
     */
   def getStringList: Seq[String] = value.asInstanceOf[Seq[String]]
 
+  /** Get list of ints.
+    *
+    * @return list of ints
+    */
+  def getIntList: Seq[Int] = value.asInstanceOf[Seq[Int]]
+
   /** Get list of longs.
     *
     * @return list of longs

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/VectorSlicerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/VectorSlicerModel.scala
@@ -8,9 +8,12 @@ import org.apache.spark.ml.linalg.mleap.VectorUtil._
   * Created by hollinwilkins on 12/28/16.
   */
 @SparkCode(uri = "https://github.com/apache/spark/blob/v2.0.0/mllib/src/main/scala/org/apache/spark/ml/feature/VectorSlicer.scala")
-case class VectorSlicerModel(indices: Array[Int]) {
+case class VectorSlicerModel(indices: Array[Int],
+                             namedIndices: Array[(String, Int)] = Array()) {
+  val allIndices: Array[Int] = indices.union(namedIndices.map(_._2))
+
   def apply(features: Vector): Vector = features match {
-    case features: DenseVector => Vectors.dense(indices.map(features.apply))
-    case features: SparseVector => features.slice(indices)
+    case features: DenseVector => Vectors.dense(allIndices.map(features.apply))
+    case features: SparseVector => features.slice(allIndices)
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/VectorSlicerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/VectorSlicerOp.scala
@@ -18,12 +18,19 @@ class VectorSlicerOp extends OpNode[MleapContext, VectorSlicer, VectorSlicerMode
 
     override def store(model: Model, obj: VectorSlicerModel)
                       (implicit context: BundleContext[MleapContext]): Model = {
-      model.withAttr("indices", Value.longList(obj.indices.map(_.toLong).toSeq))
+      val (names, namedIndices) = obj.namedIndices.unzip
+      model.withAttr("indices", Value.longList(obj.indices.map(_.toLong).toSeq)).
+        withAttr("names", Value.stringList(names)).
+        withAttr("named_indices", Value.intList(namedIndices))
     }
 
     override def load(model: Model)
                      (implicit context: BundleContext[MleapContext]): VectorSlicerModel = {
-      VectorSlicerModel(indices = model.value("indices").getLongList.map(_.toInt).toArray)
+      val names = model.value("names").getStringList
+      val namedIndices = model.value("named_indices").getIntList
+      val namedIndicesMap = names.zip(namedIndices)
+      VectorSlicerModel(indices = model.value("indices").getLongList.map(_.toInt).toArray,
+        namedIndices = namedIndicesMap.toArray)
     }
   }
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/VectorSlicerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/VectorSlicerOp.scala
@@ -3,8 +3,12 @@ package org.apache.spark.ml.bundle.ops.feature
 import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.VectorSlicer
+import org.apache.spark.ml.linalg.VectorUDT
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types.StructField
 
 /**
   * Created by hollinwilkins on 12/28/16.
@@ -17,12 +21,40 @@ class VectorSlicerOp extends OpNode[SparkBundleContext, VectorSlicer, VectorSlic
 
     override def store(model: Model, obj: VectorSlicer)
                       (implicit context: BundleContext[SparkBundleContext]): Model = {
-      model.withAttr("indices", Value.longList(obj.getIndices.map(_.toLong).toSeq))
+      val namedIndicesMap: Array[(String, Int)] = if(obj.getNames.nonEmpty) {
+        assert(context.context.dataset.isDefined, "Must provide a sample dataset when using names with VectorSlicer")
+        val dataset = context.context.dataset.get
+        extractNamedIndices(obj.getInputCol, obj.getNames, dataset)
+      } else { Array() }
+      val (names, namedIndices) = namedIndicesMap.unzip
+
+      model.withAttr("indices", Value.longList(obj.getIndices.map(_.toLong).toSeq)).
+        withAttr("names", Value.stringList(names)).
+        withAttr("named_indices", Value.intList(namedIndices))
     }
 
     override def load(model: Model)
                      (implicit context: BundleContext[SparkBundleContext]): VectorSlicer = {
-      new VectorSlicer(uid = "").setIndices(model.value("indices").getLongList.map(_.toInt).toArray)
+      val names = model.value("names").getStringList
+      new VectorSlicer(uid = "").setIndices(model.value("indices").getLongList.map(_.toInt).toArray).
+        setNames(names.toArray)
+    }
+
+    private def extractNamedIndices(inputCol: String,
+                                    names: Array[String],
+                                    dataset: DataFrame): Array[(String, Int)] = {
+      names.zip(getFeatureIndicesFromNames(dataset.schema(inputCol), names))
+    }
+
+    private def getFeatureIndicesFromNames(col: StructField, names: Array[String]): Array[Int] = {
+      require(col.dataType.isInstanceOf[VectorUDT], s"getFeatureIndicesFromNames expected column $col"
+        + s" to be Vector type, but it was type ${col.dataType} instead.")
+      val inputAttr = AttributeGroup.fromStructField(col)
+      names.map { name =>
+        require(inputAttr.hasAttr(name),
+          s"getFeatureIndicesFromNames found no feature with name $name in column $col.")
+        inputAttr.getAttr(name).index.get
+      }
     }
   }
 
@@ -35,6 +67,7 @@ class VectorSlicerOp extends OpNode[SparkBundleContext, VectorSlicer, VectorSlic
   override def load(node: Node, model: VectorSlicer)
                    (implicit context: BundleContext[SparkBundleContext]): VectorSlicer = {
     new VectorSlicer(uid = node.name).setIndices(model.getIndices).
+      setNames(model.getNames).
       setInputCol(node.shape.standardInput.name).
       setOutputCol(node.shape.standardOutput.name)
   }

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/VectorSlicerParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/VectorSlicerParitySpec.scala
@@ -15,6 +15,7 @@ class VectorSlicerParitySpec extends SparkParityBase {
     setOutputCol("features"),
     new VectorSlicer().
       setIndices(Array(1)).
+      setNames(Array("dti")).
       setInputCol("features").
       setOutputCol("scaled_features"))).fit(dataset)
 }


### PR DESCRIPTION
This fixes an issue where named fields were not being stored with the vector slicer model