### PR TITLE
Make sure that serialization errors bubble up to PySpark.

### DIFF
--- a/mleap-spark-base/src/main/scala/ml/combust/mleap/spark/SimpleSparkSerializer.scala
+++ b/mleap-spark-base/src/main/scala/ml/combust/mleap/spark/SimpleSparkSerializer.scala
@@ -18,7 +18,7 @@ class SimpleSparkSerializer() {
       getOrElse(SparkBundleContext.defaultContext)
 
     (for(file <- managed(BundleFile(path))) yield {
-      transformer.writeBundle.save(file)
+      transformer.writeBundle.save(file).get
     }).tried.get
   }
 


### PR DESCRIPTION
This is to make sure that when serializing with PySpark we see any errors that occur.