### PR TITLE
Update BundleFile to handle '\' in Files and URIs

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/BundleFile.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/BundleFile.scala
@@ -23,6 +23,7 @@ object BundleFile {
     apply(new URI(unbackslash(uri)))
   }
 
+
   implicit def apply(file: File): BundleFile = {
     val uri: String = if (file.getPath.endsWith(".zip")) {
       s"jar:${file.toURI.toString}"
@@ -47,15 +48,9 @@ object BundleFile {
 
     apply(fs, path)
   }
-
-  private def unbackslash(uri: String): String = {
-    // same logic as https://github.com/apache/commons-io/blob/master/src/main/java/org/apache/commons/io/FilenameUtils.java#L570
-    val BACKSLASH = '\\'
-    val NOT_FOUND = -1
-    if (uri == null || uri.indexOf(BACKSLASH) == NOT_FOUND) {
-      uri
-    }
-    uri.replace(BACKSLASH, '/')
+  private def unbackslash(uri: String) = {
+    // replace allbackslashes with forward slashes, to handle Windows file paths in URI construction
+    uri.toString.replace('\\', '/')
   }
 }
 

--- a/bundle-ml/src/main/scala/ml/combust/bundle/BundleFile.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/BundleFile.scala
@@ -24,7 +24,7 @@ object BundleFile {
   }
 
   implicit def apply(file: File): BundleFile = {
-    val uri: String = if(file.getPath.endsWith(".zip")) {
+    val uri: String = if (file.getPath.endsWith(".zip")) {
       s"jar:${file.toURI.toString}"
     } else {
       file.toURI.toString
@@ -48,8 +48,14 @@ object BundleFile {
     apply(fs, path)
   }
 
-  private def unbackslash(uri: String) = {
-    uri.replace('\\', '/')
+  private def unbackslash(uri: String): String = {
+    // same logic as https://github.com/apache/commons-io/blob/master/src/main/java/org/apache/commons/io/FilenameUtils.java#L570
+    val BACKSLASH = '\\'
+    val NOT_FOUND = -1
+    if (uri == null || uri.indexOf(BACKSLASH) == NOT_FOUND) {
+      uri
+    }
+    uri.replace(BACKSLASH, '/')
   }
 }
 

--- a/bundle-ml/src/main/scala/ml/combust/bundle/BundleFile.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/BundleFile.scala
@@ -48,9 +48,14 @@ object BundleFile {
 
     apply(fs, path)
   }
-  private def unbackslash(uri: String) = {
-    // replace allbackslashes with forward slashes, to handle Windows file paths in URI construction
-    uri.toString.replace('\\', '/')
+
+  /** Replace all backslashes with forward slashes, to handle Windows file paths in URI construction
+    *
+    * @param uri String representing a URI
+    * @return String containing no backslashes.
+    */
+  private def unbackslash(uri: String): String = {
+    uri.replace('\\', '/')
   }
 }
 

--- a/bundle-ml/src/test/scala/ml/combust/bundle/serializer/BundleSerializationSpec.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/serializer/BundleSerializationSpec.scala
@@ -107,6 +107,21 @@ class BundleSerializationSpec extends FunSpec {
           }
         }
       }
+
+      describe("with a backslash'd path for a linear regression") {
+        it("serializes and deserializes from a path containing '\\' separators") {
+          val uri = s"$prefix:${TestUtil.baseDir}/lr_bundle.$format$suffix".replace('/', '\\')
+          for(file <- managed(BundleFile(uri))) {
+            lr.writeBundle.name("my_bundle").
+              format(format).
+              save(file)
+
+            val bundleRead = file.loadBundle().get
+
+            assert(lr == bundleRead.root)
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
When mleap is built in Windows, operations related to getting a string from a File, Path, or URI will include `\` characters.  This includes calls to:
 * `file.toString()`
 * `file.getPath()`
 * `file.toPath().toString()`
 * `file.toPath().toUri().toString()`
 * `file.toURI().toString()`

To be defensive, we create new URIs from all inputs, with backslashes replaced by forward slashes.