### PR TITLE
fix keep_invalid being lost when a model gets deserialized back in Spark

### DIFF
--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOp.scala
@@ -31,7 +31,7 @@ class StringIndexerOp extends SimpleSparkOp[StringIndexerModel] {
 
   override def sparkLoad(uid: String, shape: NodeShape, model: StringIndexerModel): StringIndexerModel = {
     new StringIndexerModel(uid = uid,
-      labels = model.labels)
+      labels = model.labels).setHandleInvalid(model.getHandleInvalid)
   }
 
   override def sparkInputs(obj: StringIndexerModel): Seq[ParamSpec] = {

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/StringIndexerParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/StringIndexerParitySpec.scala
@@ -13,6 +13,6 @@ class StringIndexerParitySpec extends SparkParityBase {
 
   override val sparkTransformer: Transformer = new StringIndexer().
     setInputCol("state").
-    setOutputCol("state_index").
+    setOutputCol("state_index").setHandleInvalid("keep").
     fit(dataset)
 }

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/StringIndexerParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/StringIndexerParitySpec.scala
@@ -11,6 +11,7 @@ import org.apache.spark.sql.DataFrame
 class StringIndexerParitySpec extends SparkParityBase {
   override val dataset: DataFrame = baseDataset.select("state")
 
+  // setting to handle invalid to true
   override val sparkTransformer: Transformer = new StringIndexer().
     setInputCol("state").
     setOutputCol("state_index").setHandleInvalid("keep").


### PR DESCRIPTION
fix for StringIndexer being deserialized back into Spark

@hollinwilkins 