### PR TITLE
Fix LR threshold/thresholds when loading model into spark pipeline

### DIFF
--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOpV21.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOpV21.scala
@@ -63,7 +63,7 @@ class LogisticRegressionOpV21 extends SimpleSparkOp[LogisticRegressionModel] {
       coefficientMatrix = model.coefficientMatrix,
       interceptVector = model.interceptVector,
       numClasses = model.numClasses,
-      isMultinomial = true)
+      isMultinomial = if (model.numClasses > 2) true else false)
     if(r.isDefined(r.thresholds)) { r.setThresholds(r.getThresholds) }
     r
   }


### PR DESCRIPTION
@hollinwilkins 

Follow up the #264, the threshold/thresholds param of an LR model should be set according to the binary/multi class. I've tested that the following line does not work.

https://github.com/combust/mleap/blob/0c3329feaf40a0eac399eead70f9f4967e311ea6/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOpV21.scala#L55-L67

So, I propose this PR.  

I also wonder if GBTClassificationModel really has thresholds param to set? I don't see it in Spark api.

https://github.com/combust/mleap/blob/0c3329feaf40a0eac399eead70f9f4967e311ea6/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/GBTClassifierOpV22.scala#L55-L66

Any comments.   