### PR TITLE
Fix up basic type serialization to JSON.

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/json/JsonSupport.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/json/JsonSupport.scala
@@ -129,7 +129,7 @@ trait JsonSupport {
       if(obj.s != "") { fb += ("string" -> obj.s.toJson) }
       if(obj.bs != ByteString.EMPTY) { fb += ("byte_string" -> obj.bs.toJson) }
       obj.t.foreach(t => fb += ("tensor" -> t.toJson))
-      if(obj.bt != BasicType.BOOLEAN) { fb += ("byte_string" -> obj.bt.toJson) }
+      if(obj.bt != BasicType.BOOLEAN) { fb += ("basic_type" -> obj.bt.toJson) }
       obj.ds.foreach(ds => fb += ("data_shape" -> ds.toJson))
       obj.m.foreach(m => fb += ("model" -> m.toJson))
 


### PR DESCRIPTION
Basic type was being serialized as a byte_string, leading to issues when users need to serialize it for their models.