### PR TITLE
Exclude junit 4.8 from transitive dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
     val scalaReflect = ScalaVersionDependentModuleID.versioned("org.scala-lang" % "scala-reflect" % _)
     val sparkAvro = "com.databricks" %% "spark-avro" % "3.0.1"
     val scalaTest = "org.scalatest" %% "scalatest" % scalaTestVersion
-    val jTransform = "com.github.rwl" % "jtransforms" % "2.4.0"
+    val jTransform = "com.github.rwl" % "jtransforms" % "2.4.0" exclude("junit", "junit")
     val tensorflowDep = "org.tensorflow" % "libtensorflow" % tensorflowVersion
     val akkaHttp = "com.typesafe.akka" %% "akka-http" % akkaHttpVersion
     val akkaHttpSprayJson = "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion


### PR DESCRIPTION
Recently I noticed that some of our legacy unit tests based on JUnit fail to run from within IntelliJ. After doing a little investigation I found out that `mleap` introduces `junit 4.8` as a dependency. It confuses IntelliJ so it tries to run the tests with `junit 4.8` when in fact they're based on version 4.12.

The dependency comes transitively from `com.github.rwl:jtransforms:2.4.0` which is used by `mleap`. I believe it's a bug in [pom.xml](http://central.maven.org/maven2/com/github/rwl/jtransforms/2.4.0/jtransforms-2.4.0.pom) of `jtransforms:2.4.0` when they forgot to put `test` scope next to the `junit` to limit its transitivity. There's no reference to `junit` in the source code of jtransform.

In this PR I simply excluded `junit` from transitive dependencies of jtransform
