### PR TITLE
sync GBT Classifier with Spark 2.2

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Shape.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Shape.scala
@@ -171,7 +171,7 @@ case class Shape private (inputs: Seq[Socket],
     */
   def getInput(port: String): Option[Socket] = inputLookup.get(port)
 
-  /** Get an optional input by the port name. 
+  /** Get an optional output by the port name. 
     *
     * @param port name of the port 
     * @return optional socket for the named port 

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/classification/GBTClassifierModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/classification/GBTClassifierModel.scala
@@ -2,8 +2,9 @@ package ml.combust.mleap.core.classification
 
 import ml.combust.mleap.core.regression.DecisionTreeRegressionModel
 import ml.combust.mleap.core.tree.TreeEnsemble
+import ml.combust.mleap.core.tree.loss.LogLoss
 import org.apache.spark.ml.linalg.mleap.BLAS
-import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
 
 /** Companion object for constructing [[GBTClassifierModel]].
   */
@@ -18,19 +19,49 @@ object GBTClassifierModel {
 
 /** Class for a gradient boost classifier model.
   *
-  * @param trees trees in the gradient boost model
+  * @param trees       trees in the gradient boost model
   * @param treeWeights weights of each tree
   * @param numFeatures number of features
   */
 case class GBTClassifierModel(override val trees: Seq[DecisionTreeRegressionModel],
                               override val treeWeights: Seq[Double],
-                              numFeatures: Int) extends TreeEnsemble with Serializable {
+                              numFeatures: Int,
+                              override val thresholds: Option[Array[Double]] = None) extends ProbabilisticClassificationModel
+  with TreeEnsemble
+  with Serializable {
   private val treeWeightsVector = Vectors.dense(treeWeights.toArray)
+  // hard coded loss, which is not meant to be changed in the model
+  private val loss = LogLoss
 
-  def apply(features: Vector): Double = if(predictProbability(features) > 0.0) 1.0 else 0.0
+  // Multiclass labels are not currently supported
+  override val numClasses: Int = 2
 
-  def predictProbability(features: Vector): Double = {
+  override def predict(features: Vector): Double = {
+    if (thresholds.nonEmpty) {
+      super.predict(features)
+    } else {
+      if (margin(features) > 0.0) 1.0 else 0.0
+    }
+  }
+
+  /** Raw prediction for the positive class. */
+  def margin(features: Vector): Double = {
     val treePredictions = Vectors.dense(trees.map(_.predict(features)).toArray)
     BLAS.dot(treePredictions, treeWeightsVector)
+  }
+
+  override def rawToProbabilityInPlace(raw: Vector): Vector = {
+    raw match {
+      case dv: DenseVector =>
+        dv.values(0) = loss.computeProbability(dv.values(0))
+        dv.values(1) = 1.0 - dv.values(0)
+        dv
+      case sv: SparseVector => throw new RuntimeException("GBTClassificationModel encountered SparseVector")
+    }
+  }
+
+  override def predictRaw(features: Vector): Vector = {
+    val prediction: Double = margin(features)
+    Vectors.dense(Array(-prediction, prediction))
   }
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/linalg/LinalgUtils.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/linalg/LinalgUtils.scala
@@ -61,4 +61,12 @@ object LinalgUtils {
     }
     sqDist
   }
+
+  def log1pExp(x: Double): Double = {
+    if (x > 0) {
+      x + math.log1p(math.exp(-x))
+    } else {
+      math.log1p(math.exp(x))
+    }
+  }
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/regression/GeneralizedLinearRegressionModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/regression/GeneralizedLinearRegressionModel.scala
@@ -1,5 +1,6 @@
 package ml.combust.mleap.core.regression
 
+import breeze.numerics.erfinv
 import breeze.stats.{distributions => dist}
 import ml.combust.mleap.core.annotation.SparkCode
 import ml.combust.mleap.core.regression.GeneralizedLinearRegressionModel.FamilyAndLink
@@ -272,11 +273,13 @@ object GeneralizedLinearRegressionModel {
   }
 
   object Probit extends Link("probit") {
+    //TODO: use Gaussian#inverseCdf() from breeze 0.13 after updating to spark 2.2
+    private def icdf(mu:Double, sigma:Double, p:Double) = mu + sigma * math.sqrt(2.0) * erfinv(2 * p - 1)
 
-    override def link(mu: Double): Double = dist.Gaussian(0.0, 1.0).icdf(mu)
+    override def link(mu: Double): Double = icdf(0.0, 1.0, mu)
 
     override def deriv(mu: Double): Double = {
-      1.0 / dist.Gaussian(0.0, 1.0).pdf(dist.Gaussian(0.0, 1.0).icdf(mu))
+      1.0 / dist.Gaussian(0.0, 1.0).pdf(icdf(0.0, 1.0, mu))
     }
 
     override def unlink(eta: Double): Double = dist.Gaussian(0.0, 1.0).cdf(eta)

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/tree/loss/LogLoss.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/tree/loss/LogLoss.scala
@@ -1,0 +1,42 @@
+package ml.combust.mleap.core.tree.loss
+
+import ml.combust.mleap.core.annotation.SparkCode
+import ml.combust.mleap.core.linalg.LinalgUtils
+
+/**
+  * Class for log loss calculation (for classification).
+  * This uses twice the binomial negative log likelihood, called "deviance" in Friedman (1999).
+  *
+  * The log loss is defined as:
+  *   2 log(1 + exp(-2 y F(x)))
+  * where y is a label in {-1, 1} and F(x) is the model prediction for features x.
+  */
+@SparkCode(uri = "https://github.com/apache/spark/blob/branch-2.2/mllib/src/main/scala/org/apache/spark/mllib/tree/loss/Loss.scala")
+object LogLoss extends ClassificationLoss {
+
+  /**
+    * Method to calculate the loss gradients for the gradient boosting calculation for binary
+    * classification
+    * The gradient with respect to F(x) is: - 4 y / (1 + exp(2 y F(x)))
+    *
+    * @param prediction Predicted label.
+    * @param label True label.
+    * @return Loss gradient
+    */
+  override def gradient(prediction: Double, label: Double): Double = {
+    -4.0 * label / (1.0 + math.exp(2.0 * label * prediction))
+  }
+
+  override def computeError(prediction: Double, label: Double): Double = {
+    val margin = 2.0 * label * prediction
+    // The following is equivalent to 2.0 * log(1 + exp(-margin)) but more numerically stable.
+    2.0 * LinalgUtils.log1pExp(-margin)
+  }
+
+  /**
+    * Returns the estimated probability of a label of 1.0.
+    */
+  override def computeProbability(margin: Double): Double = {
+    1.0 / (1.0 + math.exp(-2.0 * margin))
+  }
+}

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/tree/loss/Loss.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/tree/loss/Loss.scala
@@ -1,0 +1,33 @@
+package ml.combust.mleap.core.tree.loss
+
+import ml.combust.mleap.core.annotation.SparkCode
+
+@SparkCode(uri = "https://github.com/apache/spark/blob/branch-2.2/mllib/src/main/scala/org/apache/spark/mllib/tree/loss/Loss.scala")
+trait Loss extends Serializable {
+  /**
+    * Method to calculate the gradients for the gradient boosting calculation.
+    *
+    * @param prediction Predicted feature
+    * @param label True label.
+    * @return Loss gradient.
+    */
+  def gradient(prediction: Double, label: Double): Double
+
+  /**
+    * Method to calculate loss when the predictions are already known.
+    *
+    * @param prediction Predicted label.
+    * @param label True label.
+    * @return Measure of model error on datapoint.
+    * @note This method is used in the method evaluateEachIteration to avoid recomputing the
+    *       predicted values from previously fit trees.
+    */
+  protected def computeError(prediction: Double, label: Double): Double
+}
+
+trait ClassificationLoss extends Loss {
+  /**
+    * Computes the class probability given the margin.
+    */
+  def computeProbability(margin: Double): Double
+}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/GBTClassifier.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/GBTClassifier.scala
@@ -1,12 +1,12 @@
 package ml.combust.mleap.runtime.transformer.classification
 
 import ml.combust.mleap.core.classification.GBTClassifierModel
+import ml.combust.mleap.core.util.VectorConverters._
 import ml.combust.mleap.runtime.function.UserDefinedFunction
 import ml.combust.mleap.runtime.transformer.Transformer
 import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.tensor.Tensor
-import ml.combust.mleap.core.util.VectorConverters._
 import ml.combust.mleap.runtime.types.{DoubleType, StructField, TensorType}
+import ml.combust.mleap.tensor.Tensor
 
 import scala.util.{Success, Try}
 
@@ -16,14 +16,51 @@ import scala.util.{Success, Try}
 case class GBTClassifier(override val uid: String = Transformer.uniqueName("gbt_classifier"),
                          featuresCol: String,
                          predictionCol: String,
+                         rawPredictionCol: Option[String] = None,
+                         probabilityCol: Option[String] = None,
                          model: GBTClassifierModel) extends Transformer {
-  val exec: UserDefinedFunction = (features: Tensor[Double]) => model(features)
+  val predictRaw: UserDefinedFunction = (features: Tensor[Double]) => model.predictRaw(features): Tensor[Double]
+  val rawToProbability: UserDefinedFunction = (raw: Tensor[Double]) => model.rawToProbability(raw): Tensor[Double]
+  val rawToPrediction: UserDefinedFunction = (raw: Tensor[Double]) => model.rawToPrediction(raw)
+  val probabilityToPrediction: UserDefinedFunction = (raw: Tensor[Double]) => model.probabilityToPrediction(raw)
+  val predictProbabilities: UserDefinedFunction = (features: Tensor[Double]) => model.predictProbabilities(features): Tensor[Double]
+  val predict: UserDefinedFunction = (features: Tensor[Double]) => model(features)
 
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withOutput(predictionCol, featuresCol)(exec)
+    (rawPredictionCol, probabilityCol) match {
+      case (Some(rp), Some(p)) =>
+        for (b <- builder.withOutput(rp, featuresCol)(predictRaw);
+             b2 <- b.withOutput(p, rp)(rawToProbability);
+             b3 <- b2.withOutput(predictionCol, p)(probabilityToPrediction)) yield b3
+      case ((Some(rp), None)) =>
+        for (b <- builder.withOutput(rp, featuresCol)(predictRaw);
+             b2 <- b.withOutput(predictionCol, rp)(rawToPrediction)) yield b2
+      case (None, Some(p)) =>
+        for (b <- builder.withOutput(p, featuresCol)(predictProbabilities);
+             b2 <- b.withOutput(predictionCol, p)(probabilityToPrediction)) yield b2
+      case (None, None) =>
+        builder.withOutput(predictionCol, featuresCol)(predict)
+    }
   }
 
-  override def getFields(): Try[Seq[StructField]] = Success(
-                Seq(StructField(featuresCol, TensorType(DoubleType())),
-                    StructField(predictionCol, DoubleType())))
+  override def getFields(): Try[Seq[StructField]] = {
+    (rawPredictionCol, probabilityCol) match {
+      case ((Some(rp), Some(p))) => Success(Seq(
+        StructField(featuresCol, TensorType(DoubleType())),
+        StructField(rp, TensorType(DoubleType())),
+        StructField(p, TensorType(DoubleType())),
+        StructField(predictionCol, DoubleType())))
+      case ((Some(rp), None)) => Success(Seq(
+        StructField(featuresCol, TensorType(DoubleType())),
+        StructField(rp, TensorType(DoubleType())),
+        StructField(predictionCol, DoubleType())))
+      case (None, Some(p)) => Success(Seq(
+        StructField(featuresCol, TensorType(DoubleType())),
+        StructField(p, TensorType(DoubleType())),
+        StructField(predictionCol, DoubleType())))
+      case (None, None) => Success(Seq(
+        StructField(featuresCol, TensorType(DoubleType())),
+        StructField(predictionCol, DoubleType())))
+    }
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/GBTClassifier.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/GBTClassifier.scala
@@ -22,7 +22,7 @@ case class GBTClassifier(override val uid: String = Transformer.uniqueName("gbt_
   val predictRaw: UserDefinedFunction = (features: Tensor[Double]) => model.predictRaw(features): Tensor[Double]
   val rawToProbability: UserDefinedFunction = (raw: Tensor[Double]) => model.rawToProbability(raw): Tensor[Double]
   val rawToPrediction: UserDefinedFunction = (raw: Tensor[Double]) => model.rawToPrediction(raw)
-  val probabilityToPrediction: UserDefinedFunction = (raw: Tensor[Double]) => model.probabilityToPrediction(raw)
+  val probabilityToPrediction: UserDefinedFunction = (probability: Tensor[Double]) => model.probabilityToPrediction(probability)
   val predictProbabilities: UserDefinedFunction = (features: Tensor[Double]) => model.predictProbabilities(features): Tensor[Double]
   val predict: UserDefinedFunction = (features: Tensor[Double]) => model(features)
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/GBTClassifierSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/GBTClassifierSpec.scala
@@ -11,17 +11,18 @@ import org.scalatest.FunSpec
   * Created by hollinwilkins on 9/28/16.
   */
 class GBTClassifierSpec extends FunSpec {
-  val schema = StructType(Seq(StructField("features", TensorType(DoubleType())))).get
-  val dataset = LocalDataset(Seq(Row(Tensor.denseVector(Array(0.2, 0.7, 0.4)))))
-  val frame = LeapFrame(schema, dataset)
-  val tree1 = TestUtil.buildDecisionTreeRegression(0.5, 0, goLeft = true)
-  val tree2 = TestUtil.buildDecisionTreeRegression(0.75, 1, goLeft = false)
-  val tree3 = TestUtil.buildDecisionTreeRegression(0.1, 2, goLeft = true)
-  val gbt = GBTClassifier(featuresCol = "features",
-    predictionCol = "prediction",
-    model = GBTClassifierModel(Seq(tree1, tree2, tree3), Seq(0.5, 2.0, 1.0), 5))
 
   describe("#transform") {
+    val schema = StructType(Seq(StructField("features", TensorType(DoubleType())))).get
+    val dataset = LocalDataset(Seq(Row(Tensor.denseVector(Array(0.2, 0.7, 0.4)))))
+    val frame = LeapFrame(schema, dataset)
+    val tree1 = TestUtil.buildDecisionTreeRegression(0.5, 0, goLeft = true)
+    val tree2 = TestUtil.buildDecisionTreeRegression(0.75, 1, goLeft = false)
+    val tree3 = TestUtil.buildDecisionTreeRegression(0.1, 2, goLeft = true)
+    val gbt = GBTClassifier(featuresCol = "features",
+      predictionCol = "prediction",
+      model = GBTClassifierModel(Seq(tree1, tree2, tree3), Seq(0.5, 2.0, 1.0), 5))
+
     it("uses the GBT to make predictions on the features column") {
       val frame2 = gbt.transform(frame).get
       val prediction = frame2.dataset(0).getDouble(1)
@@ -38,9 +39,35 @@ class GBTClassifierSpec extends FunSpec {
 
   describe("#getFields") {
     it("has the correct inputs and outputs") {
+      val gbt = GBTClassifier(featuresCol = "features", predictionCol = "prediction", model = null)
       assert(gbt.getFields().get ==
         Seq(StructField("features", TensorType(DoubleType())),
             StructField("prediction", DoubleType())))
+    }
+
+    it("has the correct inputs and outputs with probability column") {
+      val gbt = GBTClassifier(featuresCol = "features", predictionCol = "prediction", model = null, probabilityCol = Some("probability"))
+      assert(gbt.getFields().get ==
+        Seq(StructField("features", TensorType(DoubleType())),
+          StructField("probability", TensorType(DoubleType())),
+          StructField("prediction", DoubleType())))
+    }
+
+    it("has the correct inputs and outputs with rawPrediction column") {
+      val gbt = GBTClassifier(featuresCol = "features", predictionCol = "prediction", model = null, rawPredictionCol = Some("rawPrediction"))
+      assert(gbt.getFields().get ==
+        Seq(StructField("features", TensorType(DoubleType())),
+          StructField("rawPrediction", TensorType(DoubleType())),
+          StructField("prediction", DoubleType())))
+    }
+
+    it("has the correct inputs and outputs with both probability and rawPrediction columns") {
+      val gbt = GBTClassifier(featuresCol = "features", predictionCol = "prediction", model = null, probabilityCol = Some("probability"), rawPredictionCol = Some("rawPrediction"))
+      assert(gbt.getFields().get ==
+        Seq(StructField("features", TensorType(DoubleType())),
+          StructField("rawPrediction", TensorType(DoubleType())),
+          StructField("probability", TensorType(DoubleType())),
+          StructField("prediction", DoubleType())))
     }
   }
 }

--- a/mleap-spark/src/main/resources/reference.conf
+++ b/mleap-spark/src/main/resources/reference.conf
@@ -1,10 +1,19 @@
 ml.combust.mleap.spark.registry.v20-ops = [
+  "org.apache.spark.ml.bundle.ops.classification.GBTClassifierOpV20",
   "org.apache.spark.ml.bundle.ops.classification.LogisticRegressionOpV20"
 ]
 
 ml.combust.mleap.spark.registry.v21-ops = [
   "org.apache.spark.ml.bundle.ops.feature.MinHashLSHOp",
   "org.apache.spark.ml.bundle.ops.feature.BucketedRandomProjectionLSHOp",
+  "org.apache.spark.ml.bundle.ops.classification.GBTClassifierOpV20",
+  "org.apache.spark.ml.bundle.ops.classification.LogisticRegressionOpV21"
+]
+
+ml.combust.mleap.spark.registry.v22-ops = [
+  "org.apache.spark.ml.bundle.ops.feature.MinHashLSHOp",
+  "org.apache.spark.ml.bundle.ops.feature.BucketedRandomProjectionLSHOp",
+  "org.apache.spark.ml.bundle.ops.classification.GBTClassifierOpV22",
   "org.apache.spark.ml.bundle.ops.classification.LogisticRegressionOpV21"
 ]
 
@@ -20,11 +29,16 @@ ml.combust.mleap.spark.registry.v21 = {
   custom-types = []
 }
 
+ml.combust.mleap.spark.registry.v22 = {
+  ops = ["ml.combust.mleap.spark.registry.base-ops",
+    "ml.combust.mleap.spark.registry.v22-ops"]
+  custom-types = []
+}
+
 ml.combust.mleap.spark.registry.default = ${ml.combust.mleap.spark.registry.v20}
 
 ml.combust.mleap.spark.registry.base-ops = [
   "org.apache.spark.ml.bundle.ops.classification.DecisionTreeClassifierOp",
-  "org.apache.spark.ml.bundle.ops.classification.GBTClassifierOp",
   "org.apache.spark.ml.bundle.ops.classification.NaiveBayesClassifierOp",
   "org.apache.spark.ml.bundle.ops.classification.MultiLayerPerceptronClassifierOp",
   "org.apache.spark.ml.bundle.ops.classification.OneVsRestOp",

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/GBTClassifierOpV20.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/GBTClassifierOpV20.scala
@@ -11,7 +11,7 @@ import org.apache.spark.ml.regression.DecisionTreeRegressionModel
 /**
   * Created by hollinwilkins on 9/24/16.
   */
-class GBTClassifierOp extends OpNode[SparkBundleContext, GBTClassificationModel, GBTClassificationModel] {
+class GBTClassifierOpV20 extends OpNode[SparkBundleContext, GBTClassificationModel, GBTClassificationModel] {
   override val Model: OpModel[SparkBundleContext, GBTClassificationModel] = new OpModel[SparkBundleContext, GBTClassificationModel] {
     override val klazz: Class[GBTClassificationModel] = classOf[GBTClassificationModel]
 
@@ -35,7 +35,7 @@ class GBTClassifierOp extends OpNode[SparkBundleContext, GBTClassificationModel,
 
     override def load(model: Model)
                      (implicit context: BundleContext[SparkBundleContext]): GBTClassificationModel = {
-      if(model.value("num_classes").getLong != 2) {
+      if (model.value("num_classes").getLong != 2) {
         throw new IllegalArgumentException("MLeap only supports binary logistic regression")
       }
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/GBTClassifierOpV22.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/GBTClassifierOpV22.scala
@@ -1,0 +1,91 @@
+package org.apache.spark.ml.bundle.ops.classification
+
+import ml.combust.bundle.BundleContext
+import ml.combust.bundle.dsl._
+import ml.combust.bundle.op.{OpModel, OpNode}
+import ml.combust.bundle.serializer.ModelSerializer
+import org.apache.spark.ml.bundle.SparkBundleContext
+import org.apache.spark.ml.classification.GBTClassificationModel
+import org.apache.spark.ml.regression.DecisionTreeRegressionModel
+
+/**
+  * Created by hollinwilkins on 9/24/16.
+  */
+class GBTClassifierOpV22 extends OpNode[SparkBundleContext, GBTClassificationModel, GBTClassificationModel] {
+  override val Model: OpModel[SparkBundleContext, GBTClassificationModel] = new OpModel[SparkBundleContext, GBTClassificationModel] {
+    override val klazz: Class[GBTClassificationModel] = classOf[GBTClassificationModel]
+
+    override def opName: String = Bundle.BuiltinOps.classification.gbt_classifier
+
+    override def store(model: Model, obj: GBTClassificationModel)
+                      (implicit context: BundleContext[SparkBundleContext]): Model = {
+      var i = 0
+      val trees = obj.trees.map {
+        tree =>
+          val name = s"tree$i"
+          ModelSerializer(context.bundleContext(name)).write(tree).get
+          i = i + 1
+          name
+      }
+      model.withAttr("num_features", Value.long(obj.numFeatures)).
+        withAttr("num_classes", Value.long(2)).
+        withAttr("tree_weights", Value.doubleList(obj.treeWeights)).
+        withAttr("trees", Value.stringList(trees)).
+        withAttr("thresholds", obj.get(obj.thresholds).map(Value.doubleList(_)))
+    }
+
+    override def load(model: Model)
+                     (implicit context: BundleContext[SparkBundleContext]): GBTClassificationModel = {
+      if (model.value("num_classes").getLong != 2) {
+        throw new IllegalArgumentException("MLeap only supports binary logistic regression")
+      }
+
+      val numFeatures = model.value("num_features").getLong.toInt
+      val treeWeights = model.value("tree_weights").getDoubleList.toArray
+
+      val models = model.value("trees").getStringList.map {
+        tree => ModelSerializer(context.bundleContext(tree)).read().get.asInstanceOf[DecisionTreeRegressionModel]
+      }.toArray
+
+      val gbt = new GBTClassificationModel(uid = "",
+        _trees = models,
+        _treeWeights = treeWeights,
+        numFeatures = numFeatures)
+
+      model.getValue("thresholds")
+        .map(t => gbt.setThresholds(t.getDoubleList.toArray))
+        .getOrElse(gbt)
+    }
+  }
+
+  override val klazz: Class[GBTClassificationModel] = classOf[GBTClassificationModel]
+
+  override def name(node: GBTClassificationModel): String = node.uid
+
+  override def model(node: GBTClassificationModel): GBTClassificationModel = node
+
+  override def load(node: Node, model: GBTClassificationModel)
+                   (implicit context: BundleContext[SparkBundleContext]): GBTClassificationModel = {
+    val gbt = new GBTClassificationModel(uid = node.name,
+      _trees = model.trees,
+      _treeWeights = model.treeWeights,
+      numFeatures = model.numFeatures).
+      setFeaturesCol(node.shape.input("features").name).
+      setPredictionCol(node.shape.output("prediction").name)
+
+    node.shape.getOutput("rawPrediction").map(rp => gbt.setRawPredictionCol(rp.name))
+    node.shape.getOutput("probability").map(p => gbt.setProbabilityCol(p.name))
+    gbt
+  }
+
+  override def shape(node: GBTClassificationModel): Shape = {
+    val rawPrediction = if(node.isDefined(node.rawPredictionCol)) Some(node.getRawPredictionCol) else None
+    val probability = if(node.isDefined(node.probabilityCol)) Some(node.getProbabilityCol) else None
+
+    Shape().withInput(node.getFeaturesCol, "features").
+      withOutput(node.getPredictionCol, "prediction").
+      withOutput(rawPrediction, "rawPrediction").
+      withOutput(probability, "probability")
+  }
+
+}

--- a/mleap-spark/src/test/resources/reference.conf
+++ b/mleap-spark/src/test/resources/reference.conf
@@ -1,1 +1,1 @@
-ml.combust.mleap.spark.registry.default = ${ml.combust.mleap.spark.registry.v21}
+ml.combust.mleap.spark.registry.default = ${ml.combust.mleap.spark.registry.v22}

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/classification/GBTClassifierParityV22Spec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/classification/GBTClassifierParityV22Spec.scala
@@ -1,0 +1,31 @@
+package org.apache.spark.ml.parity.classification
+
+import org.apache.spark.ml.classification.GBTClassifier
+import org.apache.spark.ml.feature.{StringIndexer, VectorAssembler}
+import org.apache.spark.ml.parity.SparkParityBase
+import org.apache.spark.ml.{Pipeline, Transformer}
+import org.apache.spark.sql._
+
+/**
+  * Created by hollinwilkins on 10/30/16.
+  */
+class GBTClassifierParityV22Spec extends SparkParityBase {
+  override val dataset: DataFrame = baseDataset.select("fico_score_group_fnl", "dti", "approved")
+  override val sparkTransformer: Transformer = new Pipeline().setStages(Array(new StringIndexer().
+    setInputCol("fico_score_group_fnl").
+    setOutputCol("fico_index"),
+    new VectorAssembler().
+      setInputCols(Array("fico_index", "dti")).
+      setOutputCol("features"),
+    new StringIndexer().
+      setInputCol("approved").
+      setOutputCol("label"),
+    new GBTClassifier().
+      setFeaturesCol("features").
+      setLabelCol("label").
+      setThresholds(Array(1.0, 1.0)).
+      setProbabilityCol("myProbability").
+      setPredictionCol("myPrediction").
+      setRawPredictionCol("myRawPrediction")
+  )).fit(dataset)
+}

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -24,7 +24,10 @@ object Common {
     resolvers ++= {
       // Only add Sonatype Snapshots if this version itself is a snapshot version
       if(isSnapshot.value) {
-        Seq("Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
+        Seq(
+          "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
+          "ASF Snapshots" at "https://repository.apache.org/content/groups/snapshots"
+        )
       } else {
         Seq()
       }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ import Keys._
 object Dependencies {
   import DependencyHelpers._
 
-  val sparkVersion = "2.2.0-SNAPSHOT"
+  val sparkVersion = "2.2.0"
   val scalaTestVersion = "3.0.0"
   val tensorflowVersion = "1.1.0"
   val akkaVersion = "2.4.16"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,9 +6,9 @@ import Keys._
 object Dependencies {
   import DependencyHelpers._
 
-  val sparkVersion = "2.1.0"
+  val sparkVersion = "2.2.0-SNAPSHOT"
   val scalaTestVersion = "3.0.0"
-  val tensorflowVersion = "0.12.head"
+  val tensorflowVersion = "1.1.0"
   val akkaVersion = "2.4.16"
   val akkaHttpVersion = "10.0.3"
 


### PR DESCRIPTION
- add rawPrediction and probability columns to GBT Classifier
- add loss functions for probabilistic classifiers
- move `log1pExp` to LinalgUtils
- fix for breeze Gaussian usage
- add reference config for spark 2.2
- update spark to 2.2.0-SNAPSHOT
- update tensorflow to 1.1.0