### PR TITLE
Fix LogisticRegressionOpV21 for binary classification

### DIFF
--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOpV21.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOpV21.scala
@@ -63,7 +63,7 @@ class LogisticRegressionOpV21 extends SimpleSparkOp[LogisticRegressionModel] {
       coefficientMatrix = model.coefficientMatrix,
       interceptVector = model.interceptVector,
       numClasses = model.numClasses,
-      isMultinomial = true)
+      isMultinomial = if (model.numClasses > 2) true else false)
     if(r.isDefined(r.thresholds)) { r.setThresholds(r.getThresholds) }
     r
   }


### PR DESCRIPTION
When reading a LR model into spark pipeline, its family is always set to multinomial which causes an exception. This PR tries to correctly set the family of the model.

    val sparkBundle = (for(bundle <- managed(BundleFile("jar:file:" + bundleFi)))  yield {
       bundle.loadSparkBundle().get
    }).opt.get
    val model = sparkBundle.root
    val lrModel = model.asInstanceOf[PipelineModel].stages.filter(_.isInstanceOf[LogisticRegressionModel])(0).asInstanceOf[LogisticRegressionModel]
    println("Intercept = " + lrModel.intercept)

Exception in thread "main" org.apache.spark.SparkException: Multinomial models contain a vector of intercepts, use interceptVector instead.
        at org.apache.spark.ml.classification.LogisticRegressionModel.intercept(LogisticRegression.scala:953)


