### PR TITLE
Handle null values like Spark does

### DIFF
--- a/mleap-avro/src/main/scala/ml/combust/mleap/avro/DefaultFrameWriter.scala
+++ b/mleap-avro/src/main/scala/ml/combust/mleap/avro/DefaultFrameWriter.scala
@@ -31,7 +31,7 @@ class DefaultFrameWriter[LF <: LeapFrame[LF]](frame: LF) extends FrameWriter {
       for(row <- frame.dataset.toArray) {
         var i = 0
         for(writer <- writers) {
-          record.put(i, writer(row(i)))
+          record.put(i, writer(row.getRaw(i)))
           i = i + 1
         }
 

--- a/mleap-avro/src/main/scala/ml/combust/mleap/avro/DefaultRowWriter.scala
+++ b/mleap-avro/src/main/scala/ml/combust/mleap/avro/DefaultRowWriter.scala
@@ -31,7 +31,7 @@ class DefaultRowWriter(override val schema: StructType) extends RowWriter {
 
       var i = 0
       for(writer <- writers) {
-        record.put(i, writer(row(i)))
+        record.put(i, writer(row.getRaw(i)))
         i = i + 1
       }
       datumWriter.write(record, encoder)

--- a/mleap-avro/src/main/scala/ml/combust/mleap/avro/SchemaConverter.scala
+++ b/mleap-avro/src/main/scala/ml/combust/mleap/avro/SchemaConverter.scala
@@ -98,7 +98,7 @@ object SchemaConverter {
     case st: ScalarType => maybeNullableAvroType(mleapBasicToAvroType(st.base), st.isNullable)
     case lt: ListType => maybeNullableAvroType(Schema.createArray(mleapBasicToAvroType(lt.base)), lt.isNullable)
     case tt: TensorType =>
-      val ts = tt.base match {
+      tt.base match {
         case BasicType.Boolean => booleanTensorSchema
         case BasicType.Byte => byteTensorSchema
         case BasicType.Short => shortTensorSchema
@@ -110,7 +110,6 @@ object SchemaConverter {
         case BasicType.ByteString => byteStringTensorSchema
         case _ => throw new IllegalArgumentException(s"invalid type ${tt.base}")
       }
-      maybeNullableAvroType(ts, tt.isNullable)
     case _ => throw new IllegalArgumentException(s"invalid data type: $dataType")
   }
 

--- a/mleap-avro/src/main/scala/ml/combust/mleap/avro/ValueConverter.scala
+++ b/mleap-avro/src/main/scala/ml/combust/mleap/avro/ValueConverter.scala
@@ -19,7 +19,7 @@ case class ValueConverter() {
     val simple = mleapToAvroSimple(dataType)
 
     if(dataType.isNullable) {
-      (v: Any) => v.asInstanceOf[Option[Any]].map(simple).orNull
+      (v: Any) => Option(v).map(simple).orNull
     } else { simple }
   }
 
@@ -62,7 +62,7 @@ case class ValueConverter() {
   def avroToMleap(dataType: DataType): (Any) => Any = if(dataType.isNullable) {
     val simple = avroToMleapSimple(dataType)
 
-    (v) => Option[Any](v).map(simple)
+    (v) => Option[Any](v).map(simple).orNull
   } else { avroToMleapSimple(dataType) }
 
   def avroToMleapSimple(dataType: DataType): (Any) => Any = dataType match {

--- a/mleap-avro/src/test/scala/ml/combust/mleap/avro/DefaultFrameSerializerSpec.scala
+++ b/mleap-avro/src/test/scala/ml/combust/mleap/avro/DefaultFrameSerializerSpec.scala
@@ -28,7 +28,7 @@ class DefaultFrameSerializerSpec extends FunSpec {
     Tensor.denseVector(Array[Byte](1, 2, 3, 4)),
     Tensor.denseVector(Array[Short](16, 45, 78)),
     ByteString(Array[Byte](1, 2, 3, 4, 5)),
-    None)
+    null)
   val dataset = LocalDataset(Seq(row))
   val frame = LeapFrame(schema, dataset)
 

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/classification/ClassificationModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/classification/ClassificationModel.scala
@@ -101,5 +101,5 @@ trait ProbabilisticClassificationModel extends ClassificationModel {
 
   override def outputSchema: StructType = StructType("raw_prediction" -> TensorType.Double(numClasses),
     "probability" -> TensorType.Double(numClasses),
-    "prediction" -> ScalarType.Double).get
+    "prediction" -> ScalarType.Double.nonNullable).get
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/classification/MultiLayerPerceptronClassifierModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/classification/MultiLayerPerceptronClassifierModel.scala
@@ -52,7 +52,7 @@ case class MultiLayerPerceptronClassifierModel(layers: Seq[Int],
   val numFeatures: Int = layers.head
 
   private val mlpModel = FeedForwardTopology
-    .multiLayerPerceptron(layers.toArray, softmaxOnTop = true)
+    .multiLayerPerceptron(layers.toArray)
     .model(weights)
 
   def apply(features: Vector): Double = {
@@ -61,5 +61,5 @@ case class MultiLayerPerceptronClassifierModel(layers: Seq[Int],
 
   override def inputSchema: StructType = StructType("features" -> TensorType.Double(numFeatures)).get
 
-  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Double).get
+  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Double.nonNullable).get
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/clustering/BisectingKMeansModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/clustering/BisectingKMeansModel.scala
@@ -24,7 +24,7 @@ case class BisectingKMeansModel(root: ClusteringTreeNode) extends Model {
 
   override def inputSchema: StructType = StructType("features" -> TensorType.Double(numFeatures)).get
 
-  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Int).get
+  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Int.nonNullable).get
 }
 
 @SparkCode(uri = "https://github.com/apache/spark/blob/v2.0.0/mllib/src/main/scala/org/apache/spark/mllib/clustering/BisectingKMeansModel.scala")

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/clustering/GaussianMixtureModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/clustering/GaussianMixtureModel.scala
@@ -56,6 +56,6 @@ case class GaussianMixtureModel(gaussians: Array[MultivariateGaussian],
 
   override def inputSchema: StructType = StructType("features" -> TensorType.Double(numFeatures)).get
 
-  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Int,
+  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Int.nonNullable,
     "probability" -> TensorType.Double(numClusters)).get
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/clustering/KMeansModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/clustering/KMeansModel.scala
@@ -50,5 +50,5 @@ case class KMeansModel(clusterCenters: Array[VectorWithNorm], numFeatures: Int) 
 
   override def inputSchema: StructType = StructType("features" -> TensorType.Double(numFeatures)).get
 
-  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Int).get
+  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Int.nonNullable).get
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/BinarizerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/BinarizerModel.scala
@@ -33,10 +33,10 @@ case class BinarizerModel(threshold: Double,
   }
 
   override def inputSchema: StructType = {
-    StructType("input" -> DataType(BasicType.Double, inputShape)).get
+    StructType("input" -> DataType(BasicType.Double, inputShape).setNullable(!inputShape.isScalar)).get
   }
 
   override def outputSchema: StructType = {
-    StructType("output" -> DataType(BasicType.Double, inputShape)).get
+    StructType("output" -> DataType(BasicType.Double, inputShape).setNullable(!inputShape.isScalar)).get
   }
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/BucketizerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/BucketizerModel.scala
@@ -36,7 +36,7 @@ case class BucketizerModel(splits: Array[Double]) extends Model {
     }
   }
 
-  override def inputSchema: StructType = StructType("input" -> ScalarType.Double).get
+  override def inputSchema: StructType = StructType("input" -> ScalarType.Double.nonNullable).get
 
-  override def outputSchema: StructType = StructType("output" -> ScalarType.Double).get
+  override def outputSchema: StructType = StructType("output" -> ScalarType.Double.nonNullable).get
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/CoalesceModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/CoalesceModel.scala
@@ -7,18 +7,17 @@ import ml.combust.mleap.core.types.{ScalarType, StructField, StructType}
   * Created by hollinwilkins on 1/5/17.
   */
 case class CoalesceModel(nullableInputs: Seq[Boolean]) extends Model {
-  def apply(values: Any *): Option[Double] = {
+  def apply(values: Any *): java.lang.Double = {
     var i = 0
     while(i < values.size) {
-      values(i) match {
-        case value: Double => return Some(value)
-        case Some(value: Double) => return Some(value)
+      Option(values(i)) match {
+        case Some(value) => return value.asInstanceOf[Double]
         case None => // next
       }
       i += 1
     }
 
-    None
+    null
   }
 
   override def inputSchema: StructType = {

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/CoalesceModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/CoalesceModel.scala
@@ -28,5 +28,5 @@ case class CoalesceModel(nullableInputs: Seq[Boolean]) extends Model {
     StructType(is).get
   }
 
-  override def outputSchema: StructType = StructType(StructField("output", ScalarType.Double.asNullable)).get
+  override def outputSchema: StructType = StructType(StructField("output", ScalarType.Double)).get
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/ImputerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/ImputerModel.scala
@@ -9,7 +9,7 @@ import ml.combust.mleap.core.types.{BasicType, ScalarType, StructField, StructTy
 case class ImputerModel(surrogateValue: Double,
                         missingValue: Double,
                         strategy: String,
-                        nullableInput: Boolean = false) extends Model {
+                        nullableInput: Boolean = true) extends Model {
   def predictAny(value: Any): Double = value match {
     case value: Double => apply(value)
     case value: Option[_] => apply(value.asInstanceOf[Option[Double]])

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/ImputerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/ImputerModel.scala
@@ -20,5 +20,5 @@ case class ImputerModel(surrogateValue: Double,
 
   override def inputSchema: StructType = StructType(StructField("input" -> ScalarType(BasicType.Double, nullableInput))).get
 
-  override def outputSchema: StructType = StructType(StructField("output" -> ScalarType.Double)).get
+  override def outputSchema: StructType = StructType(StructField("output" -> ScalarType.Double.nonNullable)).get
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/ImputerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/ImputerModel.scala
@@ -10,18 +10,12 @@ case class ImputerModel(surrogateValue: Double,
                         missingValue: Double,
                         strategy: String,
                         nullableInput: Boolean = true) extends Model {
-  def predictAny(value: Any): Double = value match {
-    case value: Double => apply(value)
-    case value: Option[_] => apply(value.asInstanceOf[Option[Double]])
-  }
-
   def apply(value: Double): Double = {
     if(value.isNaN || value == missingValue) surrogateValue else value
   }
 
-  def apply(value: Option[Double]): Double = value match {
-    case Some(v) => apply(v)
-    case None => surrogateValue
+  def apply(value: java.lang.Double): Double = {
+    Option(value).map(v => apply(v: Double)).getOrElse(surrogateValue)
   }
 
   override def inputSchema: StructType = StructType(StructField("input" -> ScalarType(BasicType.Double, nullableInput))).get

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/MathBinaryModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/MathBinaryModel.scala
@@ -60,13 +60,13 @@ case class MathBinaryModel(operation: BinaryOperation,
   override def inputSchema: StructType = {
     (da, db) match {
       case (Some(a), Some(b)) => StructType.empty.get
-      case (Some(a), None) => StructType("input_b" -> ScalarType.Double).get
-      case (None, Some(b)) => StructType("input_a" -> ScalarType.Double).get
-      case (None, None) => StructType("input_a" -> ScalarType.Double,
-        "input_b" -> ScalarType.Double).get
+      case (Some(a), None) => StructType("input_b" -> ScalarType.Double.nonNullable).get
+      case (None, Some(b)) => StructType("input_a" -> ScalarType.Double.nonNullable).get
+      case (None, None) => StructType("input_a" -> ScalarType.Double.nonNullable,
+        "input_b" -> ScalarType.Double.nonNullable).get
     }
   }
 
   override def outputSchema: StructType = StructType(
-    "output" -> ScalarType.Double).get
+    "output" -> ScalarType.Double.nonNullable).get
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/MathUnaryModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/MathUnaryModel.scala
@@ -47,8 +47,8 @@ case class MathUnaryModel(operation: UnaryOperation) extends Model {
   }
 
   override def inputSchema: StructType = StructType(
-    "input" -> ScalarType.Double).get
+    "input" -> ScalarType.Double.nonNullable).get
 
   override def outputSchema: StructType = StructType(
-    "output" -> ScalarType.Double).get
+    "output" -> ScalarType.Double.nonNullable).get
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/OneHotEncoderModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/OneHotEncoderModel.scala
@@ -38,7 +38,7 @@ case class OneHotEncoderModel(size: Int,
     }
   }
 
-  override def inputSchema: StructType = StructType("input" -> ScalarType.Double).get
+  override def inputSchema: StructType = StructType("input" -> ScalarType.Double.nonNullable).get
 
   override def outputSchema: StructType = StructType("output" -> TensorType.Double(size)).get
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/ReverseStringIndexerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/ReverseStringIndexerModel.scala
@@ -20,7 +20,7 @@ case class ReverseStringIndexerModel(labels: Seq[String]) extends Model {
     */
   def apply(index: Int): String = indexToString(index)
 
-  override def inputSchema: StructType = StructType("input" -> ScalarType.Double).get
+  override def inputSchema: StructType = StructType("input" -> ScalarType.Double.nonNullable).get
 
   override def outputSchema: StructType = StructType("output" -> ScalarType.String).get
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringIndexerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringIndexerModel.scala
@@ -40,7 +40,7 @@ object HandleInvalid {
   *                      or 'keep' (put invalid data in a special bucket at index labels.size
   */
 case class StringIndexerModel(labels: Seq[String],
-                              nullableInput: Boolean = false,
+                              nullableInput: Boolean = true,
                               handleInvalid: HandleInvalid = HandleInvalid.Error) extends Model {
   private val stringToIndex: Map[String, Int] = labels.zipWithIndex.toMap
   private val keepInvalid = handleInvalid == HandleInvalid.Keep
@@ -50,7 +50,7 @@ case class StringIndexerModel(labels: Seq[String],
     * @param value label to index
     * @return index of label
     */
-  def apply(value: Any): Int = if (value == null || value == None) {
+  def apply(value: Any): Int = if (value == null) {
     if (keepInvalid) {
       labels.length
     } else {
@@ -58,10 +58,7 @@ case class StringIndexerModel(labels: Seq[String],
         s"To handle NULLS, set handleInvalid to ${HandleInvalid.Keep.asParamString}")
     }
   } else {
-    val label = value match {
-      case Some(v) => v.toString
-      case _ => value.toString
-    }
+    val label = value.toString
     if (stringToIndex.contains(label)) {
       stringToIndex(label)
     } else if (keepInvalid) {

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringIndexerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringIndexerModel.scala
@@ -40,7 +40,6 @@ object HandleInvalid {
   *                      or 'keep' (put invalid data in a special bucket at index labels.size
   */
 case class StringIndexerModel(labels: Seq[String],
-                              nullableInput: Boolean = true,
                               handleInvalid: HandleInvalid = HandleInvalid.Error) extends Model {
   private val stringToIndex: Map[String, Int] = labels.zipWithIndex.toMap
   private val keepInvalid = handleInvalid == HandleInvalid.Keep
@@ -75,7 +74,7 @@ case class StringIndexerModel(labels: Seq[String],
     */
   def toReverse: ReverseStringIndexerModel = ReverseStringIndexerModel(labels)
 
-  override def inputSchema: StructType = StructType("input" -> ScalarType(BasicType.String, this.nullableInput)).get
+  override def inputSchema: StructType = StructType("input" -> ScalarType.String).get
 
-  override def outputSchema: StructType = StructType("output" -> ScalarType.Double).get
+  override def outputSchema: StructType = StructType("output" -> ScalarType.Double.nonNullable).get
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/reflection/MleapReflection.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/reflection/MleapReflection.scala
@@ -43,25 +43,30 @@ trait MleapReflection {
 
   private def dataTypeFor(tpe: `Type`): DataType = MleapReflectionLock.synchronized {
     tpe match {
-      case t if t <:< mirrorType[Boolean] => ScalarType(BasicType.Boolean)
-      case t if t <:< mirrorType[Byte] => ScalarType(BasicType.Byte)
-      case t if t <:< mirrorType[Short] => ScalarType(BasicType.Short)
-      case t if t <:< mirrorType[Int] => ScalarType(BasicType.Int)
-      case t if t <:< mirrorType[Long] => ScalarType(BasicType.Long)
-      case t if t <:< mirrorType[Float] => ScalarType(BasicType.Float)
-      case t if t <:< mirrorType[Double] => ScalarType(BasicType.Double)
+      case t if t <:< mirrorType[Boolean] => ScalarType(BasicType.Boolean).nonNullable
+      case t if t <:< mirrorType[Byte] => ScalarType(BasicType.Byte).nonNullable
+      case t if t <:< mirrorType[Short] => ScalarType(BasicType.Short).nonNullable
+      case t if t <:< mirrorType[Int] => ScalarType(BasicType.Int).nonNullable
+      case t if t <:< mirrorType[Long] => ScalarType(BasicType.Long).nonNullable
+      case t if t <:< mirrorType[Float] => ScalarType(BasicType.Float).nonNullable
+      case t if t <:< mirrorType[Double] => ScalarType(BasicType.Double).nonNullable
+
       case t if t <:< mirrorType[String] => ScalarType(BasicType.String)
       case t if t <:< mirrorType[ByteString] => ScalarType(BasicType.ByteString)
+      case t if t <:< mirrorType[java.lang.Boolean] => ScalarType(BasicType.Boolean)
+      case t if t <:< mirrorType[java.lang.Byte] => ScalarType(BasicType.Byte)
+      case t if t <:< mirrorType[java.lang.Short] => ScalarType(BasicType.Short)
+      case t if t <:< mirrorType[java.lang.Integer] => ScalarType(BasicType.Int)
+      case t if t <:< mirrorType[java.lang.Long] => ScalarType(BasicType.Long)
+      case t if t <:< mirrorType[java.lang.Float] => ScalarType(BasicType.Float)
+      case t if t <:< mirrorType[java.lang.Double] => ScalarType(BasicType.Double)
+
       case t if t <:< mirrorType[Seq[_]] =>
         val TypeRef(_, _, Seq(elementType)) = t
         ListType(basicTypeFor(elementType))
       case t if t <:< mirrorType[Tensor[_]] =>
         val TypeRef(_, _, Seq(elementType)) = t
         TensorType(basicTypeFor(elementType))
-      case t if t <:< mirrorType[Option[_]] =>
-        val TypeRef(_, _, Seq(elementType)) = t
-        val baseType = dataTypeFor(elementType)
-        baseType.asNullable
       case t => throw new IllegalArgumentException(s"unknown type $t")
     }
   }
@@ -106,7 +111,7 @@ trait MleapReflection {
     }
   }
 
-  def newInstance[T:TypeTag](args: Seq[_]) : T = MleapReflectionLock.synchronized {
+  def newInstance[T: TypeTag](args: Seq[_]) : T = MleapReflectionLock.synchronized {
     val tpe = mirrorType[T]
     tpe match {
       case t if representsCaseClass(t) =>

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/regression/AFTSurvivalRegressionModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/regression/AFTSurvivalRegressionModel.scala
@@ -40,7 +40,7 @@ case class AFTSurvivalRegressionModel(coefficients: Vector,
   override def inputSchema: StructType = StructType("features" -> TensorType.Double(coefficients.size)).get
 
   override def outputSchema: StructType = {
-    StructType("prediction" -> ScalarType.Double,
+    StructType("prediction" -> ScalarType.Double.nonNullable,
       "quantiles" -> TensorType.Double(quantileProbabilities.length)).get
   }
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/regression/DecisionTreeRegressionModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/regression/DecisionTreeRegressionModel.scala
@@ -29,6 +29,6 @@ case class DecisionTreeRegressionModel(rootNode: Node, numFeatures: Int) extends
 
   override def inputSchema: StructType = StructType("features" -> TensorType.Double(numFeatures)).get
 
-  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Double).get
+  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Double.nonNullable).get
 
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/regression/GBTRegressionModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/regression/GBTRegressionModel.scala
@@ -47,6 +47,6 @@ case class GBTRegressionModel(override val trees: Seq[DecisionTreeRegressionMode
 
   override def inputSchema: StructType = StructType("features" -> TensorType.Double(numFeatures)).get
 
-  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Double).get
+  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Double.nonNullable).get
 
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/regression/GeneralizedLinearRegressionModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/regression/GeneralizedLinearRegressionModel.scala
@@ -328,7 +328,7 @@ case class GeneralizedLinearRegressionModel(coefficients: Vector,
   override def inputSchema: StructType = StructType("features" -> TensorType.Double(coefficients.size)).get
 
   override def outputSchema: StructType = {
-    StructType("prediction" -> ScalarType.Double,
-      "link_prediction" -> ScalarType.Double).get
+    StructType("prediction" -> ScalarType.Double.nonNullable,
+      "link_prediction" -> ScalarType.Double.nonNullable).get
   }
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/regression/IsotonicRegressionModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/regression/IsotonicRegressionModel.scala
@@ -46,9 +46,9 @@ case class IsotonicRegressionModel(boundaries: Array[Double],
   override def inputSchema: StructType = {
     this.featureIndex match {
       case Some(_) => StructType("features" -> TensorType.Double()).get
-      case None => StructType("features" -> ScalarType.Double).get
+      case None => StructType("features" -> ScalarType.Double.nonNullable).get
     }
   }
 
-  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Double).get
+  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Double.nonNullable).get
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/regression/LinearRegressionModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/regression/LinearRegressionModel.scala
@@ -30,5 +30,5 @@ case class LinearRegressionModel(coefficients: Vector,
 
   override def inputSchema: StructType = StructType("features" -> TensorType.Double(coefficients.size)).get
 
-  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Double).get
+  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Double.nonNullable).get
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/regression/RandomForestRegressionModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/regression/RandomForestRegressionModel.scala
@@ -43,6 +43,6 @@ case class RandomForestRegressionModel(override val trees: Seq[DecisionTreeRegre
 
   override def inputSchema: StructType = StructType("features" -> TensorType.Double(numFeatures)).get
 
-  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Double).get
+  override def outputSchema: StructType = StructType("prediction" -> ScalarType.Double.nonNullable).get
 
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/types/DataShape.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/types/DataShape.scala
@@ -11,19 +11,18 @@ sealed trait DataShape {
   val isNullable: Boolean
 }
 
-case class ScalarShape(override val isNullable: Boolean = false) extends DataShape {
+case class ScalarShape(override val isNullable: Boolean = true) extends DataShape {
   override def isScalar: Boolean = true
 }
-case class ListShape(override val isNullable: Boolean = false) extends DataShape {
+case class ListShape(override val isNullable: Boolean = true) extends DataShape {
   override def isList: Boolean = true
 }
 
 object TensorShape {
   def apply(dim0: Int, dims: Int *): TensorShape = TensorShape(Some(dim0 +: dims))
-  def nullable(dim0: Int, dims: Int *): TensorShape = TensorShape(Some(dim0 +: dims), isNullable = true)
 }
 
 case class TensorShape(dimensions: Option[Seq[Int]] = None,
-                       override val isNullable: Boolean = false) extends DataShape {
+                       override val isNullable: Boolean = true) extends DataShape {
   override def isTensor: Boolean = true
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/types/DataType.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/types/DataType.scala
@@ -15,7 +15,9 @@ object DataType {
 
 sealed trait DataType extends Serializable {
   val isNullable: Boolean
+
   def asNullable: DataType = setNullable(true)
+  def nonNullable: DataType = setNullable(false)
   def setNullable(isNullable: Boolean): DataType
 
   def base: BasicType
@@ -68,7 +70,7 @@ object ScalarType {
   val ByteString = ScalarType(BasicType.ByteString)
 }
 
-case class ScalarType(override val base: BasicType, override val isNullable: Boolean = false) extends DataType {
+case class ScalarType(override val base: BasicType, override val isNullable: Boolean = true) extends DataType {
   override def setNullable(isNullable: Boolean): ScalarType = copy(isNullable = isNullable)
   override def simpleString: String = "scalar"
   override def printString: String = s"$simpleString(base=$base,nullable=$isNullable)"
@@ -91,7 +93,7 @@ object TensorType {
  */
 case class TensorType(override val base: BasicType,
                       dimensions: Option[Seq[Int]] = None,
-                      override val isNullable: Boolean = false) extends DataType {
+                      override val isNullable: Boolean = true) extends DataType {
   def this(base: BasicType, isNullable: Boolean) = this(base, None, isNullable)
 
   override def setNullable(isNullable: Boolean): DataType = copy(isNullable = isNullable)
@@ -114,7 +116,7 @@ object ListType {
 }
 
 case class ListType(override val base: BasicType,
-                    override val isNullable: Boolean = false) extends DataType {
+                    override val isNullable: Boolean = true) extends DataType {
   override def setNullable(isNullable: Boolean): DataType = copy(isNullable = isNullable)
   override def simpleString: String = "list"
   override def printString: String = s"$simpleString(base=$base,nullable=$isNullable)"

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/types/TypeSpec.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/types/TypeSpec.scala
@@ -17,8 +17,7 @@ case class DataTypeSpec(dt: DataType) extends TypeSpec {
 }
 
 object SchemaSpec {
-  def
-  apply(schema: StructType): SchemaSpec = SchemaSpec(schema.fields.map(_.dataType))
+  def apply(schema: StructType): SchemaSpec = SchemaSpec(schema.fields.map(_.dataType))
 }
 case class SchemaSpec(dts: Seq[DataType]) extends TypeSpec {
   override def dataTypes: Seq[DataType] = dts

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/classification/DecisionTreeClassifierModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/classification/DecisionTreeClassifierModelSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.FunSpec
 class DecisionTreeClassifierModelSpec extends FunSpec {
 
   describe("decision tree classifier model") {
-    val model = new DecisionTreeClassifierModel(null, 3, 2)
+    val model = DecisionTreeClassifierModel(null, 3, 2)
 
     it("has the right input schema") {
       assert(model.inputSchema.fields ==
@@ -17,7 +17,7 @@ class DecisionTreeClassifierModelSpec extends FunSpec {
       assert(model.outputSchema.fields ==
         Seq(StructField("raw_prediction", TensorType.Double(2)),
           StructField("probability", TensorType.Double(2)),
-          StructField("prediction", ScalarType.Double)
+          StructField("prediction", ScalarType.Double.nonNullable)
         ))
     }
   }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/classification/GBTClassifierModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/classification/GBTClassifierModelSpec.scala
@@ -35,7 +35,7 @@ class GBTClassifierModelSpec extends FunSpec {
       assert(classifier.outputSchema.fields ==
         Seq(StructField("raw_prediction", TensorType.Double(2)),
           StructField("probability", TensorType.Double(2)),
-          StructField("prediction", ScalarType.Double)
+          StructField("prediction", ScalarType.Double.nonNullable)
         ))
     }
   }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/classification/LogisticRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/classification/LogisticRegressionModelSpec.scala
@@ -30,7 +30,7 @@ class LogisticRegressionModelSpec extends FunSpec {
         assert(lr.outputSchema.fields == Seq(
           StructField("raw_prediction", TensorType.Double(2)),
           StructField("probability", TensorType.Double(2)),
-          StructField("prediction", ScalarType.Double)
+          StructField("prediction", ScalarType.Double.nonNullable)
         ))
       }
     }
@@ -50,7 +50,7 @@ class LogisticRegressionModelSpec extends FunSpec {
         assert(lr.outputSchema.fields == Seq(
           StructField("raw_prediction", TensorType.Double(3)),
           StructField("probability", TensorType.Double(3)),
-          StructField("prediction", ScalarType.Double)
+          StructField("prediction", ScalarType.Double.nonNullable)
         ))
       }
     }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/classification/MultiLayerPerceptronClassifierModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/classification/MultiLayerPerceptronClassifierModelSpec.scala
@@ -16,7 +16,7 @@ class MultiLayerPerceptronClassifierModelSpec extends FunSpec {
 
     it("has the right output schema") {
       assert(model.outputSchema.fields ==
-        Seq(StructField("prediction", ScalarType.Double)))
+        Seq(StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/classification/NaiveBayesModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/classification/NaiveBayesModelSpec.scala
@@ -17,7 +17,7 @@ class NaiveBayesModelSpec extends FunSpec {
       assert(model.outputSchema.fields ==
         Seq(StructField("raw_prediction", TensorType.Double(2)),
           StructField("probability", TensorType.Double(2)),
-          StructField("prediction", ScalarType.Double)
+          StructField("prediction", ScalarType.Double.nonNullable)
         ))
     }
   }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/classification/RandomForestClassifierModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/classification/RandomForestClassifierModelSpec.scala
@@ -17,7 +17,7 @@ class RandomForestClassifierModelSpec extends FunSpec {
       assert(model.outputSchema.fields ==
         Seq(StructField("raw_prediction", TensorType.Double(2)),
         StructField("probability", TensorType.Double(2)),
-        StructField("prediction", ScalarType.Double)
+        StructField("prediction", ScalarType.Double.nonNullable)
         ))
     }
   }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/classification/SupportVectorMachineModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/classification/SupportVectorMachineModelSpec.scala
@@ -18,7 +18,7 @@ class SupportVectorMachineModelSpec extends FunSpec {
       assert(model.outputSchema.fields ==
         Seq(StructField("raw_prediction", TensorType.Double(2)),
           StructField("probability", TensorType.Double(2)),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/clustering/BisectingKMeansModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/clustering/BisectingKMeansModelSpec.scala
@@ -18,7 +18,7 @@ class BisectingKMeansModelSpec extends FunSpec {
 
     it("has the right output schema") {
       assert(model.outputSchema.fields ==
-        Seq(StructField("prediction", ScalarType.Int)))
+        Seq(StructField("prediction", ScalarType.Int.nonNullable)))
     }
   }
 }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/clustering/GaussianMixtureModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/clustering/GaussianMixtureModelSpec.scala
@@ -15,7 +15,7 @@ class GaussianMixtureModelSpec extends FunSpec {
 
     it("has the right output schema") {
       assert(model.outputSchema.fields ==
-        Seq(StructField("prediction", ScalarType.Int),
+        Seq(StructField("prediction", ScalarType.Int.nonNullable),
           StructField("probability", TensorType.Double(3))))
     }
   }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/clustering/KMeansModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/clustering/KMeansModelSpec.scala
@@ -27,7 +27,7 @@ class KMeansModelSpec extends FunSpec {
     }
 
     it("has the right output schema") {
-      assert(km.outputSchema.fields == Seq(StructField("prediction", ScalarType.Int)))
+      assert(km.outputSchema.fields == Seq(StructField("prediction", ScalarType.Int.nonNullable)))
     }
   }
 }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/BinarizerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/BinarizerModelSpec.scala
@@ -41,7 +41,7 @@ class BinarizerModelSpec extends FunSpec {
 
     it("Has the right output schema") {
       assert(binarizer.outputSchema.fields ==
-        Seq(StructField("output", ScalarType.Double)))
+        Seq(StructField("output", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/BinarizerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/BinarizerModelSpec.scala
@@ -36,7 +36,7 @@ class BinarizerModelSpec extends FunSpec {
 
     it("Has the right input schema") {
       assert(binarizer.inputSchema.fields ==
-        Seq(StructField("input", ScalarType.Double)))
+        Seq(StructField("input", ScalarType.Double.nonNullable)))
     }
 
     it("Has the right output schema") {

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/BucketizerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/BucketizerModelSpec.scala
@@ -19,12 +19,12 @@ class BucketizerModelSpec extends FunSpec {
 
     it("has the right input schema") {
       assert(bucketizer.inputSchema.fields ==
-        Seq(StructField("input", ScalarType.Double)))
+        Seq(StructField("input", ScalarType.Double.nonNullable)))
     }
 
     it("has the right output schema") {
       assert(bucketizer.outputSchema.fields ==
-        Seq(StructField("output", ScalarType.Double)))
+        Seq(StructField("output", ScalarType.Double.nonNullable)))
     }
 
     describe("with invalid feature") {

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/CoalesceModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/CoalesceModelSpec.scala
@@ -10,14 +10,14 @@ class CoalesceModelSpec extends FunSpec {
 
     it("Has the right input schema") {
       assert(model.inputSchema.fields ==
-        Seq(StructField("input0", ScalarType.Double.asNullable),
-          StructField("input1", ScalarType.Double.asNullable),
-          StructField("input2", ScalarType.Double.asNullable)))
+        Seq(StructField("input0", ScalarType.Double),
+          StructField("input1", ScalarType.Double),
+          StructField("input2", ScalarType.Double)))
     }
 
     it("Has the right output schema") {
       assert(model.outputSchema.fields ==
-        Seq(StructField("output", ScalarType.Double.asNullable)))
+        Seq(StructField("output", ScalarType.Double)))
     }
   }
 }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/ImputerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/ImputerModelSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.FunSpec
 class ImputerModelSpec extends FunSpec {
 
   describe("input/output schema"){
-    val model = new ImputerModel(12, 23.4, "mean", false)
+    val model = ImputerModel(12, 23.4, "mean")
 
     it("Has the right input schema") {
       assert(model.inputSchema.fields ==

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/ImputerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/ImputerModelSpec.scala
@@ -15,7 +15,7 @@ class ImputerModelSpec extends FunSpec {
 
     it("Has the right output schema") {
       assert(model.outputSchema.fields ==
-        Seq(StructField("output", ScalarType.Double)))
+        Seq(StructField("output", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MathBinaryModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MathBinaryModelSpec.scala
@@ -18,11 +18,11 @@ class MathBinaryModelSpec extends FunSpec {
       it(s"has the name: $name") { assert(operation.name == name) }
       it("calculated the value properly") { assert(model(Some(a), Some(b)) == expected) }
       it("has the right input schema") {
-        assert(model.inputSchema.fields == Seq(StructField("input_a" -> ScalarType.Double),
-          StructField("input_b" -> ScalarType.Double)))
+        assert(model.inputSchema.fields == Seq(StructField("input_a" -> ScalarType.Double.nonNullable),
+          StructField("input_b" -> ScalarType.Double.nonNullable)))
       }
       it("has the right output schema") {
-        assert(model.outputSchema.fields == Seq(StructField("output" -> ScalarType.Double)))
+        assert(model.outputSchema.fields == Seq(StructField("output" -> ScalarType.Double.nonNullable)))
       }
     }
   }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MathUnaryModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MathUnaryModelSpec.scala
@@ -18,9 +18,9 @@ class MathUnaryModelSpec extends FunSpec {
       it(s"has the name: $name") { assert(operation.name == name) }
       it("computes the value properly") { assert(model(input) == expected) }
       it("has the right input schema") {
-        assert(model.inputSchema.fields == Seq(StructField("input", ScalarType.Double)))}
+        assert(model.inputSchema.fields == Seq(StructField("input", ScalarType.Double.nonNullable)))}
       it("has the right output schema") {
-        assert(model.outputSchema.fields == Seq(StructField("output", ScalarType.Double)))}
+        assert(model.outputSchema.fields == Seq(StructField("output", ScalarType.Double.nonNullable)))}
     }
   }
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/OneHotEncoderModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/OneHotEncoderModelSpec.scala
@@ -18,7 +18,7 @@ class OneHotEncoderModelSpec extends FunSpec {
     }
 
     it("has the right input schema") {
-      assert(encoder.inputSchema.fields == Seq(StructField("input", ScalarType.Double)))
+      assert(encoder.inputSchema.fields == Seq(StructField("input", ScalarType.Double.nonNullable)))
     }
 
     it("has the right output schema") {

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/ReverseStringIndexerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/ReverseStringIndexerModelSpec.scala
@@ -10,7 +10,7 @@ class ReverseStringIndexerModelSpec extends FunSpec {
 
     it("has the right input schema") {
       assert(model.inputSchema.fields ==
-        Seq(StructField("input", ScalarType.Double)))
+        Seq(StructField("input", ScalarType.Double.nonNullable)))
     }
 
     it("has the right output schema") {

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/StringIndexerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/StringIndexerModelSpec.scala
@@ -17,14 +17,6 @@ class StringIndexerModelSpec extends FunSpec with TableDrivenPropertyChecks {
       assert(indexer("dude") == 2.0)
     }
 
-    it("returns the index of Optional string") {
-      val indexer = StringIndexerModel(Array("hello", "there", "dude"), nullableInput = true)
-
-      assert(indexer("hello") == 0.0)
-      assert(indexer("there") == 1.0)
-      assert(indexer("dude") == 2.0)
-    }
-
     it("throws NullPointerException when encounters NULL/None and handleInvalid is not keep") {
       val indexer = StringIndexerModel(Array("hello"))
       assertThrows[NullPointerException](indexer(null))
@@ -59,7 +51,7 @@ class StringIndexerModelSpec extends FunSpec with TableDrivenPropertyChecks {
     }
 
     it("has the right output schema") {
-      assert(indexer.outputSchema.fields == Seq(StructField("output", ScalarType.Double)))
+      assert(indexer.outputSchema.fields == Seq(StructField("output", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/StringIndexerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/StringIndexerModelSpec.scala
@@ -20,25 +20,19 @@ class StringIndexerModelSpec extends FunSpec with TableDrivenPropertyChecks {
     it("returns the index of Optional string") {
       val indexer = StringIndexerModel(Array("hello", "there", "dude"), nullableInput = true)
 
-      assert(indexer(Some("hello")) == 0.0)
-      assert(indexer(Some("there")) == 1.0)
-      assert(indexer(Some("dude")) == 2.0)
+      assert(indexer("hello") == 0.0)
+      assert(indexer("there") == 1.0)
+      assert(indexer("dude") == 2.0)
     }
 
     it("throws NullPointerException when encounters NULL/None and handleInvalid is not keep") {
       val indexer = StringIndexerModel(Array("hello"))
-      val nullLabels = Table(null, None)
-
-      forAll(nullLabels) { (label: Any) =>
-        intercept[NullPointerException] {
-          indexer(label)
-        }
-      }
+      assertThrows[NullPointerException](indexer(null))
     }
 
     it("throws NoSuchElementException when encounters unseen label and handleInvalid is not keep") {
       val indexer = StringIndexerModel(Array("hello"))
-      val unseenLabels = Table("unknown1", Some("unknown2"))
+      val unseenLabels = Table("unknown1", "unknown2")
 
       forAll(unseenLabels) { (label: Any) =>
         intercept[NoSuchElementException] {
@@ -49,7 +43,7 @@ class StringIndexerModelSpec extends FunSpec with TableDrivenPropertyChecks {
 
     it("returns default index for HandleInvalid.keep mode") {
       val indexer = StringIndexerModel(Array("hello", "there", "dude"), handleInvalid = HandleInvalid.Keep)
-      val invalidLabels = Table("unknown", Some("other unknown"), null, None)
+      val invalidLabels = Table("unknown", "other unknown", null, None)
 
       forAll(invalidLabels) { (label: Any) =>
         assert(indexer(label) == 3.0)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/reflection/MleapReflectionSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/reflection/MleapReflectionSpec.scala
@@ -12,11 +12,11 @@ class MleapReflectionSpec extends FunSpec {
     import ml.combust.mleap.core.reflection.MleapReflection.dataType
 
     it("returns the Mleap runtime data type from the Scala type") {
-      assert(dataType[Boolean] == ScalarType.Boolean)
-      assert(dataType[Int] == ScalarType.Int)
-      assert(dataType[Long] == ScalarType.Long)
-      assert(dataType[Float] == ScalarType.Float)
-      assert(dataType[Double] == ScalarType.Double)
+      assert(dataType[Boolean] == ScalarType.Boolean.nonNullable)
+      assert(dataType[Int] == ScalarType.Int.nonNullable)
+      assert(dataType[Long] == ScalarType.Long.nonNullable)
+      assert(dataType[Float] == ScalarType.Float.nonNullable)
+      assert(dataType[Double] == ScalarType.Double.nonNullable)
       assert(dataType[String] == ScalarType.String)
       assert(dataType[ByteString] == ScalarType.ByteString)
       assert(dataType[Seq[Boolean]] == ListType(BasicType.Boolean))
@@ -24,11 +24,10 @@ class MleapReflectionSpec extends FunSpec {
       assert(dataType[Seq[Int]] == ListType(BasicType.Int))
       assert(dataType[Seq[Long]] == ListType(BasicType.Long))
       assert(dataType[Seq[Double]] == ListType(BasicType.Double))
-      assert(dataType[Option[Boolean]] == ScalarType.Boolean.asNullable)
-      assert(dataType[Option[String]] == ScalarType.String.asNullable)
-      assert(dataType[Option[Int]] == ScalarType.Int.asNullable)
-      assert(dataType[Option[Long]] == ScalarType.Long.asNullable)
-      assert(dataType[Option[Double]] == ScalarType.Double.asNullable)
+      assert(dataType[java.lang.Boolean] == ScalarType.Boolean)
+      assert(dataType[java.lang.Integer] == ScalarType.Int)
+      assert(dataType[java.lang.Long] == ScalarType.Long)
+      assert(dataType[java.lang.Double] == ScalarType.Double)
       assert(dataType[Tensor[Double]] == TensorType(BasicType.Double))
     }
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/regression/AFTSurvivalRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/regression/AFTSurvivalRegressionModelSpec.scala
@@ -16,7 +16,7 @@ class AFTSurvivalRegressionModelSpec extends FunSpec {
 
     it("has the right output schema") {
       assert(model.outputSchema.fields ==
-        Seq(StructField("prediction", ScalarType.Double),
+        Seq(StructField("prediction", ScalarType.Double.nonNullable),
           StructField("quantiles", TensorType.Double(4))))
     }
   }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/regression/DecisionTreeRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/regression/DecisionTreeRegressionModelSpec.scala
@@ -26,7 +26,7 @@ class DecisionTreeRegressionModelSpec extends FunSpec {
     }
 
     it("has the right output schema") {
-      assert(regression.outputSchema.fields == Seq(StructField("prediction", ScalarType.Double)))
+      assert(regression.outputSchema.fields == Seq(StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/regression/GBTRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/regression/GBTRegressionModelSpec.scala
@@ -32,7 +32,7 @@ class GBTRegressionModelSpec extends FunSpec {
     }
 
     it("has the right output schema") {
-      assert(regression.outputSchema.fields == Seq(StructField("prediction", ScalarType.Double)))
+      assert(regression.outputSchema.fields == Seq(StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/regression/GeneralizedLinearRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/regression/GeneralizedLinearRegressionModelSpec.scala
@@ -16,8 +16,8 @@ class GeneralizedLinearRegressionModelSpec extends FunSpec {
 
     it("has the right output schema") {
       assert(model.outputSchema.fields ==
-        Seq(StructField("prediction", ScalarType.Double),
-           StructField("link_prediction", ScalarType.Double)))
+        Seq(StructField("prediction", ScalarType.Double.nonNullable),
+           StructField("link_prediction", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/regression/IsotonicRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/regression/IsotonicRegressionModelSpec.scala
@@ -28,7 +28,7 @@ class IsotonicRegressionModelSpec extends FunSpec {
     }
 
     it("has the right output schema") {
-      assert(regression.outputSchema.fields == Seq(StructField("prediction", ScalarType.Double)))
+      assert(regression.outputSchema.fields == Seq(StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/regression/LinearRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/regression/LinearRegressionModelSpec.scala
@@ -22,7 +22,7 @@ class LinearRegressionModelSpec extends FunSpec {
     }
 
     it("has the right output schema") {
-      assert(linearRegression.outputSchema.fields == Seq(StructField("prediction", ScalarType.Double)))
+      assert(linearRegression.outputSchema.fields == Seq(StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/regression/RandomForestRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/regression/RandomForestRegressionModelSpec.scala
@@ -32,7 +32,7 @@ class RandomForestRegressionModelSpec extends FunSpec {
     }
 
     it("has the right output schema") {
-      assert(regression.outputSchema.fields == Seq(StructField("prediction", ScalarType.Double)))
+      assert(regression.outputSchema.fields == Seq(StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/types/CastingSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/types/CastingSpec.scala
@@ -121,14 +121,14 @@ class CastingSpec extends FunSpec {
     describe(s"cast from $from to $to - $i") {
       it("casts the scalar") {
         val c = Casting.cast(ScalarType(from), ScalarType(to)).get.get
-        val oc = Casting.cast(ScalarType(from).asNullable, ScalarType(to)).get.get
-        val co = Casting.cast(ScalarType(from), ScalarType(to).asNullable).get.get
-        val oco = Casting.cast(ScalarType(from).asNullable, ScalarType(to).asNullable).get.get
+        val oc = Casting.cast(ScalarType(from), ScalarType(to).nonNullable).get.get
+        val co = Casting.cast(ScalarType(from).nonNullable, ScalarType(to)).get.get
+        val oco = Casting.cast(ScalarType(from), ScalarType(to)).get.get
 
         assert(c(fromValue) == expectedValue)
-        assert(oc(Option(fromValue)) == expectedValue)
-        assert(co(fromValue) == Option(expectedValue))
-        assert(oco(Option(fromValue)) == Option(expectedValue))
+        assertThrows[NullPointerException](oc(null))
+        assert(co(fromValue) == expectedValue)
+        assert(oco(null) == null)
       }
 
       it("casts the list") {
@@ -136,14 +136,14 @@ class CastingSpec extends FunSpec {
         val expectedList = Seq(expectedValue, expectedValue, expectedValue)
 
         val c = Casting.cast(ListType(from), ListType(to)).get.get
-        val oc = Casting.cast(ListType(from).asNullable, ListType(to)).get.get
-        val co = Casting.cast(ListType(from), ListType(to).asNullable).get.get
-        val oco = Casting.cast(ListType(from).asNullable, ListType(to).asNullable).get.get
+        val oc = Casting.cast(ListType(from), ListType(to).nonNullable).get.get
+        val co = Casting.cast(ListType(from).nonNullable, ListType(to)).get.get
+        val oco = Casting.cast(ListType(from), ListType(to)).get.get
 
         assert(c(fromList) == expectedList)
-        assert(oc(Option(fromList)) == expectedList)
-        assert(co(fromList) == Option(expectedList))
-        assert(oco(Option(fromList)) == Option(expectedList))
+        assertThrows[NullPointerException](oc(null))
+        assert(co(fromList) == expectedList)
+        assert(oco(null) == null)
       }
 
       it("casts the tensor") {
@@ -154,16 +154,16 @@ class CastingSpec extends FunSpec {
         val expectedScalarTensor = createTensorScalar(to, expectedValue)
 
         val c = Casting.cast(TensorType(from), TensorType(to)).get.get
-        val oc = Casting.cast(TensorType(from).asNullable, TensorType(to)).get.get
-        val co = Casting.cast(TensorType(from), TensorType(to).asNullable).get.get
-        val oco = Casting.cast(TensorType(from).asNullable, TensorType(to).asNullable).get.get
+        val oc = Casting.cast(TensorType(from), TensorType(to).nonNullable).get.get
+        val co = Casting.cast(TensorType(from).nonNullable, TensorType(to)).get.get
+        val oco = Casting.cast(TensorType(from), TensorType(to)).get.get
         val tc = Casting.cast(ScalarType(from), TensorType(to, Some(Seq()))).get.get
         val ct = Casting.cast(TensorType(from, Some(Seq())), ScalarType(to)).get.get
 
         assert(c(fromTensor) == expectedTensor)
-        assert(oc(Option(fromTensor)) == expectedTensor)
-        assert(co(fromTensor) == Option(expectedTensor))
-        assert(oco(Option(fromTensor)) == Option(expectedTensor))
+        assertThrows[NullPointerException](oc(null))
+        assert(co(fromTensor) == expectedTensor)
+        assert(oco(null) == null)
         assert(tc(fromValue) == expectedScalarTensor)
         assert(ct(fromScalarTensor) == expectedValue)
       }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/types/StructTypeSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/types/StructTypeSpec.scala
@@ -119,7 +119,7 @@ class StructTypeSpec extends FunSuite with GivenWhenThen with TryValues{
 
   test("prints the schema to a PrintStream") {
     val printStruct = StructType(StructField("a_double", ScalarType.Double),
-      StructField("a_list", ListType(BasicType.Float, isNullable = true)),
+      StructField("a_list", ListType(BasicType.Float).nonNullable),
       StructField("a_tensor", TensorType(BasicType.Byte))).get
 
     val out = new ByteArrayOutputStream()
@@ -132,9 +132,9 @@ class StructTypeSpec extends FunSuite with GivenWhenThen with TryValues{
     val expected =
       """
         |root
-        | |-- a_double: scalar(base=double,nullable=false)
-        | |-- a_list: list(base=float,nullable=true)
-        | |-- a_tensor: tensor(base=byte,nullable=false)
+        | |-- a_double: scalar(base=double,nullable=true)
+        | |-- a_list: list(base=float,nullable=false)
+        | |-- a_tensor: tensor(base=byte,nullable=true)
       """.stripMargin
 
     assert(schema.trim == expected.trim)

--- a/mleap-runtime/src/main/java/ml/combust/mleap/runtime/javadsl/LeapFrameBuilder.java
+++ b/mleap-runtime/src/main/java/ml/combust/mleap/runtime/javadsl/LeapFrameBuilder.java
@@ -42,7 +42,7 @@ public class LeapFrameBuilder {
         return new LocalDataset(rows);
     }
 
-    public ScalarType createBool() { return createBool(false); }
+    public ScalarType createBool() { return createBool(true); }
     public ScalarType createBool(boolean isNullable) {
         return new ScalarType(support.createBoolean(), isNullable);
     }
@@ -57,51 +57,51 @@ public class LeapFrameBuilder {
     public BasicType createBasicString() { return support.createString(); }
     public BasicType createBasicByteString() { return support.createByteString(); }
 
-    public ScalarType createBoolean() { return createBoolean(false); }
+    public ScalarType createBoolean() { return createBoolean(true); }
     public ScalarType createBoolean(boolean isNullable) {
         return new ScalarType(support.createBoolean(), isNullable);
     }
 
-    public ScalarType createByte() { return createByte(false); }
+    public ScalarType createByte() { return createByte(true); }
     public ScalarType createByte(boolean isNullable) {
         return new ScalarType(support.createByte(), isNullable);
     }
 
-    public ScalarType createShort() { return createShort(false); }
+    public ScalarType createShort() { return createShort(true); }
     public ScalarType createShort(boolean isNullable) {
         return new ScalarType(support.createShort(), isNullable);
     }
 
-    public ScalarType createInt() { return createInt(false); }
+    public ScalarType createInt() { return createInt(true); }
     public ScalarType createInt(boolean isNullable) {
         return new ScalarType(support.createInt(), isNullable);
     }
 
-    public ScalarType createLong() { return createLong(false); }
+    public ScalarType createLong() { return createLong(true); }
     public ScalarType createLong(boolean isNullable) {
         return new ScalarType(support.createLong(), isNullable);
     }
 
-    public ScalarType createFloat() { return createFloat(false); }
+    public ScalarType createFloat() { return createFloat(true); }
     public ScalarType createFloat(boolean isNullable) {
         return new ScalarType(support.createFloat(), isNullable);
     }
 
-    public ScalarType createDouble() { return createDouble(false); }
+    public ScalarType createDouble() { return createDouble(true); }
     public ScalarType createDouble(boolean isNullable) {
         return new ScalarType(support.createDouble(), isNullable);
     }
 
-    public ScalarType createString() { return createString(false); }
+    public ScalarType createString() { return createString(true); }
     public ScalarType createString(boolean isNullable) { return new ScalarType(support.createString(), isNullable); }
 
-    public ScalarType createByteString() { return createByteString(false); }
+    public ScalarType createByteString() { return createByteString(true); }
     public ScalarType createByteString(boolean isNullable) { return new ScalarType(support.createByteString(), isNullable); }
 
-    public TensorType createTensor(BasicType base) { return createTensor(base, false); }
+    public TensorType createTensor(BasicType base) { return createTensor(base, true); }
     public TensorType createTensor(BasicType base, boolean isNullable) { return new TensorType(base, isNullable); }
 
-    public ListType createList(BasicType base) { return createList(base, false); }
+    public ListType createList(BasicType base) { return createList(base, true); }
     public ListType createList(BasicType base, boolean isNullable) {
         return new ListType(base, isNullable);
     }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/binary/DefaultFrameWriter.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/binary/DefaultFrameWriter.scala
@@ -27,7 +27,7 @@ class DefaultFrameWriter[LF <: LeapFrame[LF]](frame: LF) extends FrameWriter {
       for(row <- frame.dataset) {
         var i = 0
         for(s <- serializers) {
-          s.write(row(i), dout)
+          s.write(row.getRaw(i), dout)
           i = i + 1
         }
       }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/binary/DefaultRowWriter.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/binary/DefaultRowWriter.scala
@@ -21,7 +21,7 @@ class DefaultRowWriter(override val schema: StructType) extends RowWriter {
       val dout = new DataOutputStream(out)
       var i = 0
       for(s <- serializers) {
-        s.write(row(i), dout)
+        s.write(row.getRaw(i), dout)
         i = i + 1
       }
       dout.flush()

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/binary/ValueSerializer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/binary/ValueSerializer.scala
@@ -70,16 +70,17 @@ trait ValueSerializer[T] {
   def read(in: DataInputStream): T
 }
 
-case class NullableSerializer[T](base: ValueSerializer[T]) extends ValueSerializer[Option[T]] {
-  override def write(value: Option[T], out: DataOutputStream): Unit = {
-    out.writeBoolean(value.isDefined)
-    value.foreach(v => base.write(v, out))
+case class NullableSerializer[T](base: ValueSerializer[T]) extends ValueSerializer[T] {
+  override def write(value: T, out: DataOutputStream): Unit = {
+    val o = Option(value)
+    out.writeBoolean(o.isDefined)
+    o.foreach(v => base.write(v, out))
   }
 
-  override def read(in: DataInputStream): Option[T] = {
+  override def read(in: DataInputStream): T = {
     if(in.readBoolean()) {
-      Option(base.read(in))
-    } else { None }
+      base.read(in)
+    } else { null.asInstanceOf[T] }
   }
 }
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/StringIndexerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/StringIndexerOp.scala
@@ -20,7 +20,6 @@ class StringIndexerOp extends MleapOp[StringIndexer, StringIndexerModel] {
     override def store(model: Model, obj: StringIndexerModel)
                       (implicit context: BundleContext[MleapContext]): Model = {
         model.withValue("labels", Value.stringList(obj.labels)).
-          withValue("nullable_input", Value.boolean(obj.nullableInput)).
           withValue("handle_invalid", Value.string(obj.handleInvalid.asParamString))
 
     }
@@ -30,7 +29,6 @@ class StringIndexerOp extends MleapOp[StringIndexer, StringIndexerModel] {
       val handleInvalid = model.getValue("handle_invalid").map(_.getString).map(HandleInvalid.fromString).getOrElse(HandleInvalid.default)
 
       StringIndexerModel(labels = model.value("labels").getStringList,
-        model.value("nullable_input").getBoolean,
         handleInvalid = handleInvalid)
     }
   }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/json/DatasetFormat.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/json/DatasetFormat.scala
@@ -20,7 +20,9 @@ object DatasetFormat {
     }
   }
 
-  def listSerializer(lt: ListType): JsonFormat[_] = seqFormat(basicSerializer(lt.base, isNullable = false))
+  def listSerializer(lt: ListType): JsonFormat[_] = {
+    maybeNullableFormat(seqFormat(basicSerializer(lt.base, isNullable = false)), lt.isNullable)
+  }
 
   def tensorSerializer(tt: TensorType): JsonFormat[_] = {
     val isNullable = tt.isNullable

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Row.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Row.scala
@@ -34,17 +34,32 @@ trait Row extends Iterable[Any] {
 
   /** Get value at index.
     *
+    * Does not perform null checks
+    *
     * @param index index of value
     * @return value at index
     */
-  def get(index: Int): Any
+  def getRaw(index: Int): Any
+
+  /** Get value at index.
+    *
+    * Performs a null check
+    *
+    * @param index index of value
+    * @return value at index
+    */
+  def get(index: Int): Any = {
+    Option(getRaw(index)).getOrElse {
+      throw new NullPointerException(s"value at $index is null")
+    }
+  }
 
   /** Get optional value at index.
     *
     * @param index index of value
     * @return optional value at index
     */
-  def option(index: Int): Option[Any] = getAs[Option[Any]](index)
+  def option(index: Int): Option[Any] = Option(getRaw(index))
 
   /** Get value at index as specified type.
     *
@@ -60,7 +75,7 @@ trait Row extends Iterable[Any] {
     * @tparam T type of value
     * @return optional value at index cast to given type
     */
-  def optionAs[T](index: Int): Option[T] = get(index).asInstanceOf[Option[T]]
+  def optionAs[T](index: Int): Option[T] = Option(get(index)).asInstanceOf[Option[T]]
 
   /** Get value at index as a boolean.
     *
@@ -274,7 +289,7 @@ object ArrayRow {
 case class ArrayRow(values: mutable.WrappedArray[Any]) extends Row {
   def this(values: java.lang.Iterable[Any]) = this(values.asScala.toArray)
 
-  override def get(index: Int): Any = values(index)
+  override def getRaw(index: Int): Any = values(index)
 
   override def iterator: Iterator[Any] = values.iterator
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Row.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Row.scala
@@ -75,7 +75,7 @@ trait Row extends Iterable[Any] {
     * @tparam T type of value
     * @return optional value at index cast to given type
     */
-  def optionAs[T](index: Int): Option[T] = Option(get(index)).asInstanceOf[Option[T]]
+  def optionAs[T](index: Int): Option[T] = option(index).asInstanceOf[Option[T]]
 
   /** Get value at index as a boolean.
     *

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/RowUtil.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/RowUtil.scala
@@ -45,10 +45,10 @@ object RowUtil {
           val dt = typeSpec.asInstanceOf[DataTypeSpec].dt
           Casting.cast(field.dataType, dt).map {
             _.map {
-              c => (r: Row) => c(r.get(index))
+              c => (r: Row) => c(r.getRaw(index))
             }
           }.getOrElse {
-            Success((r: Row) => r.get(index))
+            Success((r: Row) => r.getRaw(index))
           }
       }
     case StructSelector(fields) =>
@@ -59,9 +59,9 @@ object RowUtil {
             dts.zip(fields).map {
               case (expDt, (index, field)) =>
                 Casting.cast(field.dataType, expDt).map(_.get).map {
-                    c => (r: Row) => c(r.get(index))
+                    c => (r: Row) => c(r.getRaw(index))
                 }.getOrElse {
-                  (r: Row) => r.get(index)
+                  (r: Row) => r.getRaw(index)
                 }
             }
           }.map {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Imputer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Imputer.scala
@@ -11,9 +11,5 @@ import ml.combust.mleap.runtime.transformer.{SimpleTransformer, Transformer}
 case class Imputer(override val uid: String = Transformer.uniqueName("imputer"),
                    override val shape: NodeShape,
                    override val model: ImputerModel) extends SimpleTransformer {
-  override val exec: UserDefinedFunction = if(model.nullableInput) {
-    (value: Option[Double]) => model(value)
-  } else {
-    (value: Double) => model(value)
-  }
+  override val exec: UserDefinedFunction = (value: java.lang.Double) => model(value)
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/StringIndexer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/StringIndexer.scala
@@ -11,9 +11,5 @@ import ml.combust.mleap.runtime.transformer.{SimpleTransformer, Transformer}
 case class StringIndexer(override val uid: String = Transformer.uniqueName("string_indexer"),
                          override val shape: NodeShape,
                          override val model: StringIndexerModel) extends SimpleTransformer {
-  val exec: UserDefinedFunction = if(model.nullableInput) {
-    (value: Option[String]) => model(value).toDouble
-  } else {
-    (value: String) => model(value).toDouble
-  }
+  val exec: UserDefinedFunction = (value: String) => model(value).toDouble
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/RowSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/RowSpec.scala
@@ -14,13 +14,13 @@ trait RowSpec[R <: Row] extends FunSpec {
     val rowValues = Seq("test", 42, Seq(56, 78, 23), 57.3, Tensor.denseVector(Array(2.3, 4.4)), 56L)
     val row = create(rowValues: _*)
 
-    val optionRowValues = Seq(Option("test"),
-      None,
-      Option(42),
-      Option(45.4),
-      Option(Tensor.denseVector(Array(42.3, 65.7))),
-      Option(33l),
-      Option(Seq(56, 78, 23)))
+    val optionRowValues = Seq("test",
+      null,
+      42,
+      45.4,
+      Tensor.denseVector(Array(42.3, 65.7)),
+      33l,
+      Seq(56, 78, 23))
     val optionRow = create(optionRowValues: _*)
 
     describe("#apply") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/converter/LeapFrameConverterSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/converter/LeapFrameConverterSpec.scala
@@ -9,7 +9,7 @@ class LeapFrameConverterSpec extends FunSpec {
 
   describe("LeapFrameConverter") {
     val expectedSchema = StructType(Seq(StructField("test_string", ScalarType.String),
-      StructField("test_double", ScalarType.Double))).get
+      StructField("test_double", ScalarType.Double.nonNullable))).get
 
     val frameWith1Row = DefaultLeapFrame(expectedSchema,
       LocalDataset(Array(Row("hello", 42.13))))
@@ -36,4 +36,4 @@ class LeapFrameConverterSpec extends FunSpec {
   }
 }
 
-case class DummyData(test_string:String, test_double:Double)
+case class DummyData(test_string: String, test_double: Double)

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/UserDefinedFunctionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/UserDefinedFunctionSpec.scala
@@ -14,15 +14,15 @@ class UserDefinedFunctionSpec extends FunSpec {
       val udf1: UserDefinedFunction = (_: Double) => Seq("hello")
       val udf2: UserDefinedFunction = (v1: Long, v2: Int) => v1 + v2
       val udf3: UserDefinedFunction = (_: Boolean, _: Tensor[Double]) => "hello"
-      val udf4: UserDefinedFunction = (_: Seq[Boolean], _: Option[Seq[String]], _: Seq[Double]) => "hello"
-      val udf5: UserDefinedFunction = (_: Double, _: Float, _: Double, _: Double, _: String) => 55d
+      val udf4: UserDefinedFunction = (_: Seq[Boolean], _: Seq[String], _: Seq[Double]) => "hello"
+      val udf5: UserDefinedFunction = (_: java.lang.Double, _: java.lang.Float, _: java.lang.Double, _: java.lang.Double, _: String) => 55d
 
       assertUdfForm(udf0, ScalarType.String)
-      assertUdfForm(udf1, ListType(BasicType.String), ScalarType.Double)
-      assertUdfForm(udf2, ScalarType.Long, ScalarType.Long, ScalarType.Int)
-      assertUdfForm(udf3, ScalarType.String, ScalarType.Boolean, TensorType(base = BasicType.Double))
-      assertUdfForm(udf4, ScalarType.String, ListType(BasicType.Boolean), ListType(BasicType.String, isNullable = true), ListType(BasicType.Double))
-      assertUdfForm(udf5, ScalarType.Double, ScalarType.Double, ScalarType.Float, ScalarType.Double, ScalarType.Double, ScalarType.String)
+      assertUdfForm(udf1, ListType(BasicType.String), ScalarType.Double.nonNullable)
+      assertUdfForm(udf2, ScalarType.Long.nonNullable, ScalarType.Long.nonNullable, ScalarType.Int.nonNullable)
+      assertUdfForm(udf3, ScalarType.String, ScalarType.Boolean.nonNullable, TensorType(base = BasicType.Double))
+      assertUdfForm(udf4, ScalarType.String, ListType(BasicType.Boolean), ListType(BasicType.String), ListType(BasicType.Double))
+      assertUdfForm(udf5, ScalarType.Double.nonNullable, ScalarType.Double, ScalarType.Float, ScalarType.Double, ScalarType.Double, ScalarType.String)
     }
   }
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/serialization/FrameSerializerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/serialization/FrameSerializerSpec.scala
@@ -21,11 +21,11 @@ class FrameSerializerSpec extends FunSpec {
     StructField("nullable_string", ScalarType.String.asNullable)).get
   val dataset = LocalDataset(Row(Tensor.denseVector(Array(20.0, 10.0, 5.0)),
     "hello", Seq("hello", "there"),
-    Option(56.7d), 32.4f,
+    56.7d, 32.4f,
     Tensor.denseVector(Array[Byte](1, 2, 3, 4)),
     Seq[Short](99, 12, 45),
     ByteString(Array[Byte](32, 4, 55, 67)),
-    None))
+    null))
   val frame = LeapFrame(schema, dataset)
   import MleapContext.defaultContext
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/serialization/FrameSerializerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/serialization/FrameSerializerSpec.scala
@@ -13,12 +13,12 @@ class FrameSerializerSpec extends FunSpec {
   val schema = StructType(StructField("features", TensorType(BasicType.Double)),
     StructField("name", ScalarType.String),
     StructField("list_data", ListType(BasicType.String)),
-    StructField("nullable_double", ScalarType.Double.asNullable),
+    StructField("nullable_double", ScalarType.Double),
     StructField("float", ScalarType.Float),
     StructField("byte_tensor", TensorType(BasicType.Byte)),
     StructField("short_list", ListType(BasicType.Short)),
     StructField("byte_string", ScalarType.ByteString),
-    StructField("nullable_string", ScalarType.String.asNullable)).get
+    StructField("nullable_string", ScalarType.String)).get
   val dataset = LocalDataset(Row(Tensor.denseVector(Array(20.0, 10.0, 5.0)),
     "hello", Seq("hello", "there"),
     56.7d, 32.4f,

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/PipelineSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/PipelineSpec.scala
@@ -16,7 +16,7 @@ class PipelineSpec extends FunSpec {
                         model = LinearRegressionModel(Vectors.dense(1.0, 2.0, 3.0), 4.0)))))
       assert(pipeline.schema.fields == Seq(
           StructField("features", TensorType.Double(3)),
-          StructField("prediction", ScalarType.Double)
+          StructField("prediction", ScalarType.Double.nonNullable)
       ))
     }
   }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/DecisionTreeClassifierSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/DecisionTreeClassifierSpec.scala
@@ -13,7 +13,7 @@ class DecisionTreeClassifierSpec extends FunSpec {
         model = new DecisionTreeClassifierModel(null, 3, 2))
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType(BasicType.Double, Seq(3))),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
 
     it("has the correct inputs and outputs with prediction column as well as probabilityCol") {
@@ -22,7 +22,7 @@ class DecisionTreeClassifierSpec extends FunSpec {
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType(BasicType.Double, Seq(3))),
           StructField("probability", TensorType(BasicType.Double, Seq(2))),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
 
     it("has the correct inputs and outputs with prediction column as well as rawPredictionCol") {
@@ -31,7 +31,7 @@ class DecisionTreeClassifierSpec extends FunSpec {
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType(BasicType.Double, Seq(3))),
           StructField("rp", TensorType(BasicType.Double, Seq(2))),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
 
     it("has the correct inputs and outputs with prediction column as well as both rawPredictionCol and probabilityCol") {
@@ -43,7 +43,7 @@ class DecisionTreeClassifierSpec extends FunSpec {
         Seq(StructField("features", TensorType(BasicType.Double, Seq(3))),
           StructField("rp", TensorType(BasicType.Double, Seq(2))),
           StructField("probability", TensorType(BasicType.Double, Seq(2))),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/GBTClassifierSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/GBTClassifierSpec.scala
@@ -52,7 +52,7 @@ class GBTClassifierSpec extends FunSpec {
         model = new GBTClassifierModel(null, Seq(1.0, 1.0), 3))
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType(BasicType.Double, Seq(3))),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
 
     it("has the correct inputs and outputs with prediction column as well as probabilityCol") {
@@ -61,7 +61,7 @@ class GBTClassifierSpec extends FunSpec {
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType(BasicType.Double, Seq(3))),
           StructField("probability", TensorType(BasicType.Double, Seq(2))),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
 
     it("has the correct inputs and outputs with prediction column as well as rawPredictionCol") {
@@ -70,7 +70,7 @@ class GBTClassifierSpec extends FunSpec {
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType(BasicType.Double, Seq(3))),
           StructField("rp", TensorType(BasicType.Double, Seq(2))),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
 
     it("has the correct inputs and outputs with prediction column as well as both rawPredictionCol and probabilityCol") {
@@ -82,7 +82,7 @@ class GBTClassifierSpec extends FunSpec {
         Seq(StructField("features", TensorType(BasicType.Double, Seq(3))),
           StructField("rp", TensorType(BasicType.Double, Seq(2))),
           StructField("probability", TensorType(BasicType.Double, Seq(2))),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/LogisticRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/LogisticRegressionSpec.scala
@@ -54,7 +54,7 @@ class LogisticRegressionSpec extends FunSpec {
       it("has the correct inputs and outputs") {
         assert(logisticRegression.schema.fields ==
           Seq(StructField("features", TensorType.Double(3)),
-            StructField("prediction", ScalarType.Double)))
+            StructField("prediction", ScalarType.Double.nonNullable)))
       }
 
       it("has the correct inputs and outputs with probability column") {
@@ -62,7 +62,7 @@ class LogisticRegressionSpec extends FunSpec {
         assert(logisticRegression2.schema.fields ==
           Seq(StructField("features", TensorType.Double(3)),
             StructField("probability", TensorType.Double(2)),
-            StructField("prediction", ScalarType.Double)))
+            StructField("prediction", ScalarType.Double.nonNullable)))
       }
 
       it("has the correct inputs and outputs with rawPrediction column") {
@@ -70,7 +70,7 @@ class LogisticRegressionSpec extends FunSpec {
         assert(logisticRegression2.schema.fields ==
           Seq(StructField("features", TensorType.Double(3)),
             StructField("rp", TensorType.Double(2)),
-            StructField("prediction", ScalarType.Double)))
+            StructField("prediction", ScalarType.Double.nonNullable)))
       }
 
       it("has the correct inputs and outputs with both probability and rawPrediction column") {
@@ -81,7 +81,7 @@ class LogisticRegressionSpec extends FunSpec {
           Seq(StructField("features", TensorType.Double(3)),
             StructField("rp", TensorType.Double(2)),
             StructField("p", TensorType.Double(2)),
-            StructField("prediction", ScalarType.Double)))
+            StructField("prediction", ScalarType.Double.nonNullable)))
       }
     }
   }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/MultiLayerPerceptronClassifierSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/MultiLayerPerceptronClassifierSpec.scala
@@ -14,7 +14,7 @@ class MultiLayerPerceptronClassifierSpec extends FunSpec {
           model = new MultiLayerPerceptronClassifierModel(Seq(3, 1), Vectors.dense(Array(1.9, 2.2, 4, 1))))
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType(BasicType.Double, Seq(3))),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/NaiveBayesClassifierSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/NaiveBayesClassifierSpec.scala
@@ -12,7 +12,7 @@ class NaiveBayesClassifierSpec extends FunSpec {
         model = new NaiveBayesModel(3, 2, null, null, null))
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType.Double(3)),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
 
     it("has the correct inputs and outputs with probability column") {
@@ -21,7 +21,7 @@ class NaiveBayesClassifierSpec extends FunSpec {
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType.Double(3)),
           StructField("probability", TensorType.Double(2)),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
 
     it("has the correct inputs and outputs with rawPrediction column") {
@@ -30,7 +30,7 @@ class NaiveBayesClassifierSpec extends FunSpec {
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType.Double(3)),
           StructField("rp", TensorType.Double(2)),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
 
     it("has the correct inputs and outputs with both probability and rawPrediction columns") {
@@ -42,7 +42,7 @@ class NaiveBayesClassifierSpec extends FunSpec {
         Seq(StructField("features", TensorType.Double(3)),
           StructField("rp", TensorType.Double(2)),
           StructField("probability", TensorType.Double(2)),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/RandomForestClassifierSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/RandomForestClassifierSpec.scala
@@ -12,7 +12,7 @@ class RandomForestClassifierSpec extends FunSpec {
         model = new RandomForestClassifierModel(Seq(), Seq(), 3, 2))
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType(BasicType.Double, Seq(3))),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
 
     it("has the correct inputs and outputs with probability column") {
@@ -21,7 +21,7 @@ class RandomForestClassifierSpec extends FunSpec {
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType(BasicType.Double, Seq(3))),
           StructField("probability", TensorType(BasicType.Double, Seq(2))),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
 
     it("has the correct inputs and outputs with rawPrediction column") {
@@ -30,7 +30,7 @@ class RandomForestClassifierSpec extends FunSpec {
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType(BasicType.Double, Seq(3))),
           StructField("rp", TensorType(BasicType.Double, Seq(2))),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
 
     it("has the correct inputs and outputs with both probability and rawPrediction columns") {
@@ -42,7 +42,7 @@ class RandomForestClassifierSpec extends FunSpec {
         Seq(StructField("features", TensorType(BasicType.Double, Seq(3))),
           StructField("rp", TensorType(BasicType.Double, Seq(2))),
           StructField("probability", TensorType(BasicType.Double, Seq(2))),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/SupportVectorMachineSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/SupportVectorMachineSpec.scala
@@ -13,7 +13,7 @@ class SupportVectorMachineSpec extends FunSpec {
         model = new SupportVectorMachineModel(Vectors.dense(1, 2, 3), 2))
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType.Double(3)),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
 
     it("has the correct inputs and outputs with probability column") {
@@ -22,7 +22,7 @@ class SupportVectorMachineSpec extends FunSpec {
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType.Double(3)),
           StructField("probability", TensorType.Double(2)),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
 
     it("has the correct inputs and outputs with rawPrediction column") {
@@ -31,7 +31,7 @@ class SupportVectorMachineSpec extends FunSpec {
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType.Double(3)),
           StructField("rp", TensorType(BasicType.Double, Seq(2))),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
 
     it("has the correct inputs and outputs with both probability and rawPrediction columns") {
@@ -43,7 +43,7 @@ class SupportVectorMachineSpec extends FunSpec {
         Seq(StructField("features", TensorType.Double(3)),
           StructField("rp", TensorType.Double(2)),
           StructField("probability", TensorType.Double(2)),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/clustering/BisectingKMeansSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/clustering/BisectingKMeansSpec.scala
@@ -16,7 +16,7 @@ class BisectingKMeansSpec extends FunSpec {
 
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType.Double(3)),
-          StructField("prediction", ScalarType.Int)))
+          StructField("prediction", ScalarType.Int.nonNullable)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/clustering/GaussianMixtureSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/clustering/GaussianMixtureSpec.scala
@@ -12,7 +12,7 @@ class GaussianMixtureSpec extends FunSpec {
         model = new GaussianMixtureModel(Array(null, null), Array(1, 2, 3)))
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType.Double(3)),
-          StructField("prediction", ScalarType.Int)))
+          StructField("prediction", ScalarType.Int.nonNullable)))
     }
 
     it("has the correct inputs and outputs with only prediction column as well as probability column") {
@@ -20,7 +20,7 @@ class GaussianMixtureSpec extends FunSpec {
         model = new GaussianMixtureModel(Array(null, null, null, null), Array(1, 2, 3)))
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType.Double(3)),
-          StructField("prediction", ScalarType.Int),
+          StructField("prediction", ScalarType.Int.nonNullable),
           StructField("probability", TensorType.Double(4))))
     }
   }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/clustering/KMeansSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/clustering/KMeansSpec.scala
@@ -43,7 +43,7 @@ class KMeansSpec extends FunSpec {
     it("has the correct inputs and outputs") {
       assert(km.schema.fields ==
         Seq(StructField("features", TensorType.Double(3)),
-          StructField("prediction", ScalarType.Int)))
+          StructField("prediction", ScalarType.Int.nonNullable)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/BinarizerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/BinarizerSpec.scala
@@ -62,7 +62,7 @@ class BinarizerSpec extends FunSpec {
       it("has the correct inputs and outputs") {
         assert(binarizer2.schema.fields ==
           Seq(StructField("test", ScalarType.Double),
-            StructField("test_binarizer", ScalarType.Double)))
+            StructField("test_binarizer", ScalarType.Double.nonNullable)))
       }
     }
   }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/BinarizerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/BinarizerSpec.scala
@@ -61,7 +61,7 @@ class BinarizerSpec extends FunSpec {
     describe("input/output schema") {
       it("has the correct inputs and outputs") {
         assert(binarizer2.schema.fields ==
-          Seq(StructField("test", ScalarType.Double),
+          Seq(StructField("test", ScalarType.Double.nonNullable),
             StructField("test_binarizer", ScalarType.Double.nonNullable)))
       }
     }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/BucketizerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/BucketizerSpec.scala
@@ -44,8 +44,8 @@ class BucketizerSpec extends FunSpec {
   describe("input/output schema") {
     it("has the correct inputs and outputs") {
       assert(bucketizer.schema.fields ==
-        Seq(StructField("test_double", ScalarType.Double),
-          StructField("test_bucket", ScalarType.Double)))
+        Seq(StructField("test_double", ScalarType.Double.nonNullable),
+          StructField("test_bucket", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/CoalesceSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/CoalesceSpec.scala
@@ -9,10 +9,10 @@ import org.scalatest.FunSpec
   * Created by hollinwilkins on 1/5/17.
   */
 class CoalesceSpec extends FunSpec {
-  val schema = StructType(StructField("test1", ScalarType.Double.asNullable),
-    StructField("test2", ScalarType.Double.asNullable),
-    StructField("test3", ScalarType.Double.asNullable),
-    StructField("test4", ScalarType.Double)).get
+  val schema = StructType(StructField("test1", ScalarType.Double),
+    StructField("test2", ScalarType.Double),
+    StructField("test3", ScalarType.Double),
+    StructField("test4", ScalarType.Double.nonNullable)).get
   val dataset = LocalDataset(Seq(Row(null, null, 23.4, 56.7),
     Row(null, null, null, 34.4)))
   val frame = LeapFrame(schema, dataset)
@@ -36,10 +36,10 @@ class CoalesceSpec extends FunSpec {
     describe("input/output schema") {
       it("has the correct inputs and outputs") {
         assert(coalesce.schema.fields ==
-          Seq(StructField("test1", ScalarType.Double.asNullable),
-            StructField("test2", ScalarType.Double.asNullable),
-            StructField("test3", ScalarType.Double.asNullable),
-            StructField("test_bucket", ScalarType.Double.asNullable)))
+          Seq(StructField("test1", ScalarType.Double),
+            StructField("test2", ScalarType.Double),
+            StructField("test3", ScalarType.Double),
+            StructField("test_bucket", ScalarType.Double)))
       }
     }
   }
@@ -63,10 +63,10 @@ class CoalesceSpec extends FunSpec {
     describe("input/output schema") {
       it("has the correct inputs and outputs") {
         assert(coalesce.schema.fields ==
-          Seq(StructField("test1", ScalarType.Double.asNullable),
-            StructField("test3", ScalarType.Double.asNullable),
-            StructField("test4", ScalarType.Double),
-            StructField("test_bucket", ScalarType.Double.asNullable)))
+          Seq(StructField("test1", ScalarType.Double),
+            StructField("test3", ScalarType.Double),
+            StructField("test4", ScalarType.Double.nonNullable),
+            StructField("test_bucket", ScalarType.Double)))
       }
     }
   }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/CoalesceSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/CoalesceSpec.scala
@@ -13,8 +13,8 @@ class CoalesceSpec extends FunSpec {
     StructField("test2", ScalarType.Double.asNullable),
     StructField("test3", ScalarType.Double.asNullable),
     StructField("test4", ScalarType.Double)).get
-  val dataset = LocalDataset(Seq(Row(None, None, Some(23.4), 56.7),
-    Row(None, None, None, 34.4)))
+  val dataset = LocalDataset(Seq(Row(null, null, 23.4, 56.7),
+    Row(null, null, null, 34.4)))
   val frame = LeapFrame(schema, dataset)
 
   describe("with all optional doubles") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/ImputerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/ImputerSpec.scala
@@ -13,10 +13,10 @@ class ImputerSpec extends FunSpec {
     val transformer = Imputer(
       shape = NodeShape().withStandardInput("test_a").
               withStandardOutput("test_out"),
-      model = ImputerModel(45.7, 23.6, "", nullableInput = true))
+      model = ImputerModel(45.7, 23.6, ""))
 
     describe("null values") {
-      val schema = StructType(StructField("test_a", ScalarType.Double.asNullable)).get
+      val schema = StructType(StructField("test_a", ScalarType.Double)).get
       val dataset = LocalDataset(Seq(Row(42.0), Row(null), Row(23.6)))
       val frame = LeapFrame(schema, dataset)
 
@@ -30,7 +30,7 @@ class ImputerSpec extends FunSpec {
 
       it("has the correct inputs and outputs") {
         assert(transformer.schema.fields ==
-          Seq(StructField("test_a", ScalarType.Double.asNullable),
+          Seq(StructField("test_a", ScalarType.Double),
             StructField("test_out", ScalarType.Double)))
       }
     }
@@ -54,7 +54,7 @@ class ImputerSpec extends FunSpec {
 
       it("has the correct inputs and outputs") {
         assert(transformer2.schema.fields ==
-          Seq(StructField("test_a", ScalarType.Double),
+          Seq(StructField("test_a", ScalarType.Double.nonNullable),
             StructField("test_out", ScalarType.Double)))
       }
     }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/ImputerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/ImputerSpec.scala
@@ -17,7 +17,7 @@ class ImputerSpec extends FunSpec {
 
     describe("null values") {
       val schema = StructType(StructField("test_a", ScalarType.Double.asNullable)).get
-      val dataset = LocalDataset(Seq(Row(Option(42.0)), Row(None), Row(Option(23.6))))
+      val dataset = LocalDataset(Seq(Row(42.0), Row(null), Row(23.6)))
       val frame = LeapFrame(schema, dataset)
 
       it("transforms the leap frame using the given input and operation") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/ImputerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/ImputerSpec.scala
@@ -31,7 +31,7 @@ class ImputerSpec extends FunSpec {
       it("has the correct inputs and outputs") {
         assert(transformer.schema.fields ==
           Seq(StructField("test_a", ScalarType.Double),
-            StructField("test_out", ScalarType.Double)))
+            StructField("test_out", ScalarType.Double.nonNullable)))
       }
     }
 
@@ -55,7 +55,7 @@ class ImputerSpec extends FunSpec {
       it("has the correct inputs and outputs") {
         assert(transformer2.schema.fields ==
           Seq(StructField("test_a", ScalarType.Double.nonNullable),
-            StructField("test_out", ScalarType.Double)))
+            StructField("test_out", ScalarType.Double.nonNullable)))
       }
     }
   }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MathBinarySpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MathBinarySpec.scala
@@ -28,9 +28,9 @@ class MathBinarySpec extends FunSpec {
 
     it("has correct inputs and outputs with a and b inputs") {
       assert(transformer.schema.fields ==
-        Seq(StructField("test_a", ScalarType.Double),
-          StructField("test_b", ScalarType.Double),
-          StructField("test_out", ScalarType.Double)))
+        Seq(StructField("test_a", ScalarType.Double.nonNullable),
+          StructField("test_b", ScalarType.Double.nonNullable),
+          StructField("test_out", ScalarType.Double.nonNullable)))
     }
   }
 
@@ -47,8 +47,8 @@ class MathBinarySpec extends FunSpec {
 
     it("has correct inputs and outputs using the default b") {
       assert(transformer.schema.fields ==
-        Seq(StructField("test_a", ScalarType.Double),
-          StructField("test_out", ScalarType.Double)))
+        Seq(StructField("test_a", ScalarType.Double.nonNullable),
+          StructField("test_out", ScalarType.Double.nonNullable)))
     }
   }
 
@@ -65,8 +65,8 @@ class MathBinarySpec extends FunSpec {
 
     it("has correct inputs and outputs using the default a") {
       assert(transformer.schema.fields ==
-        Seq(StructField("test_b", ScalarType.Double),
-          StructField("test_out", ScalarType.Double)))
+        Seq(StructField("test_b", ScalarType.Double.nonNullable),
+          StructField("test_out", ScalarType.Double.nonNullable)))
     }
   }
 
@@ -80,7 +80,7 @@ class MathBinarySpec extends FunSpec {
     }
 
     it("has correct inputs and outputs using both defaults") {
-      assert(transformer.schema.fields == Seq(StructField("test_out", ScalarType.Double)))
+      assert(transformer.schema.fields == Seq(StructField("test_out", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MathUnarySpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MathUnarySpec.scala
@@ -29,8 +29,8 @@ class MathUnarySpec extends FunSpec {
   describe("input/output schema") {
     it("has the correct inputs and outputs") {
       assert(transformer.schema.fields ==
-        Seq(StructField("test_a", ScalarType.Double),
-          StructField("test_out", ScalarType.Double)))
+        Seq(StructField("test_a", ScalarType.Double.nonNullable),
+          StructField("test_out", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/OneHotEncoderSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/OneHotEncoderSpec.scala
@@ -10,7 +10,7 @@ class OneHotEncoderSpec extends FunSpec {
     it("has the correct inputs and outputs") {
       val transformer = OneHotEncoder(shape = NodeShape.vector(1, 5), model = OneHotEncoderModel(5))
       assert(transformer.schema.fields ==
-        Seq(StructField("input", ScalarType.Double),
+        Seq(StructField("input", ScalarType.Double.nonNullable),
           StructField("output", TensorType.Double(5))))
     }
   }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/ReverseStringIndexerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/ReverseStringIndexerSpec.scala
@@ -14,7 +14,7 @@ class ReverseStringIndexerSpec extends FunSpec {
       ), model = new ReverseStringIndexerModel(Seq("one", "two", "three")))
 
       assert(transformer.schema.fields ==
-        Seq(StructField("input", ScalarType.Double),
+        Seq(StructField("input", ScalarType.Double.nonNullable),
           StructField("output", ScalarType.String)))
     }
   }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/StringIndexerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/StringIndexerSpec.scala
@@ -48,7 +48,7 @@ class StringIndexerSpec extends FunSpec {
     it("has the correct inputs and outputs") {
       assert(stringIndexer.schema.fields ==
         Seq(StructField("test_string", ScalarType.String),
-          StructField("test_index", ScalarType.Double)))
+          StructField("test_index", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/AFTSurvivalRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/AFTSurvivalRegressionSpec.scala
@@ -15,7 +15,7 @@ class AFTSurvivalRegressionSpec extends FunSpec {
         model = new AFTSurvivalRegressionModel(Vectors.dense(1, 3, 4), 23, Array(1, 2, 3, 4, 5), 5))
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType.Double(3)),
-          StructField("prediction", ScalarType.Double),
+          StructField("prediction", ScalarType.Double.nonNullable),
           StructField("quantiles", TensorType.Double(5))))
     }
   }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/DecisionTreeRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/DecisionTreeRegressionSpec.scala
@@ -17,7 +17,7 @@ class DecisionTreeRegressionSpec extends FunSpec {
 
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType.Double(3)),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/GBTRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/GBTRegressionSpec.scala
@@ -39,7 +39,7 @@ class GBTRegressionSpec extends FunSpec {
     it("has the correct inputs and outputs") {
       assert(gbt.schema.fields ==
         Seq(StructField("features", TensorType.Double(5)),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/GeneralizedLinearRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/GeneralizedLinearRegressionSpec.scala
@@ -13,7 +13,7 @@ class GeneralizedLinearRegressionSpec extends FunSpec {
         model = new GeneralizedLinearRegressionModel(Vectors.dense(1, 2, 3), 23, null))
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType.Double(3)),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
 
     it("has the correct inputs and outputs with prediction column as well as linkPrediction column") {
@@ -22,8 +22,8 @@ class GeneralizedLinearRegressionSpec extends FunSpec {
         model = new GeneralizedLinearRegressionModel(Vectors.dense(1, 2, 3), 23, null))
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType.Double(3)),
-          StructField("prediction", ScalarType.Double),
-          StructField("lp", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable),
+          StructField("lp", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/IsotonicRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/IsotonicRegressionSpec.scala
@@ -14,8 +14,8 @@ class IsotonicRegressionSpec extends FunSpec {
         isotonic = true,
         featureIndex = None))
       assert(transformer.schema.fields ==
-        Seq(StructField("features", ScalarType.Double),
-          StructField("prediction", ScalarType.Double)))
+        Seq(StructField("features", ScalarType.Double.nonNullable),
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
 
     it("has the correct inputs and outputs with feature index") {
@@ -26,7 +26,7 @@ class IsotonicRegressionSpec extends FunSpec {
           featureIndex = Some(2)))
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType.Double()),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/LinearRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/LinearRegressionSpec.scala
@@ -41,7 +41,7 @@ class LinearRegressionSpec extends FunSpec {
     it("has the correct inputs and outputs") {
       assert(linearRegression.schema.fields ==
         Seq(StructField("features", TensorType.Double(3)),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/RandomForestRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/RandomForestRegressionSpec.scala
@@ -19,7 +19,7 @@ class RandomForestRegressionSpec extends FunSpec {
         model = regression)
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType.Double(5)),
-          StructField("prediction", ScalarType.Double)))
+          StructField("prediction", ScalarType.Double.nonNullable)))
     }
   }
 }

--- a/mleap-serving/src/test/scala/ml/combust/mleap/serving/MleapServiceSpec.scala
+++ b/mleap-serving/src/test/scala/ml/combust/mleap/serving/MleapServiceSpec.scala
@@ -90,7 +90,7 @@ class MleapServiceSpec extends AsyncFunSpec with Matchers {
         assert(schema.getField("second_double").get.dataType == ScalarType.Double)
         assert(schema.getField("third_double").get.dataType == ScalarType.Double)
         assert(schema.getField("features").get.dataType == TensorType(BasicType.Double, Some(Seq(3))))
-        assert(schema.getField("prediction").get.dataType == ScalarType.Double)
+        assert(schema.getField("prediction").get.dataType == ScalarType.Double.nonNullable)
       })
     }
 

--- a/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
+++ b/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
@@ -29,8 +29,6 @@ trait TypeConverters {
         val s = t.head.size
         val values = t.flatMap(_.toArray).toArray
         DenseTensor(values, Seq(t.size, s))
-    case StringType if isNullable =>
-      (v: Any) => Option(v.asInstanceOf[String])
     case _ => (v) => v
   }
 
@@ -81,8 +79,6 @@ trait TypeConverters {
   }
 
   def mleapToSparkValue(dataType: types.DataType): (Any) => Any = dataType match {
-    case types.ScalarType(BasicType.String, true) => (v: Any) => v.asInstanceOf[Option[String]].orNull
-    case types.ScalarType(_, true) => (v: Any) => v.asInstanceOf[Option[Any]].get
     case tt: types.TensorType =>
       if(tt.dimensions.isEmpty) {
         (v: Any) => v.asInstanceOf[Tensor[_]](0)

--- a/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
+++ b/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
@@ -11,7 +11,7 @@ import com.databricks.spark.avro._
 import ml.combust.bundle.BundleFile
 import ml.combust.bundle.serializer.SerializationFormat
 import ml.combust.mleap.core.Model
-import ml.combust.mleap.core.types.{DataType, TensorType}
+import ml.combust.mleap.core.types.{BasicType, DataType, TensorType}
 import ml.combust.mleap.runtime.MleapContext
 import org.apache.spark.ml.bundle.SparkBundleContext
 import ml.combust.mleap.spark.SparkSupport._
@@ -80,8 +80,28 @@ abstract class SparkParityBase extends FunSpec with BeforeAndAfterAll {
   }
 
   def asssertModelTypesMatchTransformerTypes(model: Model, exec: UserDefinedFunction) = {
+//    println("\n\n*************** INPUT")
+//    println("*************** INPUT")
+//    println("*************** INPUT")
+//    println(model)
+//    println("=============== INPUT")
+//    println(model.inputSchema)
+//    println("=============== INPUT")
+//    println("MODEL: " + model.inputSchema.fields.map(field => field.dataType))
+//    println("TRANSFORMER: " + exec.inputs.map(in => in.dataTypes).flatten)
+//    println("===============\n\n")
     checkTypes(model.inputSchema.fields.map(field => field.dataType),
       exec.inputs.map(in => in.dataTypes).flatten)
+
+//    println("\n\n***************")
+//    println("***************")
+//    println(model)
+//    println("===============")
+//    println(model.outputSchema)
+//    println("===============")
+//    println("MODEL: " + model.outputSchema.fields.map(field => field.dataType))
+//    println("TRANSFORMER: " + exec.output.dataTypes)
+//    println("===============\n\n")
     checkTypes(model.outputSchema.fields.map(field => field.dataType),
       exec.output.dataTypes)
   }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOp.scala
@@ -18,12 +18,7 @@ class StringIndexerOp extends SimpleSparkOp[StringIndexerModel] {
 
     override def store(model: Model, obj: StringIndexerModel)
                       (implicit context: BundleContext[SparkBundleContext]): Model = {
-      val dataset = context.context.dataset.get
-      val field = dataset.schema(obj.getInputCol)
-      val isNullable = field.dataType == org.apache.spark.sql.types.StringType && field.nullable
-
       model.withValue("labels", Value.stringList(obj.labels)).
-        withValue("nullable_input", Value.boolean(isNullable)).
         withValue("handle_invalid", Value.string(obj.getHandleInvalid))
     }
 


### PR DESCRIPTION
Spark handles null values through a mix of boxing/unboxing for primitive types and plain old null values for objects. We should handle nulls the same way.

This PR gets rid of the notion of an Option[T] as a null value in MLeap. Instead, we rely on boxing/unboxing and nulls.

This is desirable for several reasons:
1. It closer matches how Spark works
2. It will allow us to integrate more easily with libraries like Apache Arrow and Parquet
3. Java integration becomes much simpler, no need for handling Scala Options!