### PR TITLE
update local maven repo with SBT internal representation

### DIFF
--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/util/LeapFrameShow.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/util/LeapFrameShow.scala
@@ -14,11 +14,11 @@ case class LeapFrameShow[LF <: LeapFrame[LF]](frame: LF, n: Int = 20, truncate: 
     val rows = schema.fields.map(_.name) +: dataset.take(n).toSeq.map {
       _.map {
         cell =>
-          val str = cell match {
+          val str = if (cell != null) cell match {
             case v: Option[_] => v.map(_.toString).getOrElse("null")
             case v: Seq[_] => v.mkString("[", ",", "]")
             case v => v.toString
-          }
+          }else "null"
 
           if (truncate > 0 && str.length > truncate) {
             // do not show ellipses for strings shorter than 4 characters.

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -20,7 +20,7 @@ object Common {
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
     fork in Test := true,
     javaOptions in test += sys.env.getOrElse("JVM_OPTS", ""),
-    resolvers += "Local Maven Repository" at "file://" + Path.userHome.absolutePath + "/.m2/repository",
+    resolvers += Resolver.mavenLocal,
     resolvers ++= {
       // Only add Sonatype Snapshots if this version itself is a snapshot version
       if(isSnapshot.value) {


### PR DESCRIPTION
Fix for LeapFrameShow in case the frame contains null values.

Without the fix the below piece of code will fail with NPE: 

      val leapSchema = types.StructType(
        types.StructField("id", types.ByteType(true)),
        types.StructField("hour", types.ByteType(true)),
        types.StructField("mobile", types.FloatType(true)),
        types.StructField("userFeatures", types.TensorType(types.DoubleType(true), true)),
        types.StructField("clicked", types.DoubleType(true)),
        types.StructField("stringField", types.StringType(true)),
        types.StructField("stringField2", types.StringType(true))).get

      val validationData = LocalDataset(Array(ml.combust.mleap.runtime.Row(3.toByte, null, null, VectorConverters.sparkVectorToMleapTensor(Vectors.dense(2.0, 10.0, 0.5)), null, null, "testField2_4")))
      val frame = LeapFrame(leapSchema, validationData)
      frame.show()


Fix for Maven local repo client : 
If someone wants to build mleap project in windows using sbt command line will receive a failure with message "URI has an authority component". 
This can be fixed by adding double slash on file:// scheme
(e.g. "Local Maven Repository" at "file:////" + Path.userHome.absolutePath + "/.m2/repository", )
but this will fail on importing the project in some IDE (e.g. IntelliJ Idea ).
So the best way to fix both cases (sbt command line build and IDE import ) is to use sbt representation of local maven repo