### PR TITLE
Allow serialization format to be set in SimpleSparkSerializer

### DIFF
--- a/mleap-spark-base/src/main/scala/ml/combust/mleap/spark/SimpleSparkSerializer.scala
+++ b/mleap-spark-base/src/main/scala/ml/combust/mleap/spark/SimpleSparkSerializer.scala
@@ -2,6 +2,7 @@ package ml.combust.mleap.spark
 
 import ml.combust.bundle.BundleFile
 import ml.combust.mleap.spark.SparkSupport._
+import ml.combust.bundle.serializer.SerializationFormat
 import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.sql.DataFrame
@@ -12,13 +13,13 @@ import resource._
   *
   */
 class SimpleSparkSerializer() {
-  def serializeToBundle(transformer: Transformer, path: String, dataset: DataFrame): Unit = {
+  def serializeToBundle(transformer: Transformer, path: String, dataset: DataFrame, format: SerializationFormat = SerializationFormat.Json): Unit = {
     implicit val context: SparkBundleContext = Option(dataset).
       map(d => SparkBundleContext.defaultContext.withDataset(d)).
       getOrElse(SparkBundleContext.defaultContext)
 
     (for(file <- managed(BundleFile(path))) yield {
-      transformer.writeBundle.save(file).get
+      transformer.writeBundle.format(format).save(file).get
     }).tried.get
   }
 

--- a/mleap-spark-base/src/main/scala/ml/combust/mleap/spark/SimpleSparkSerializer.scala
+++ b/mleap-spark-base/src/main/scala/ml/combust/mleap/spark/SimpleSparkSerializer.scala
@@ -13,7 +13,11 @@ import resource._
   *
   */
 class SimpleSparkSerializer() {
-  def serializeToBundle(transformer: Transformer, path: String, dataset: DataFrame, format: SerializationFormat = SerializationFormat.Json): Unit = {
+  def serializeToBundle(transformer: Transformer, path: String, dataset: DataFrame): Unit = {
+    serializeToBundleWithFormat(transformer = transformer, path = path, dataset = dataset, format = SerializationFormat.Json)
+  }
+
+  def serializeToBundleWithFormat(transformer: Transformer, path: String, dataset: DataFrame, format: SerializationFormat = SerializationFormat.Json): Unit = {
     implicit val context: SparkBundleContext = Option(dataset).
       map(d => SparkBundleContext.defaultContext.withDataset(d)).
       getOrElse(SparkBundleContext.defaultContext)


### PR DESCRIPTION
This simple PR allows the bundle serialization format to be set in `SimpleSparkSerializer`.  The default is Json, much like everywhere else, so the change is backwards compatible.