### PR TITLE
Add in time created to bundle.json

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
@@ -1,7 +1,9 @@
 package ml.combust.bundle.dsl
 
 import java.nio.file.{FileSystem, Path}
+import java.time
 import java.util.UUID
+import java.time.LocalDateTime
 
 import ml.combust.mleap.BuildValues
 import ml.combust.bundle.{BundleContext, BundleRegistry}
@@ -104,7 +106,8 @@ object Bundle {
     apply(BundleInfo(uid = UUID.randomUUID(),
       name = name,
       format = format,
-      version = Bundle.version), root)
+      version = Bundle.version,
+      LocalDateTime.now()), root)
   }
 }
 
@@ -114,11 +117,13 @@ object Bundle {
   * @param name name of the bundle
   * @param format serialization format of the [[Bundle]]
   * @param version Bundle.ML version used for serializing
+  * @param timeCreated LocalDateTime when the model was created
   */
 case class BundleInfo(uid: UUID,
                       name: String,
                       format: SerializationFormat,
-                      version: String)
+                      version: String,
+                      timeCreated: LocalDateTime)
 
 /** Root object for serializing Bundle.ML pipelines and graphs.
   *

--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
@@ -107,7 +107,7 @@ object Bundle {
       name = name,
       format = format,
       version = Bundle.version,
-      LocalDateTime.now()), root)
+      LocalDateTime.now().toString), root)
   }
 }
 
@@ -123,7 +123,7 @@ case class BundleInfo(uid: UUID,
                       name: String,
                       format: SerializationFormat,
                       version: String,
-                      timeCreated: LocalDateTime)
+                      timeCreated: String)
 
 /** Root object for serializing Bundle.ML pipelines and graphs.
   *

--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
@@ -106,7 +106,7 @@ object Bundle {
       name = name,
       format = format,
       version = Bundle.version,
-      LocalDateTime.now().toString), root)
+      timeCreated = LocalDateTime.now().toString), root)
   }
 }
 

--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
@@ -1,7 +1,6 @@
 package ml.combust.bundle.dsl
 
 import java.nio.file.{FileSystem, Path}
-import java.time
 import java.util.UUID
 import java.time.LocalDateTime
 

--- a/bundle-ml/src/main/scala/ml/combust/bundle/json/JsonSupport.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/json/JsonSupport.scala
@@ -311,7 +311,7 @@ trait JsonSupportLowPriority {
 
   implicit def bundleModelFormat(implicit hr: HasBundleRegistry): RootJsonFormat[Model] = jsonFormat2(Model.apply)
   implicit val bundleNodeFormat: RootJsonFormat[Node] = jsonFormat2(Node.apply)
-  implicit val bundleBundleInfoFormat: RootJsonFormat[BundleInfo] = jsonFormat4(BundleInfo)
+  implicit val bundleBundleInfoFormat: RootJsonFormat[BundleInfo] = jsonFormat5(BundleInfo)
 }
 
 /** All spray.json.RootJsonFormat formats needed for Bundle.ML JSON serialization.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
 
   val sparkVersion = "2.1.0"
   val scalaTestVersion = "3.0.0"
-  val tensorflowVersion = "0.12.head"
+  val tensorflowVersion = "1.1.0"
   val akkaVersion = "2.4.16"
   val akkaHttpVersion = "10.0.3"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
 
   val sparkVersion = "2.1.0"
   val scalaTestVersion = "3.0.0"
-  val tensorflowVersion = "1.1.0"
+  val tensorflowVersion = "0.12.head"
   val akkaVersion = "2.4.16"
   val akkaHttpVersion = "10.0.3"
 

--- a/python/mleap/sklearn/pipeline.py
+++ b/python/mleap/sklearn/pipeline.py
@@ -22,7 +22,7 @@ import json
 import shutil
 import uuid
 import zipfile
-
+import datetime
 
 def serialize_to_bundle(self, path, model_name, init=False):
     serializer = SimpleSerializer()
@@ -126,6 +126,7 @@ class SimpleSerializer(object):
           "name": transformer.name,
           "format": "json",
           "version": __version__,
+          "timeCreated": datetime.datetime.now().isoformat(),
           "uid": "{}".format(uuid.uuid4())
         }
         return js


### PR DESCRIPTION
One of the use cases we've had  is keeping our models up to date on a nightly basis and having alerts for when they're X hours old. So I added a field to the bundle case class and have it auto populate when the bundle is being created. I also couldn't get this to build with the `0.12.head` version of tensorflow so I updated to the latest stable version and the unit tests passed. I can revert that if need be for the time stamp.