### PR TITLE
update javadoc for string indexer

### DIFF
--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringIndexerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringIndexerModel.scala
@@ -36,7 +36,7 @@ object HandleInvalid {
   *
   * @param labels list of labels that can be indexed
   * @param handleInvalid how to handle invalid values (unseen or NULL labels): 'error' (throw an error),
-  *                      'skip' (doesn't work in MLeap Runtime and also throws an error)
+  *                      'skip' (skips invalid data)
   *                      or 'keep' (put invalid data in a special bucket at index labels.size
   */
 case class StringIndexerModel(labels: Seq[String],


### PR DESCRIPTION
Tiny PR to update java doc for string indexer model, which now supports "skip".