### PR TITLE
#185 update LabelEncoder tests 

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ reshape_le_tf = ReshapeArrayToN1()
 # Vector Assembler for x1 One Hot Encoder
 one_hot_encoder_tf = OneHotEncoder(sparse=False)
 one_hot_encoder_tf.mlinit(input_features = label_encoder_tf.output_features, 
-                          output_features = '{}_label_one_hot_encoded'.format(feature_extractor_tf.output_vector))
+                          output_features = '{}_label_one_hot_encoded'.format(continuous_features[0]))
 
 one_hot_encoder_pipeline_x0 = Pipeline([
                                          (feature_extractor_tf.name, feature_extractor_tf),

--- a/README.md
+++ b/README.md
@@ -200,11 +200,8 @@ one_hot_encoder_pipeline_x0 = Pipeline([
                                         ])
 
 one_hot_encoder_pipeline_x0.mlinit()
-
-one_hot_encoder_pipeline_x0.serialize_to_bundle('/tmp', 'mleap-scikit-test-pipeline', init=True)
-
-
 one_hot_encoder_pipeline_x0.fit_transform(data)
+one_hot_encoder_pipeline_x0.serialize_to_bundle('/tmp', 'mleap-scikit-test-pipeline', init=True)
 
 # array([[ 1.,  0.,  0.],
 #        [ 0.,  1.,  0.],

--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ feature_extractor_tf = FeatureExtractor(input_features=continuous_features,
                                          output_vector_items=continuous_features)
 
 # Label Encoder for x1 Label 
-label_encoder_tf = LabelEncoder(input_features=[feature_extractor_tf.output_vector],
-                               output_features='{}_label_le'.format(feature_extractor_tf.output_vector))
+label_encoder_tf = LabelEncoder(input_features=feature_extractor_tf.output_vector_items,
+                               output_features='{}_label_le'.format(continuous_features[0]))
 
 # Reshape the output of the LabelEncoder to N-by-1 array
 reshape_le_tf = ReshapeArrayToN1()

--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ feature_extractor_tf = FeatureExtractor(input_features=continuous_features,
                                          output_vector_items=continuous_features)
 
 # Label Encoder for x1 Label 
-label_encoder_tf = LabelEncoder(input_features=feature_extractor_tf.output_vector,
-                               output_features=['{}_label_le'.format(feature_extractor_tf.output_vector)])
+label_encoder_tf = LabelEncoder(input_features=[feature_extractor_tf.output_vector],
+                               output_features='{}_label_le'.format(feature_extractor_tf.output_vector))
 
 # Reshape the output of the LabelEncoder to N-by-1 array
 reshape_le_tf = ReshapeArrayToN1()

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ from mleap.sklearn.preprocessing.data import NDArrayToDataFrame
 from mleap.sklearn.preprocessing.data import FeatureExtractor, LabelEncoder, ReshapeArrayToN1
 
 # Load scikit-learn transformers and models
-from sklearn.preprocessing import OneHotEncoder, Binarizer
+from sklearn.preprocessing import OneHotEncoder
 from sklearn.pipeline import Pipeline
 
 data = pd.DataFrame(['a', 'b', 'c'], columns=['col_a'])
@@ -181,8 +181,8 @@ feature_extractor_tf = FeatureExtractor(input_features=continuous_features,
                                          output_vector_items=continuous_features)
 
 # Label Encoder for x1 Label 
-label_encoder_tf = LabelEncoder(input_features=feature_extractor_tf.output_vector_items,
-                               output_features=['{}_label_le'.format(x) for x in feature_extractor_tf.output_vector_items])
+label_encoder_tf = LabelEncoder(input_features=feature_extractor_tf.output_vector,
+                               output_features=['{}_label_le'.format(feature_extractor_tf.output_vector)])
 
 # Reshape the output of the LabelEncoder to N-by-1 array
 reshape_le_tf = ReshapeArrayToN1()
@@ -190,7 +190,7 @@ reshape_le_tf = ReshapeArrayToN1()
 # Vector Assembler for x1 One Hot Encoder
 one_hot_encoder_tf = OneHotEncoder(sparse=False)
 one_hot_encoder_tf.mlinit(input_features = label_encoder_tf.output_features, 
-                          output_features = ['{}_label_one_hot_encoded'.format(x) for x in label_encoder_tf.output_features])
+                          output_features = '{}_label_one_hot_encoded'.format(feature_extractor_tf.output_vector))
 
 one_hot_encoder_pipeline_x0 = Pipeline([
                                          (feature_extractor_tf.name, feature_extractor_tf),

--- a/python/mleap/sklearn/preprocessing/data.py
+++ b/python/mleap/sklearn/preprocessing/data.py
@@ -236,8 +236,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin, MLeapSerializer, MLeapDeseri
 
     >>> data = pd.DataFrame([['a', 0], ['b', 1], ['b', 3], ['c', 1]], columns=['col_a', 'col_b'])
     >>> # Label Encoder for x1 Label
-    >>> label_encoder_tf = LabelEncoder()
-    >>> label_encoder_tf.mlinit(input_features = ['col_a'] , output_features='col_a_label_le')
+    >>> label_encoder_tf = LabelEncoder(input_features = ['col_a'] , output_features='col_a_label_le')
     >>> # Convert output of Label Encoder to Data Frame instead of 1d-array
     >>> n_dim_array_to_df_tf = NDArrayToDataFrame('col_a_label_le')
     >>> n_dim_array_to_df_tf.fit_transform(label_encoder_tf.fit_transform(data['col_a']))

--- a/python/mleap/sklearn/preprocessing/tests.py
+++ b/python/mleap/sklearn/preprocessing/tests.py
@@ -365,7 +365,7 @@ class TransformerTests(unittest.TestCase):
 
         labels = ['a', 'b', 'c']
 
-        le = LabelEncoder(input_features='label_feature',
+        le = LabelEncoder(input_features=['label_feature'],
                   output_features='label_feature_le_encoded')
 
         le.fit(labels)
@@ -381,12 +381,20 @@ class TransformerTests(unittest.TestCase):
         self.assertEqual(le.op, model['op'])
         self.assertEqual('labels', model['attributes'].keys()[0])
 
+        # Test node.json
+        with open("{}/{}.node/node.json".format(self.tmp_dir, le.name)) as json_data:
+            node = json.load(json_data)
+
+        self.assertEqual(le.name, node['name'])
+        self.assertEqual(le.input_features[0], node['shape']['inputs'][0]['name'])
+        self.assertEqual(le.output_features, node['shape']['outputs'][0]['name'])
+
     def label_encoder_deserializer_test(self):
 
         labels = ['a', 'b', 'c']
 
         le = LabelEncoder(input_features=['label_feature'],
-                          output_features=['label_feature_le_encoded'])
+                          output_features='label_feature_le_encoded')
 
         le.fit(labels)
 
@@ -412,14 +420,14 @@ class TransformerTests(unittest.TestCase):
         self.assertEqual(res_a[1], res_b[1])
         self.assertEqual(res_a[2], res_b[2])
         self.assertEqual(le.input_features, label_encoder_tf.input_features)
-        self.assertEqual(le.output_features, label_encoder_tf.output_features)
+        self.assertEqual(le.output_features, label_encoder_tf.output_features[0])
 
     def one_hot_encoder_serializer_test(self):
 
         labels = ['a', 'b', 'c']
 
         le = LabelEncoder(input_features=['label_feature'],
-                          output_features=['label_feature_le_encoded'])
+                          output_features='label_feature_le_encoded')
 
         oh_data = le.fit_transform(labels).reshape(3, 1)
 
@@ -443,7 +451,7 @@ class TransformerTests(unittest.TestCase):
         labels = ['a', 'b', 'c']
 
         le = LabelEncoder(input_features=['label_feature'],
-                          output_features=['label_feature_le_encoded'])
+                          output_features='label_feature_le_encoded')
 
         oh_data = le.fit_transform(labels).reshape(3, 1)
 
@@ -453,10 +461,6 @@ class TransformerTests(unittest.TestCase):
         one_hot_encoder_tf.fit(oh_data)
 
         one_hot_encoder_tf.serialize_to_bundle(self.tmp_dir, one_hot_encoder_tf.name)
-
-        # Test model.json
-        with open("{}/{}.node/model.json".format(self.tmp_dir, one_hot_encoder_tf.name)) as json_data:
-            model = json.load(json_data)
 
         # Deserialize the OneHotEncoder
         node_name = "{}.node".format(one_hot_encoder_tf.name)
@@ -476,7 +480,7 @@ class TransformerTests(unittest.TestCase):
             node = json.load(json_data)
 
         self.assertEqual(one_hot_encoder_tf_ds.name, node['name'])
-        self.assertEqual(one_hot_encoder_tf_ds.input_features, node['shape']['inputs'][0]['name'])
+        self.assertEqual(one_hot_encoder_tf_ds.input_features[0], node['shape']['inputs'][0]['name'])
         self.assertEqual(one_hot_encoder_tf_ds.output_features, node['shape']['outputs'][0]['name'])
 
     def feature_extractor_test(self):
@@ -583,6 +587,14 @@ class TransformerTests(unittest.TestCase):
         self.assertEqual(expected_model['attributes']['threshold']['value'],
                          model['attributes']['threshold']['value'])
 
+        # Test node.json
+        with open("{}/{}.node/node.json".format(self.tmp_dir, binarizer.name)) as json_data:
+            node = json.load(json_data)
+
+        self.assertEqual(binarizer.name, node['name'])
+        self.assertEqual(binarizer.input_features, node['shape']['inputs'][0]['name'])
+        self.assertEqual(binarizer.output_features, node['shape']['outputs'][0]['name'])
+
     def binarizer_deserializer_test(self):
 
         binarizer = Binarizer(threshold=0.0)
@@ -609,14 +621,6 @@ class TransformerTests(unittest.TestCase):
         self.assertEqual(res_a[1][0], res_b[1][0])
         self.assertEqual(res_a[2][0], res_b[2][0])
         self.assertEqual(res_a[3][0], res_b[3][0])
-
-         # Test node.json
-        with open("{}/{}.node/node.json".format(self.tmp_dir, binarizer.name)) as json_data:
-            node = json.load(json_data)
-
-        self.assertEqual(binarizer.name, node['name'])
-        self.assertEqual(binarizer.input_features, node['shape']['inputs'][0]['name'])
-        self.assertEqual(binarizer.output_features, node['shape']['outputs'][0]['name'])
 
     def polynomial_expansion_test(self):
 
@@ -645,6 +649,14 @@ class TransformerTests(unittest.TestCase):
             model = json.load(json_data)
 
         self.assertEqual(expected_model['attributes']['degree']['value'], model['attributes']['degree']['value'])
+
+        # Test node.json
+        with open("{}/{}.node/node.json".format(self.tmp_dir, polynomial_exp.name)) as json_data:
+            node = json.load(json_data)
+
+        self.assertEqual(polynomial_exp.name, node['name'])
+        self.assertEqual(polynomial_exp.input_features, node['shape']['inputs'][0]['name'])
+        self.assertEqual(polynomial_exp.output_features, node['shape']['outputs'][0]['name'])
 
     def polynomial_expansion_deserializer_test(self):
 
@@ -675,13 +687,6 @@ class TransformerTests(unittest.TestCase):
         self.assertEqual(res_a[1][1], res_b[1][1])
         self.assertEqual(res_a[2][1], res_b[2][1])
         self.assertEqual(res_a[3][1], res_b[3][1])
-        # Test node.json
-        with open("{}/{}.node/node.json".format(self.tmp_dir, polynomial_exp.name)) as json_data:
-            node = json.load(json_data)
-
-        self.assertEqual(polynomial_exp.name, node['name'])
-        self.assertEqual(polynomial_exp.input_features, node['shape']['inputs'][0]['name'])
-        self.assertEqual(polynomial_exp.output_features, node['shape']['outputs'][0]['name'])
 
     def math_unary_exp_test(self):
 


### PR DESCRIPTION
#185 Updated LabelEncoder tests to make input_features an array and output_features a string, as required by mleap scoring as a result of having updated the mleap-demos
https://github.com/combust/mleap-demo/pull/7