### PR TITLE
Make sure that JSON serialization retains all information for data types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 import ml.combust.mleap.MleapProject
 
+enablePlugins(CrossPerProjectPlugin)
+
 lazy val root = MleapProject.root
 lazy val base = MleapProject.baseProject
 lazy val bundleMl = MleapProject.bundleMl

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/json/SchemaSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/json/SchemaSpec.scala
@@ -1,0 +1,41 @@
+package ml.combust.mleap.json
+
+import ml.combust.mleap.core.types._
+import JsonSupport._
+import spray.json._
+import org.scalatest.FunSpec
+
+/**
+  * Created by hollinwilkins on 9/25/17.
+  */
+class SchemaSpec extends FunSpec {
+  private val BASIC_TYPES = Seq(
+    BasicType.Boolean,
+    BasicType.Byte,
+    BasicType.Short,
+    BasicType.Int,
+    BasicType.Long,
+    BasicType.Float,
+    BasicType.Double,
+    BasicType.String,
+    BasicType.ByteString
+  )
+
+  private val DATA_TYPES: Seq[DataType] = BASIC_TYPES.flatMap {
+    bt =>
+      Seq[DataType](ScalarType(bt).asNullable,
+        ScalarType(bt).nonNullable,
+        ListType(bt).asNullable,
+        ListType(bt).nonNullable,
+        TensorType(bt, Seq(23, 44)).asNullable,
+        TensorType(bt, Seq(23, 44)).nonNullable)
+  }
+
+  describe("DataType -> JSON -> DataType") {
+    for(dt <- DATA_TYPES) {
+      it(s"$dt retains all information") {
+        assert(dt.toJson.convertTo[DataType] == dt)
+      }
+    }
+  }
+}

--- a/mleap-serving/src/test/scala/ml/combust/mleap/serving/MleapResourceSpec.scala
+++ b/mleap-serving/src/test/scala/ml/combust/mleap/serving/MleapResourceSpec.scala
@@ -60,7 +60,7 @@ class MleapResourceSpec extends FunSpec with Matchers with ScalatestRouteTest wi
         assert(schema.getField("second_double").get.dataType == ScalarType.Double)
         assert(schema.getField("third_double").get.dataType == ScalarType.Double)
         assert(schema.getField("features").get.dataType == TensorType(BasicType.Double, Some(Seq(3))))
-        assert(schema.getField("prediction").get.dataType == ScalarType.Double)
+        assert(schema.getField("prediction").get.dataType == ScalarType.Double.nonNullable)
       }
     }
 

--- a/project/MleapProject.scala
+++ b/project/MleapProject.scala
@@ -11,6 +11,7 @@ object MleapProject {
       core,
       runtime,
       avro,
+      serving,
       sparkBase,
       sparkTestkit,
       spark,

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -8,17 +8,17 @@ import xerial.sbt.Sonatype.SonatypeCommand
 
 object Release {
   lazy val settings = Seq(releaseVersionBump := sbtrelease.Version.Bump.Minor,
-    releaseCrossBuild := true,
+    releaseCrossBuild := false, // rely on sbt-doge for cross versions
 
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,
       inquireVersions,
       runClean,
-      runTest,
+      releaseStepCommand("+ test"),
       setReleaseVersion,
       commitReleaseVersion,
       tagRelease,
-      publishArtifacts,
+      releaseStepCommand("+ publishSigned"),
       releaseStepCommand(SonatypeCommand.sonatypeRelease),
       releaseStepTask(publish in autoImport.Docker in MleapProject.serving),
       setNextVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,5 +7,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
+addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
 
 libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.0"


### PR DESCRIPTION
This PR fixes the issue outlined here: https://github.com/combust/mleap/issues/269

As well as bugs with retaining nullability in the list and tensor data type.
Added specs to make sure this doesn't crop up again, even if default nullability or anything like that changes in the internals.