### PR TITLE
Allow OneHotEncoder etc. to be copied

### DIFF
--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/feature/MathBinary.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/feature/MathBinary.scala
@@ -52,7 +52,8 @@ with MathBinaryParams {
     }
   }
 
-  override def copy(extra: ParamMap): Transformer = defaultCopy(extra)
+  override def copy(extra: ParamMap): Transformer =
+    copyValues(new MathBinary(uid, model), extra)
 
   @DeveloperApi
   override def transformSchema(schema: StructType): StructType = {

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/feature/MathUnary.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/feature/MathUnary.scala
@@ -29,7 +29,8 @@ class MathUnary(override val uid: String = Identifiable.randomUID("math_unary"),
     dataset.withColumn($(outputCol), unaryUdf(dataset($(inputCol)).cast(DoubleType)))
   }
 
-  override def copy(extra: ParamMap): Transformer = defaultCopy(extra)
+  override def copy(extra: ParamMap): Transformer =
+    copyValues(new MathUnary(uid, model), extra)
 
   @DeveloperApi
   override def transformSchema(schema: StructType): StructType = {

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/feature/MultinomialLabeler.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/feature/MultinomialLabeler.scala
@@ -40,7 +40,8 @@ class MultinomialLabeler(override val uid: String = Identifiable.randomUID("math
       withColumn($(labelsCol), labelsUdf(col($(featuresCol))))
   }
 
-  override def copy(extra: ParamMap): Transformer = defaultCopy(extra)
+  override def copy(extra: ParamMap): Transformer =
+    copyValues(new MultinomialLabeler(uid, model), extra)
 
   @DeveloperApi
   override def transformSchema(schema: StructType): StructType = {

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/feature/OneHotEncoder.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/feature/OneHotEncoder.scala
@@ -46,7 +46,8 @@ class OneHotEncoderModel(override val uid: String, val size: Int) extends Model[
   /** @group setParam */
   def setOutputCol(value: String): this.type = set(outputCol, value)
 
-  override def copy(extra: ParamMap): OneHotEncoderModel = defaultCopy(extra)
+  override def copy(extra: ParamMap): OneHotEncoderModel =
+    copyValues(new OneHotEncoderModel(uid, size), extra)
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     val indexMax = size

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/feature/StringMap.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/feature/StringMap.scala
@@ -31,7 +31,8 @@ class StringMap(override val uid: String,
     dataset.withColumn($(outputCol), stringMapUdf(dataset($(inputCol))))
   }
 
-  override def copy(extra: ParamMap): Transformer = defaultCopy(extra)
+  override def copy(extra: ParamMap): Transformer =
+    copyValues(new StringMap(uid, model), extra)
 
   @DeveloperApi
   override def transformSchema(schema: StructType): StructType = {


### PR DESCRIPTION
When we used the `OneHotEncoder` in some of our pipelines, we discovered it can't be copied (which e.g. `Estimator`s try to do) due to the `defaultCopy` method requiring a `(String)` constructor, which `OneHotEncoder` (and some of the other types) lack.

I've assumed here that this is not intentional, and updated the `copy` implementations to explicitly call an existing constructor in these cases.