### PR TITLE
fix for scikit-learn binarizer serialization

### DIFF
--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/BinarizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/BinarizerOp.scala
@@ -22,13 +22,13 @@ class BinarizerOp extends MleapOp[Binarizer, BinarizerModel] {
     override def store(model: Model, obj: BinarizerModel)
                       (implicit context: BundleContext[MleapContext]): Model = {
         model.withValue("threshold", Value.double(obj.threshold)).
-          withValue("input_shape", Value.dataShape(obj.inputShape))
+          withValue("input_shapes", Value.dataShape(obj.inputShape))
       }
 
     override def load(model: Model)
                      (implicit context: BundleContext[MleapContext]): BinarizerModel = {
       BinarizerModel(model.value("threshold").getDouble,
-        model.value("input_shape").getDataShape)
+        model.value("input_shapes").getDataShape)
     }
   }
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BinarizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BinarizerOp.scala
@@ -23,7 +23,7 @@ class BinarizerOp extends SimpleSparkOp[Binarizer] {
 
       val dataset = context.context.dataset.get
       model.withValue("threshold", Value.double(obj.getThreshold)).
-        withValue("input_shape", Value.dataShape(sparkToMleapDataShape(dataset.schema(obj.getInputCol), dataset)))
+        withValue("input_shapes", Value.dataShape(sparkToMleapDataShape(dataset.schema(obj.getInputCol), dataset)))
     }
 
     override def load(model: Model)


### PR DESCRIPTION
ensure binarizer parity between scikit-learn serialization and MLeap/Spark.