### PR TITLE
RowTransformer handles correctly the output of udf in the shape of a Row for multiple outputs

### DIFF
--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/frame/RowTransformer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/frame/RowTransformer.scala
@@ -92,7 +92,11 @@ case class RowTransformer private (inputSchema: StructType,
           schema2 =>
             val transform = {
               (row: ArrayRow) =>
-                val values = row.udfValue(rowSelectors: _*)(udf).asInstanceOf[Product].productIterator.toSeq
+                val outputs = row.udfValue(rowSelectors: _*)(udf)
+                val values = outputs match {
+                  case r: ArrayRow => r.iterator.toSeq
+                  case _ => outputs.asInstanceOf[Product].productIterator.toSeq
+                }
                 indices.zip(values).foreach {
                   case (index, value) => row.set(index, value)
                 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/frame/RowTransformerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/frame/RowTransformerSpec.scala
@@ -66,5 +66,22 @@ class RowTransformerSpec extends FunSpec {
         assert(row2.getDouble(3) == 84.0 * 84.0)
       }).get
     }
+
+    it("handles correctly the output of udf in the shape of a Row for multiple outputs") {
+      val udf: UserDefinedFunction = (in1: Double, in2: Int) => ArrayRow(Seq(in1 + in2, in1 - in2))
+
+      val is = StructType("double" -> ScalarType.Double,
+        "string" -> ScalarType.String,
+        "int" -> ScalarType.Int)
+
+      (for(inputSchema <- is;
+           f = RowTransformer(inputSchema);
+           f1 <- f.withColumns(Seq("out1", "out2"), "double", "int")(udf)) yield {
+        val row = Row(42.0, "NO", 23)
+        val row2 = f1.transform(row)
+        assert(row2.getDouble(3) == 65)
+        assert(row2.getDouble(4) == 19)
+      }).get
+    }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/frame/RowTransformerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/frame/RowTransformerSpec.scala
@@ -67,7 +67,7 @@ class RowTransformerSpec extends FunSpec {
       }).get
     }
 
-    it("handles correctly the output of udf in the shape of a Row for multiple outputs") {
+    it("handles correctly the output of UDF in the shape of a Row for multiple outputs") {
       val udf: UserDefinedFunction = (in1: Double, in2: Int) => ArrayRow(Seq(in1 + in2, in1 - in2))
 
       val is = StructType("double" -> ScalarType.Double,


### PR DESCRIPTION
This enables the row transformer to be used with transformers such as probabilistic logistic regression, etc.