### PR TITLE
Treat UNDEFINED as empty value for BasicType

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/json/JsonSupport.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/json/JsonSupport.scala
@@ -129,7 +129,7 @@ trait JsonSupport {
       if(obj.s != "") { fb += ("string" -> obj.s.toJson) }
       if(obj.bs != ByteString.EMPTY) { fb += ("byte_string" -> obj.bs.toJson) }
       obj.t.foreach(t => fb += ("tensor" -> t.toJson))
-      if(obj.bt != BasicType.BOOLEAN) { fb += ("basic_type" -> obj.bt.toJson) }
+      if(obj.bt != BasicType.UNDEFINED) { fb += ("basic_type" -> obj.bt.toJson) }
       obj.ds.foreach(ds => fb += ("data_shape" -> ds.toJson))
       obj.m.foreach(m => fb += ("model" -> m.toJson))
 


### PR DESCRIPTION
Note that this is related to [this bundle-protobuf PR](https://github.com/combust/bundle-protobuf/pull/1) (and requires that PR to be merged first).

Per protobuf best practices (here's an example of the problem: http://androiddevblog.com/protocol-buffers-pitfall-adding-enum-values/), you should never use '0' as a real value in your enums.  This would prevent you from being able to determine if the value is 'empty' or 'default', as the language generated code always uses the value at 0 as the default for the field.

This is causing problems in mleap for BasicType serialization in transformers.  If the type being serialized is `BasicType.BOOLEAN`, the code has no way to determine if the value has been set or is the default, which is causing mleap to skip serialization of the field.

Please note that this is entirely NOT backwards compatible (as in Mleap models previously serialized as protobuf will no longer deserialize properly with regards to `BasicType`).  It is, however, the correct solution in this scenario (in my opinion).