### PR TITLE
.im_class has been removed in Python 3. Use __class__.__name__ instead

### DIFF
--- a/python/mleap/sklearn/preprocessing/data.py
+++ b/python/mleap/sklearn/preprocessing/data.py
@@ -87,7 +87,7 @@ def mleap_init(self, prior_tf, output_features=None):
         output_size = 1
         output_feature_name = prior_tf.output_features
 
-    class_name = "{}".format(self.__init__.im_class).split('.')[-1].replace('>','').replace("'",'')
+    class_name = self.__class__.__name__
 
     if output_features is not None:
         self.output_features = output_features


### PR DESCRIPTION
I tried your demo (https://github.com/combust/mleap-demo/blob/master/notebooks/airbnb-price-regression-scikit.ipynb) and I had troubles running it in Python 3 even though mleap library supports Python 3 according to setup.py

It seems there was only one place where you use something Python 2 specific. I suggest this modification to make it Python 3 compatible (it still works on Python 2)

I ran unit tests and everything seems ok

