### PR TITLE
Fix scikit-learn Random Forest serialization

### DIFF
--- a/python/mleap/sklearn/ensemble/forest.py
+++ b/python/mleap/sklearn/ensemble/forest.py
@@ -89,7 +89,7 @@ class SimpleSerializer(MLeapSerializer):
         attributes.append(('num_features', transformer.n_features_))
         attributes.append(('tree_weights', tree_weights))
         attributes.append(('trees', ["tree{}".format(x) for x in range(0, len(transformer.estimators_))]))
-        if transformer.n_classes_ > 1:
+        if isinstance(transformer, RandomForestClassifier):
             attributes.append(('num_classes', transformer.n_classes_)) # TODO: get number of classes from the transformer
 
         self.serialize(transformer, path, model, attributes, inputs, outputs)

--- a/python/mleap/sklearn/ensemble/forest.py
+++ b/python/mleap/sklearn/ensemble/forest.py
@@ -89,8 +89,8 @@ class SimpleSerializer(MLeapSerializer):
         attributes.append(('num_features', transformer.n_features_))
         attributes.append(('tree_weights', tree_weights))
         attributes.append(('trees', ["tree{}".format(x) for x in range(0, len(transformer.estimators_))]))
-        if transformer.n_outputs_ > 1:
-            attributes.append(('num_classes', transformer.n_outputs_)) # TODO: get number of classes from the transformer
+        if transformer.n_classes_ > 1:
+            attributes.append(('num_classes', transformer.n_classes_)) # TODO: get number of classes from the transformer
 
         self.serialize(transformer, path, model, attributes, inputs, outputs)
 

--- a/python/mleap/sklearn/tree/tree.py
+++ b/python/mleap/sklearn/tree/tree.py
@@ -114,8 +114,8 @@ class SimpleSerializer(MLeapSerializer):
         # Define attributes
         attributes = list()
         attributes.append(('num_features', transformer.n_features_))
-        if transformer.classes_ is not None:
-            attributes.append(('num_classes', transformer.n_classes_))
+        if transformer.n_classes_ is not None:
+            attributes.append(('num_classes', int(transformer.n_classes_)))
 
         inputs = []
         outputs = []

--- a/python/mleap/sklearn/tree/tree.py
+++ b/python/mleap/sklearn/tree/tree.py
@@ -114,7 +114,7 @@ class SimpleSerializer(MLeapSerializer):
         # Define attributes
         attributes = list()
         attributes.append(('num_features', transformer.n_features_))
-        if transformer.n_classes_ is not None:
+        if isinstance(transformer, DecisionTreeClassifier):
             attributes.append(('num_classes', int(transformer.n_classes_)))
 
         inputs = []

--- a/python/mleap/version.py
+++ b/python/mleap/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.8.1-fix"
+__version__ = "0.9.4"

--- a/python/mleap/version.py
+++ b/python/mleap/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.8.1"
+__version__ = "0.8.1-fix"


### PR DESCRIPTION
The number of classes was read from the wrong attribute of the RandomForestClassifier and of the DecisionTreeClassifier. 

As a result Mleap was unable to load and run the bundle.