### PR TITLE
Problem using python3 with MLeap Pyspark

### DIFF
--- a/python/mleap/pyspark/spark_support.py
+++ b/python/mleap/pyspark/spark_support.py
@@ -25,12 +25,12 @@ def serializeToBundle(self, path, dataset=None):
     serializer.serializeToBundle(self, path, dataset=dataset)
 
 
-def deserializeFromBundle(self, path):
+def deserializeFromBundle(path):
     serializer = SimpleSparkSerializer()
     return serializer.deserializeFromBundle(path)
 
 setattr(Transformer, 'serializeToBundle', serializeToBundle)
-setattr(Transformer.__class__, 'deserializeFromBundle', deserializeFromBundle)
+setattr(Transformer, 'deserializeFromBundle', staticmethod(deserializeFromBundle))
 
 
 class SimpleSparkSerializer(object):


### PR DESCRIPTION
Hi,

we have been trying to execute the PySpark - AirBnb.ipynb notebook in a python3 kernel. 

We have found an error while loading mleap.pyspark.spark_support library. It seems that the line 
`setattr(Transformer.__class__, 'deserializeFromBundle', deserializeFromBundle)` cannot be executed correctly in python3.

We have modified the spark_support.py file to be able to execute the notebook in python3, adding the 'deserializeFromBundle' method as a static method for the Transformer class. 

I include a mention to @guille-rios, who helped me to understand the problem.