### PR TITLE
SimpleTransformer & MultiTransformer input fixes

### DIFF
--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/Transformer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/Transformer.scala
@@ -92,7 +92,7 @@ trait BaseTransformer extends Transformer {
 trait SimpleTransformer extends BaseTransformer {
   val output: String = outputSchema.fields.head.name
 
-  lazy val typedExec: UserDefinedFunction = exec.withOutput(outputSchema)
+  lazy val typedExec: UserDefinedFunction = exec.withInputs(inputSchema).withOutput(outputSchema)
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
     builder.withOutput(output, selectors: _*)(typedExec)
   }
@@ -101,7 +101,7 @@ trait SimpleTransformer extends BaseTransformer {
 trait MultiTransformer extends BaseTransformer {
   val outputs: Seq[String] = outputSchema.fields.map(_.name)
 
-  lazy val typedExec: UserDefinedFunction = exec.withOutput(outputSchema)
+  lazy val typedExec: UserDefinedFunction = exec.withInputs(inputSchema).withOutput(outputSchema)
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
     builder.withOutputs(outputs, selectors: _*)(typedExec)
   }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/RegexTokenizer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/RegexTokenizer.scala
@@ -8,6 +8,5 @@ import ml.combust.mleap.runtime.transformer.{SimpleTransformer, Transformer}
 case class RegexTokenizer(override val uid: String = Transformer.uniqueName("regex_tokenizer"),
                           override val shape: NodeShape,
                           override val model: RegexTokenizerModel) extends SimpleTransformer {
-  override val exec: UserDefinedFunction = UserDefinedFunction((value: String) => model(value),
-    ListType(BasicType.String), ScalarType.String.nonNullable)
+  override val exec: UserDefinedFunction = (value: String) => model(value)
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Tokenizer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Tokenizer.scala
@@ -11,6 +11,5 @@ import ml.combust.mleap.runtime.transformer.{SimpleTransformer, Transformer}
 case class Tokenizer(override val uid: String = Transformer.uniqueName("tokenizer"),
                      override val shape: NodeShape,
                      override val model: TokenizerModel) extends SimpleTransformer {
-  override val exec: UserDefinedFunction = UserDefinedFunction((value: String) => model(value),
-    ListType(BasicType.String), ScalarType.String.nonNullable)
+  override val exec: UserDefinedFunction = (value: String) => model(value)
 }

--- a/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
+++ b/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
@@ -4,18 +4,19 @@ import java.io.File
 
 import ml.combust.mleap.runtime
 import org.apache.spark.ml.Transformer
-import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.scalatest.{BeforeAndAfterAll, FunSpec}
 import ml.combust.mleap.runtime.MleapSupport._
 import com.databricks.spark.avro._
 import ml.combust.bundle.BundleFile
 import ml.combust.bundle.serializer.SerializationFormat
 import ml.combust.mleap.core.Model
-import ml.combust.mleap.core.types.{DataType, TensorType}
+import ml.combust.mleap.core.types.{DataType, NodeShape, TensorType}
 import ml.combust.mleap.runtime.MleapContext
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 import org.apache.spark.ml.bundle.SparkBundleContext
 import ml.combust.mleap.spark.SparkSupport._
-import ml.combust.mleap.runtime.transformer.{BaseTransformer, Pipeline}
+import ml.combust.mleap.runtime.transformer.{BaseTransformer, MultiTransformer, Pipeline, SimpleTransformer}
 import resource._
 
 /**
@@ -79,18 +80,18 @@ abstract class SparkParityBase extends FunSpec with BeforeAndAfterAll {
     }).tried.get
   }
 
-  def assertModelTypesMatchTransformerTypes(model: Model, transformer: BaseTransformer): Unit = {
-    val modelInputTypes = transformer.shape.inputs.
+  def assertModelTypesMatchTransformerTypes(model: Model, shape: NodeShape, exec: UserDefinedFunction): Unit = {
+    val modelInputTypes = shape.inputs.
       map(_._2.port).
       map(n => model.inputSchema.getField(n).get.dataType).
       toSeq
-    val transformerInputTypes = transformer.exec.inputs.flatMap(_.dataTypes)
+    val transformerInputTypes = exec.inputs.flatMap(_.dataTypes)
 
-    val modelOutputTypes = transformer.shape.outputs.
+    val modelOutputTypes = shape.outputs.
       map(_._2.port).
       map(n => model.outputSchema.getField(n).get.dataType).
       toSeq
-    val transformerOutputTypes = transformer.exec.outputTypes
+    val transformerOutputTypes = exec.outputTypes
 
     checkTypes(modelInputTypes, transformerInputTypes)
     checkTypes(modelOutputTypes, transformerOutputTypes)
@@ -153,12 +154,20 @@ abstract class SparkParityBase extends FunSpec with BeforeAndAfterAll {
       val mTransformer = mleapTransformer(sparkTransformer)
 
       mTransformer match {
+        case transformer: SimpleTransformer =>
+          assertModelTypesMatchTransformerTypes(transformer.model, transformer.shape, transformer.typedExec)
+        case transformer: MultiTransformer =>
+          assertModelTypesMatchTransformerTypes(transformer.model, transformer.shape, transformer.typedExec)
         case transformer: BaseTransformer =>
-          assertModelTypesMatchTransformerTypes(transformer.model, transformer)
+          assertModelTypesMatchTransformerTypes(transformer.model, transformer.shape, transformer.exec)
         case pipeline: Pipeline =>
           pipeline.transformers.foreach {
+            case transformer: SimpleTransformer =>
+              assertModelTypesMatchTransformerTypes(transformer.model, transformer.shape, transformer.typedExec)
+            case transformer: MultiTransformer =>
+              assertModelTypesMatchTransformerTypes(transformer.model, transformer.shape, transformer.typedExec)
             case stage: BaseTransformer =>
-              assertModelTypesMatchTransformerTypes(stage.model, stage)
+              assertModelTypesMatchTransformerTypes(stage.model, stage.shape, stage.exec)
             case _ => // no udf to check against
           }
         case _ => // no udf to check against


### PR DESCRIPTION
Fix typedExec copying inputs from the model for the UDF.
Change Spark parity base to check for typedExec for Simple and Multi Transformers.