### PR TITLE
Fix MaxAbsScaler.

### DIFF
--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/MaxAbsScalerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/MaxAbsScalerModel.scala
@@ -37,7 +37,7 @@ case class MaxAbsScalerModel(maxAbs: Vector) extends Model {
         while (i < nnz) {
           val raw = max(-1.0, min(1.0, values(i) / maxAbsUnzero(i)))
 
-          vs(i) *= raw
+          vs(i) = raw
           i += 1
         }
         Vectors.sparse(size, indices, vs)


### PR DESCRIPTION
This fixes the issue with MaxAbsScaler not producing the same values as Spark.

https://github.com/combust/mleap/issues/272