### PR TITLE
Issue #305 - fix sklearn serialization for decision tree classifier

### DIFF
--- a/python/mleap/sklearn/tree/tests.py
+++ b/python/mleap/sklearn/tree/tests.py
@@ -1,0 +1,93 @@
+import unittest
+import os
+import shutil
+import json
+import uuid
+
+from mleap.sklearn.tree.tree import DecisionTreeClassifier, DecisionTreeRegressor
+from sklearn.datasets import load_iris
+
+class TransformerTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = "/tmp/mleap.python.tests/{}".format(uuid.uuid1())
+
+        if os.path.exists(self.tmp_dir):
+            shutil.rmtree(self.tmp_dir)
+
+        os.makedirs(self.tmp_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir)
+
+    def test_decision_tree_classifier(self):
+        X = [[0, 1], [1, 1]]
+        Y = [0, 0]
+
+        dt_classifier = DecisionTreeClassifier()
+        dt_classifier = dt_classifier.fit(X, Y)
+        dt_classifier.mlinit(input_features ='feature', prediction_column = 'pred', feature_names = ['a'])
+        dt_classifier.serialize_to_bundle(self.tmp_dir, dt_classifier.name)
+
+        expected_model = {
+            "attributes": {
+                "num_features": {
+                    "long": 2
+                },
+                "num_classes": {
+                    "long": 1
+                }
+            },
+            "op": "decision_tree_classifier"
+        }
+
+        # Test model.json
+        with open("{}/{}.node/model.json".format(self.tmp_dir, dt_classifier.name)) as json_data:
+            model = json.load(json_data)
+
+        self.assertEqual(dt_classifier.op, expected_model['op'])
+        self.assertEqual(expected_model['attributes']['num_features']['long'], model['attributes']['num_features']['long'])
+        self.assertEqual(expected_model['attributes']['num_classes']['long'], model['attributes']['num_classes']['long'])
+
+        # Test node.json
+        with open("{}/{}.node/node.json".format(self.tmp_dir, dt_classifier.name)) as json_data:
+            node = json.load(json_data)
+
+        self.assertEqual(dt_classifier.name, node['name'])
+        self.assertEqual(dt_classifier.input_features, node['shape']['inputs'][0]['name'])
+        self.assertEqual(dt_classifier.prediction_column, node['shape']['outputs'][0]['name'])
+
+    def test_decision_tree_classifier_with_iris_dataset(self):
+        iris = load_iris()
+
+        dt_classifier = DecisionTreeClassifier()
+        dt_classifier.mlinit(input_features = 'features', prediction_column = 'species', feature_names = iris.feature_names)
+        dt_classifier = dt_classifier.fit(iris.data, iris.target)
+        dt_classifier.serialize_to_bundle(self.tmp_dir, dt_classifier.name)
+
+        expected_model = {
+            "attributes": {
+                "num_features": {
+                    "long": 4
+                },
+                "num_classes": {
+                    "long": 3
+                }
+            },
+            "op": "decision_tree_classifier"
+        }
+
+        # Test model.json
+        with open("{}/{}.node/model.json".format(self.tmp_dir, dt_classifier.name)) as json_data:
+            model = json.load(json_data)
+
+        self.assertEqual(dt_classifier.op, expected_model['op'])
+        self.assertEqual(expected_model['attributes']['num_features']['long'], model['attributes']['num_features']['long'])
+        self.assertEqual(expected_model['attributes']['num_classes']['long'], model['attributes']['num_classes']['long'])
+
+        # Test node.json
+        with open("{}/{}.node/node.json".format(self.tmp_dir, dt_classifier.name)) as json_data:
+            node = json.load(json_data)
+
+        self.assertEqual(dt_classifier.name, node['name'])
+        self.assertEqual(dt_classifier.input_features, node['shape']['inputs'][0]['name'])
+        self.assertEqual(dt_classifier.prediction_column, node['shape']['outputs'][0]['name'])

--- a/python/mleap/sklearn/tree/tree.py
+++ b/python/mleap/sklearn/tree/tree.py
@@ -114,7 +114,7 @@ class SimpleSerializer(MLeapSerializer):
         # Define attributes
         attributes = list()
         attributes.append(('num_features', transformer.n_features_))
-        if transformer.n_classes_ > 1:
+        if transformer.classes_ is not None:
             attributes.append(('num_classes', transformer.n_classes_))
 
         inputs = []


### PR DESCRIPTION
Use classes_ instead of n_classes_ to determine whether to add the num_classes attribute to the serialized model. This ensures that num_classes gets serialized even when 1 with decision tree classifier, but doesn't get serialized with a decision tree regressor. 