### PR TITLE
Allow for arbitrary metadata to be encoded into a bundle

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/BundleWriter.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/BundleWriter.scala
@@ -11,9 +11,11 @@ import scala.util.Try
 case class BundleWriter[Context <: HasBundleRegistry,
 Transformer <: AnyRef](root: Transformer,
                        name: Option[String] = None,
-                       format: SerializationFormat = SerializationFormat.Json) {
+                       format: SerializationFormat = SerializationFormat.Json,
+                       meta: Option[ml.bundle.Attributes] = None) {
   def name(value: String): BundleWriter[Context, Transformer] = copy(name = Some(value))
   def format(value: SerializationFormat): BundleWriter[Context, Transformer] = copy(format = value)
+  def meta(value: ml.bundle.Attributes): BundleWriter[Context, Transformer] = copy(meta = Some(value))
 
   def save(file: BundleFile)
           (implicit context: Context): Try[Bundle[Transformer]] = {
@@ -23,6 +25,7 @@ Transformer <: AnyRef](root: Transformer,
 
     BundleSerializer(context, file).write(Bundle(name = n,
       format = format,
-      root = root))
+      root = root,
+      meta = meta))
   }
 }

--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
@@ -101,12 +101,14 @@ object Bundle {
 
   def apply[Transformer <: AnyRef](name: String,
                                    format: SerializationFormat,
-                                   root: Transformer): Bundle[Transformer] = {
+                                   root: Transformer,
+                                   meta: Option[ml.bundle.Attributes] = None): Bundle[Transformer] = {
     apply(BundleInfo(uid = UUID.randomUUID(),
       name = name,
       format = format,
       version = Bundle.version,
-      timestamp = LocalDateTime.now().toString), root)
+      timestamp = LocalDateTime.now().toString,
+      meta = meta), root)
   }
 }
 
@@ -116,7 +118,8 @@ object BundleInfo {
       name = bundle.name,
       format = SerializationFormat.fromBundle(bundle.format),
       version = bundle.version,
-      timestamp = bundle.timestamp)
+      timestamp = bundle.timestamp,
+      meta = bundle.meta)
   }
 }
 
@@ -132,13 +135,16 @@ case class BundleInfo(uid: UUID,
                       name: String,
                       format: SerializationFormat,
                       version: String,
-                      timestamp: String) {
+                      timestamp: String,
+                      meta: Option[ml.bundle.Attributes]) {
   def asBundle: ml.bundle.Bundle = {
     ml.bundle.Bundle(uid = uid.toString,
       name = name,
       format = format.asBundle,
       version = version,
-      timestamp = timestamp)
+      timestamp = timestamp,
+      meta = meta
+    )
   }
 }
 

--- a/bundle-ml/src/main/scala/ml/combust/bundle/json/JsonSupport.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/json/JsonSupport.scala
@@ -39,7 +39,7 @@ trait JsonSupport {
       case JsString("double") => BasicType.DOUBLE
       case JsString("string") => BasicType.STRING
       case JsString("byte_string") => BasicType.BYTE_STRING
-      case JsString("unknown") => BasicType.Unrecognized(100)
+      case JsString("unknown") => BasicType.UNDEFINED
       case _ => deserializationError("invalid basic type")
     }
 
@@ -290,6 +290,6 @@ trait JsonSupport {
 
   implicit val bundleNodeFormat: RootJsonFormat[Node] = jsonFormat2(Node.apply)
   implicit val bundleModelFormat: RootJsonFormat[Model] = jsonFormat2(Model.apply)
-  implicit val bundleBundleInfoFormat: RootJsonFormat[Bundle] = jsonFormat5(Bundle.apply)
+  implicit val bundleBundleInfoFormat: RootJsonFormat[Bundle] = jsonFormat6(Bundle.apply)
 }
 object JsonSupport extends JsonSupport

--- a/bundle-ml/src/test/scala/ml/combust/bundle/serializer/BundleSerializationSpec.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/serializer/BundleSerializationSpec.scala
@@ -140,7 +140,9 @@ class BundleSerializationSpec extends FunSpec {
 
             val bundleRead = file.loadBundle().get
 
-            assert(bundleRead.info.meta.contains(meta))
+            // These are written this way explicitly for compatibility with Scala 2.10
+            assert(!bundleRead.info.meta.isEmpty)
+            assert(bundleRead.info.meta.get.equals(meta))
           }
         }
       }

--- a/bundle-ml/src/test/scala/ml/combust/bundle/serializer/BundleSerializationSpec.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/serializer/BundleSerializationSpec.scala
@@ -2,12 +2,13 @@ package ml.combust.bundle.serializer
 
 import java.net.URI
 
-import ml.combust.bundle.{BundleFile, BundleRegistry, TestUtil}
+import ml.bundle.Attributes
+import ml.combust.bundle.dsl.Bundle
+import ml.combust.bundle.test.TestSupport._
 import ml.combust.bundle.test._
 import ml.combust.bundle.test.ops._
+import ml.combust.bundle.{BundleFile, BundleRegistry, TestUtil, dsl}
 import org.scalatest.FunSpec
-import TestSupport._
-import ml.combust.bundle.dsl.Bundle
 import resource._
 
 import scala.util.Random
@@ -119,6 +120,27 @@ class BundleSerializationSpec extends FunSpec {
             val bundleRead = file.loadBundle().get
 
             assert(lr == bundleRead.root)
+          }
+        }
+      }
+
+      describe("with metadata") {
+        it("serializes and deserializes any metadata we want to send along with the bundle") {
+          val uri = new URI(s"$prefix:${TestUtil.baseDir}/lr_bundle_meta.$format$suffix")
+          val meta = new Attributes().withList(Map(
+            "keyA" → dsl.Value.string("valA").value,
+            "keyB" → dsl.Value.double(1.2).value,
+            "keyC" → dsl.Value.stringList(Seq("listValA", "listValB")).value
+          ))
+          for(file <- managed(BundleFile(uri))) {
+            lr.writeBundle.name("my_bundle").
+              format(format).
+              meta(meta).
+              save(file)
+
+            val bundleRead = file.loadBundle().get
+
+            assert(bundleRead.info.meta.contains(meta))
           }
         }
       }


### PR DESCRIPTION
We have a use-case for wanting to encode arbitrary metadata about a particular model into the MLeap bundle at serialization time, allowing our downstream serving solution the ability to retrieve that information from the bundle and have deeper context around what params, labeled datasets, etc were used at build time.  This has been implemented in a generic way by reusing the `Attributes` message type that already existed in `bundle-protobuf` repo (the associated PR for that repo can be found here: https://github.com/combust/bundle-protobuf/pull/2)

I found an existing bug whilst writing the unit test for this functionality that has ostensibly existed since we modified the `BasicType` enum to start with `UNDEFINED` instead of `BOOLEAN`.  In the case that a `Scalar` is being parsed from JSON and the expected `BasicType` node does not exist, the code was setting the `BasicType` value to `BasicType.Unrecognized(100)`.  However, all this really does is set that field to the enum value of 100; in this case that results in all unknown `BasicType`s being parsed as `STRING` (since `STRING` has the enum value of `100`).  Since we added `UNDEFINED` to the enum list, it makes sense to me that this be the 'default' when an explicit value is not specified.

It's not included in this PR, but I recommend we go back and set the 0 value for all the protobuf enums to some variation of `UNDEFINED`.

* Add meta field to Bundle, allowing arbitrary metadata to be encoded into bundle
* Add unit-test for ensuring bundle serialization / deserialization works as expected
* Fix issue with incorrect default setting of BasicType in Value when parsing from JSON