### PR TITLE
Fix load from resource

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/BundleFile.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/BundleFile.scala
@@ -42,8 +42,17 @@ object BundleFile {
       case "file" =>
         (FileSystems.getDefault, FileSystems.getDefault.getPath(uriSafe.getPath))
       case "jar" =>
-        val zfs = FileSystems.newFileSystem(uriSafe, env)
-        (zfs, zfs.getPath("/"))
+        // handle resource in JAR path
+        val (filesystemUri: URI, path: String) = if (uriSafe.toString.contains("!")) {
+          val uriParts: Array[String] = uriSafe.toString.split("!")
+          (new URI(uriParts(0)), uriParts(1))
+        }
+        else {
+          (uriSafe, "/")
+        }
+
+        val zfs = FileSystems.newFileSystem(filesystemUri, env)
+        (zfs, zfs.getPath(path))
     }
 
     apply(fs, path)

--- a/bundle-ml/src/test/scala/ml/combust/bundle/serializer/BundleSerializationSpec.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/serializer/BundleSerializationSpec.scala
@@ -19,6 +19,7 @@ import scala.util.Random
 sealed trait FSType
 case object ZipFS extends FSType
 case object DirFS extends FSType
+case object DirInJarFS extends FSType
 
 class BundleSerializationSpec extends FunSpec {
   implicit val testContext = TestContext(BundleRegistry("test-registry"))
@@ -29,6 +30,9 @@ class BundleSerializationSpec extends FunSpec {
   it should behave like bundleSerializer("Serializing/Deserializing json a bundle as a zip",
     SerializationFormat.Json,
     ZipFS)
+  it should behave like bundleSerializer("Serializing/Deserializing json a bundle as a dir in zip",
+    SerializationFormat.Json,
+    DirInJarFS)
 
   it should behave like bundleSerializer("Serializing/Deserializing proto a bundle as a dir",
     SerializationFormat.Protobuf,
@@ -36,11 +40,15 @@ class BundleSerializationSpec extends FunSpec {
   it should behave like bundleSerializer("Serializing/Deserializing proto a bundle as a zip",
     SerializationFormat.Protobuf,
     DirFS)
+  it should behave like bundleSerializer("Serializing/Deserializing proto a bundle as a dir in zip",
+    SerializationFormat.Protobuf,
+    DirInJarFS)
 
   def bundleSerializer(description: String, format: SerializationFormat, fsType: FSType) = {
     val (prefix, suffix) = fsType match {
       case DirFS => ("file", "")
       case ZipFS => ("jar:file", ".zip")
+      case DirInJarFS => ("jar:file", ".jar!custom/path")
     }
 
     describe(description) {


### PR DESCRIPTION
This fix handles bundle loaded from a resourse inside a jar.

e.g: 
  private val sourceURI = Thread.currentThread().getContextClassLoader.getResource("models/similar-proposals-rf").toURI
  private val bundle = BundleFile(sourceURI).load().get
=>
jar:file:/tmp/sbt_1ccf9912/job-1/target/d8dd53b3/semantic_2.11-0.1.6.jar!/models/similar-proposals-rf