### PR TITLE
Fix null string mleap -> spark type conversion.

### DIFF
--- a/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
+++ b/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
@@ -81,6 +81,7 @@ trait TypeConverters {
   }
 
   def mleapToSparkValue(dataType: types.DataType): (Any) => Any = dataType match {
+    case types.ScalarType(BasicType.String, true) => (v: Any) => v.asInstanceOf[Option[String]].orNull
     case types.ScalarType(_, true) => (v: Any) => v.asInstanceOf[Option[Any]].get
     case tt: types.TensorType =>
       if(tt.dimensions.isEmpty) {


### PR DESCRIPTION
This fixes an issue where None: Option[String] is not properly converted back to a null value when going from a SparkLeapFrame back to a Spark DataFrame.