### PR TITLE
[Ready For Merge] Spark 2.3 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,23 +40,17 @@ Our goals for this project are:
 
 ## Requirements
 
-MLeap is cross-compiled for Scala 2.10 and 2.11. Because we depend
-heavily on Typesafe config for MLeap, we only support Java 8 at the
-moment. This means the following configurations should be possible:
-
-2. Scala 2.10 and Java 8
-4. Scala 2.11 and Java 8
+MLeap is built against Scala 2.11 and Java 8.  Because we depend heavily on Typesafe config for MLeap, we only support Java 8 at the
+moment.
 
 ## Setup
 
 ### Link with Maven or SBT
 
-MLeap is cross-compiled for Scala 2.10 and 2.11, so just replace 2.10 with 2.11 wherever you see it if you are running Scala version 2.11 and using a POM file for dependency management. Otherwise, use the `%%` operator if you are using SBT and the correct Scala version will be used.
-
 #### SBT
 
 ```sbt
-libraryDependencies += "ml.combust.mleap" %% "mleap-runtime" % "0.9.0"
+libraryDependencies += "ml.combust.mleap" %% "mleap-runtime" % "0.10.0"
 ```
 
 #### Maven
@@ -64,8 +58,8 @@ libraryDependencies += "ml.combust.mleap" %% "mleap-runtime" % "0.9.0"
 ```pom
 <dependency>
     <groupId>ml.combust.mleap</groupId>
-    <artifactId>mleap-runtime_2.10</artifactId>
-    <version>0.9.0</version>
+    <artifactId>mleap-runtime_2.11</artifactId>
+    <version>0.10.0</version>
 </dependency>
 ```
 
@@ -74,7 +68,7 @@ libraryDependencies += "ml.combust.mleap" %% "mleap-runtime" % "0.9.0"
 #### SBT
 
 ```sbt
-libraryDependencies += "ml.combust.mleap" %% "mleap-spark" % "0.9.0"
+libraryDependencies += "ml.combust.mleap" %% "mleap-spark" % "0.10.0"
 ```
 
 #### Maven
@@ -82,15 +76,15 @@ libraryDependencies += "ml.combust.mleap" %% "mleap-spark" % "0.9.0"
 ```pom
 <dependency>
     <groupId>ml.combust.mleap</groupId>
-    <artifactId>mleap-spark_2.10</artifactId>
-    <version>0.9.0</version>
+    <artifactId>mleap-spark_2.11</artifactId>
+    <version>0.10.0</version>
 </dependency>
 ```
 
 ### Spark Packages
 
 ```bash
-$ bin/spark-shell --packages ml.combust.mleap:mleap-spark_2.11:0.9.0
+$ bin/spark-shell --packages ml.combust.mleap:mleap-spark_2.11:0.10.0
 ```
 
 ### PySpark Integration

--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
@@ -52,6 +52,7 @@ object Bundle {
       val chi_sq_selector = "chi_sq_selector"
       val reverse_string_indexer = "reverse_string_indexer"
       val hashing_term_frequency = "hashing_term_frequency"
+      val feature_hasher = "feature_hasher"
       val imputer = "imputer"
       val standard_scaler = "standard_scaler"
       val tokenizer = "tokenizer"

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/ann/Layer.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/ann/Layer.scala
@@ -3,7 +3,7 @@ package ml.combust.mleap.core.ann
 /** NOTE: this code was taken from Spark and adopted for
   * use by MLeap outside of a Spark Context
   *
-  * https://github.com/apache/spark/blob/v2.0.0/mllib/src/main/scala/org/apache/spark/ml/ann/Layer.scala
+  * https://github.com/apache/spark/blob/v2.3.0/mllib/src/main/scala/org/apache/spark/ml/ann/Layer.scala
   */
 
 import java.util.Random
@@ -340,17 +340,42 @@ trait TopologyModel extends Serializable {
     * Forward propagation
     *
     * @param data input data
+    * @param includeLastLayer Include the last layer in the output. In
+    *                         MultilayerPerceptronClassifier, the last layer is always softmax;
+    *                         the last layer of outputs is needed for class predictions, but not
+    *                         for rawPrediction.
+    *
     * @return array of outputs for each of the layers
     */
-  def forward(data: BDM[Double]): Array[BDM[Double]]
+  def forward(data: BDM[Double], includeLastLayer: Boolean): Array[BDM[Double]]
 
   /**
-    * Prediction of the model
+    * Prediction of the model. See {@link ProbabilisticClassificationModel}
     *
-    * @param data input data
+    * @param features input features
     * @return prediction
     */
-  def predict(data: Vector): Vector
+  def predict(features: Vector): Vector
+
+  /**
+    * Raw prediction of the model. See {@link ProbabilisticClassificationModel}
+    *
+    * @param features input features
+    * @return raw prediction
+    *
+    * Note: This interface is only used for classification Model.
+    */
+  def predictRaw(features: Vector): Vector
+
+  /**
+    * Probability of the model. See {@link ProbabilisticClassificationModel}
+    *
+    * @param rawPrediction raw prediction vector
+    * @return probability
+    *
+    * Note: This interface is only used for classification Model.
+    */
+  def raw2ProbabilityInPlace(rawPrediction: Vector): Vector
 
   /**
     * Computes gradient for the network
@@ -433,7 +458,7 @@ class FeedForwardModel private(
   val layers = topology.layers
   val layerModels = new Array[LayerModel](layers.length)
   private var offset = 0
-  for (i <- layers.indices) {
+  for (i <- 0 until layers.length) {
     layerModels(i) = layers(i).createModel(
       new BDV[Double](weights.toArray, offset, 1, layers(i).weightSize))
     offset += layers(i).weightSize
@@ -441,14 +466,14 @@ class FeedForwardModel private(
   private var outputs: Array[BDM[Double]] = null
   private var deltas: Array[BDM[Double]] = null
 
-  override def forward(data: BDM[Double]): Array[BDM[Double]] = {
+  override def forward(data: BDM[Double], includeLastLayer: Boolean): Array[BDM[Double]] = {
     // Initialize output arrays for all layers. Special treatment for InPlace
     val currentBatchSize = data.cols
     // TODO: allocate outputs as one big array and then create BDMs from it
     if (outputs == null || outputs(0).cols != currentBatchSize) {
       outputs = new Array[BDM[Double]](layers.length)
       var inputSize = data.rows
-      for (i <- layers.indices) {
+      for (i <- 0 until layers.length) {
         if (layers(i).inPlace) {
           outputs(i) = outputs(i - 1)
         } else {
@@ -459,7 +484,8 @@ class FeedForwardModel private(
       }
     }
     layerModels(0).eval(data, outputs(0))
-    for (i <- 1 until layerModels.length) {
+    val end = if (includeLastLayer) layerModels.length else layerModels.length - 1
+    for (i <- 1 until end) {
       layerModels(i).eval(outputs(i - 1), outputs(i))
     }
     outputs
@@ -470,7 +496,7 @@ class FeedForwardModel private(
                                 target: BDM[Double],
                                 cumGradient: Vector,
                                 realBatchSize: Int): Double = {
-    val outputs = forward(data)
+    val outputs = forward(data, true)
     val currentBatchSize = data.cols
     // TODO: allocate deltas as one big array and then create BDMs from it
     if (deltas == null || deltas(0).cols != currentBatchSize) {
@@ -494,7 +520,7 @@ class FeedForwardModel private(
     }
     val cumGradientArray = cumGradient.toArray
     var offset = 0
-    for (i <- layers.indices) {
+    for (i <- 0 until layerModels.length) {
       val input = if (i == 0) data else outputs(i - 1)
       layerModels(i).grad(deltas(i), input,
         new BDV[Double](cumGradientArray, offset, 1, layers(i).weightSize))
@@ -505,8 +531,19 @@ class FeedForwardModel private(
 
   override def predict(data: Vector): Vector = {
     val size = data.size
-    val result = forward(new BDM[Double](size, 1, data.toArray))
+    val result = forward(new BDM[Double](size, 1, data.toArray), true)
     Vectors.dense(result.last.toArray)
+  }
+
+  override def predictRaw(data: Vector): Vector = {
+    val result = forward(new BDM[Double](data.size, 1, data.toArray), false)
+    Vectors.dense(result(result.length - 2).toArray)
+  }
+
+  override def raw2ProbabilityInPlace(data: Vector): Vector = {
+    val dataMatrix = new BDM[Double](data.size, 1, data.toArray)
+    layerModels.last.eval(dataMatrix, dataMatrix)
+    data
   }
 }
 
@@ -550,4 +587,3 @@ object FeedForwardModel {
     new FeedForwardModel(mleap.VectorUtil.fromBreeze(weights), topology)
   }
 }
-

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/classification/MultiLayerPerceptronClassifierModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/classification/MultiLayerPerceptronClassifierModel.scala
@@ -46,7 +46,7 @@ object MultiLayerPerceptronClassifierModel {
   }
 }
 
-@SparkCode(uri = "https://github.com/apache/spark/blob/v2.0.0/mllib/src/main/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifier.scala")
+@SparkCode(uri = "https://github.com/apache/spark/blob/v2.3.0/mllib/src/main/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifier.scala")
 case class MultiLayerPerceptronClassifierModel(layers: Seq[Int],
                                                weights: Vector) extends ProbabilisticClassificationModel {
   val numFeatures: Int = layers.head

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/FeatureHasherModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/FeatureHasherModel.scala
@@ -1,0 +1,114 @@
+package ml.combust.mleap.core.feature
+
+import ml.combust.mleap.core.Model
+import ml.combust.mleap.core.annotation.SparkCode
+import ml.combust.mleap.core.types._
+import ml.combust.mleap.core.util.Platform
+import ml.combust.mleap.core.util.Murmur3_x86_32.{hashInt, hashLong, hashUnsafeBytes2}
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+
+import scala.collection.mutable
+
+object FeatureHasherModel {
+  val seed = HashingTermFrequencyModel.seed
+
+  def murmur3(term: Any): Int = {
+    term match {
+      case null => seed
+      case b: Boolean => hashInt(if (b) 1 else 0, seed)
+      case b: Byte => hashInt(b, seed)
+      case s: Short => hashInt(s, seed)
+      case i: Int => hashInt(i, seed)
+      case l: Long => hashLong(l, seed)
+      case f: Float => hashInt(java.lang.Float.floatToIntBits(f), seed)
+      case d: Double => hashLong(java.lang.Double.doubleToLongBits(d), seed)
+      case s: String =>
+        val utf8 = s.getBytes("UTF-8")
+        hashUnsafeBytes2(utf8, Platform.BYTE_ARRAY_OFFSET, utf8.length, seed)
+      case _ => throw new IllegalStateException("FeatureHasher with murmur3 algorithm does not " +
+        s"support type ${term.getClass.getCanonicalName} of input data.")
+    }
+  }
+
+}
+
+/** Feature hashing projects a set of categorical or numerical features into a feature vector of
+  * specified dimension (typically substantially smaller than that of the original feature
+  * space). This is done using the hashing trick (https://en.wikipedia.org/wiki/Feature_hashing)
+  * to map features to indices in the feature vector.
+  *
+  * Source adapted from: Apache Spark Utils and FeatureHasher, see NOTICE for contributors
+  *
+  * @param numFeatures size of feature vector to hash into
+  * @param categoricalCols Numeric columns to treat as categorical features
+  * @param inputTypes the datatypes of the inputs
+  */
+@SparkCode(uri = "https://github.com/apache/spark/blob/v2.3.0/mllib/src/main/scala/org/apache/spark/ml/feature/FeatureHasher.scala")
+case class FeatureHasherModel(numFeatures: Int = 1 << 18, 
+                              categoricalCols: Seq[String],
+                              inputNames: Seq[String],
+                              inputTypes: Seq[DataType]
+                             ) extends Model  {
+  assert(inputTypes.forall(dt ⇒ dt.shape.isScalar), "must provide scalar shapes as inputs")
+
+  val schema = inputNames.zip(inputTypes)
+  val realFields = schema.filter(t ⇒ t._2.base match {
+    case BasicType.Short if !categoricalCols.contains(t._1) ⇒ true
+    case BasicType.Double if !categoricalCols.contains(t._1) ⇒ true
+    case BasicType.Float if !categoricalCols.contains(t._1) ⇒ true
+    case BasicType.Int if !categoricalCols.contains(t._1) ⇒ true
+    case BasicType.Long if !categoricalCols.contains(t._1) ⇒ true
+    case _ ⇒ false
+  }).toMap.keys.toSeq
+
+  def getDouble(x: Any): Double = {
+    x match {
+      case n: java.lang.Number ⇒ n.doubleValue()
+      // will throw ClassCastException if it cannot be cast, as would row.getDouble
+      case other ⇒ other.asInstanceOf[Double]
+    }
+  }
+
+  def nonNegativeMod(x: Int, mod: Int): Int = {
+    val rawMod = x % mod
+    rawMod + (if (rawMod < 0) mod else 0)
+  }
+
+  def apply(things: Seq[Any]): Vector = {
+    val map = new mutable.OpenHashMap[Int, Double]()
+    schema.zip(things).foreach { case (sc, item) ⇒
+      if (item != null) {
+        val (rawIdx, value) = if (realFields.contains(sc._1)) {
+          // numeric values are kept as is, with vector index based on hash of "column_name"
+          val value = getDouble(item)
+          val hash = FeatureHasherModel.murmur3(sc._1)
+          (hash, value)
+        } else {
+          // string, boolean and numeric values that are in catCols are treated as categorical,
+          // with an indicator value of 1.0 and vector index based on hash of "column_name=value"
+          val value = item.toString
+          val fieldName = s"${sc._1}=$value"
+          val hash = FeatureHasherModel.murmur3(fieldName)
+          (hash, 1.0)
+        }
+        val idx = nonNegativeMod(rawIdx, numFeatures)
+        map.+=((idx, map.getOrElse(idx, 0.0) + value))
+      }
+    }
+
+
+    // TODO: Figure this out
+    Vectors.sparse(numFeatures, map.toSeq)
+  }
+  
+  override def inputSchema: StructType = {
+    val inputFields = inputTypes.zipWithIndex.map {
+      case (dtype, i) => StructField(s"input$i", dtype)
+    }
+    StructType(inputFields).get
+  }
+
+  override def outputSchema: StructType = {
+    StructType(StructField("output" -> TensorType.Double(numFeatures))).get
+  }
+}

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/FeatureHasherModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/FeatureHasherModel.scala
@@ -95,9 +95,6 @@ case class FeatureHasherModel(numFeatures: Int = 1 << 18,
         map.+=((idx, map.getOrElse(idx, 0.0) + value))
       }
     }
-
-
-    // TODO: Figure this out
     Vectors.sparse(numFeatures, map.toSeq)
   }
   

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/util/Murmur3_x86_32.java
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/util/Murmur3_x86_32.java
@@ -69,6 +69,20 @@ public final class Murmur3_x86_32 {
         return fmix(h1, lengthInBytes);
     }
 
+    public static int hashUnsafeBytes2(Object base, long offset, int lengthInBytes, int seed) {
+        // This is compatible with original and another implementations.
+        // Use this method for new components after Spark 2.3.
+        assert (lengthInBytes >= 0): "lengthInBytes cannot be negative";
+        int lengthAligned = lengthInBytes - lengthInBytes % 4;
+        int h1 = hashBytesByInt(base, offset, lengthAligned, seed);
+        int k1 = 0;
+        for (int i = lengthAligned, shift = 0; i < lengthInBytes; i++, shift += 8) {
+            k1 ^= (Platform.getByte(base, offset + i) & 0xFF) << shift;
+        }
+        h1 ^= mixK1(k1);
+        return fmix(h1, lengthInBytes);
+    }
+
     private static int hashBytesByInt(Object base, long offset, int lengthInBytes, int seed) {
         assert (lengthInBytes % 4 == 0);
         int h1 = seed;

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/classification/MultiLayerPerceptronClassifierModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/classification/MultiLayerPerceptronClassifierModelSpec.scala
@@ -16,7 +16,10 @@ class MultiLayerPerceptronClassifierModelSpec extends FunSpec {
 
     it("has the right output schema") {
       assert(model.outputSchema.fields ==
-        Seq(StructField("prediction", ScalarType.Double.nonNullable)))
+        Seq(StructField("raw_prediction", TensorType.Double(1)),
+          StructField("probability", TensorType.Double(1)),
+          StructField("prediction", ScalarType.Double.nonNullable)
+        ))
     }
   }
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/FeatureHasherModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/FeatureHasherModelSpec.scala
@@ -1,0 +1,33 @@
+package ml.combust.mleap.core.feature
+
+import ml.combust.mleap.core.types._
+import org.scalatest.FunSpec
+
+class FeatureHasherModelSpec  extends FunSpec {
+
+  val schema = Seq(
+    StructField("doubleCol", DataType(BasicType.Double, ScalarShape())),
+    StructField("boolCol", DataType(BasicType.Boolean, ScalarShape())),
+    StructField("intCol", DataType(BasicType.Int, ScalarShape())),
+    StructField("stringCol", DataType(BasicType.String, ScalarShape()))
+  )
+
+  describe("Hashing Term Frequency Model") {
+    val model = FeatureHasherModel(
+      categoricalCols = Seq.empty[String],
+      inputNames = schema.map(_.name),
+      inputTypes = schema.map(_.dataType)
+    )
+
+    it("Has the right input schema") {
+      assert(model.inputSchema.fields == schema.zipWithIndex.map({ case (sf, idx) ⇒
+          sf.copy(name = s"input$idx")
+      }))
+    }
+
+    it("Has the right output schema") {
+      assert(model.outputSchema.fields ==
+        Seq(StructField("output", TensorType.Double(262144))))
+    }
+  }
+}

--- a/mleap-runtime/src/main/resources/reference.conf
+++ b/mleap-runtime/src/main/resources/reference.conf
@@ -24,6 +24,7 @@ ml.combust.mleap.registry.builtin-ops = [
   "ml.combust.mleap.bundle.ops.feature.CountVectorizerOp",
   "ml.combust.mleap.bundle.ops.feature.DCTOp",
   "ml.combust.mleap.bundle.ops.feature.ElementwiseProductOp",
+  "ml.combust.mleap.bundle.ops.feature.FeatureHasherOp",
   "ml.combust.mleap.bundle.ops.feature.HashingTermFrequencyOp",
   "ml.combust.mleap.bundle.ops.feature.IDFOp",
   "ml.combust.mleap.bundle.ops.feature.ImputerOp",

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/FeatureHasherOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/FeatureHasherOp.scala
@@ -1,0 +1,43 @@
+package ml.combust.mleap.bundle.ops.feature
+
+import ml.combust.bundle.BundleContext
+import ml.combust.bundle.dsl.{Bundle, Model, Value}
+import ml.combust.bundle.op.OpModel
+import ml.combust.mleap.bundle.ops.MleapOp
+import ml.combust.mleap.core.feature.FeatureHasherModel
+import ml.combust.mleap.runtime.MleapContext
+import ml.combust.mleap.runtime.transformer.feature.FeatureHasher
+import ml.combust.mleap.runtime.types.BundleTypeConverters._
+import ml.combust.mleap.core.types.DataType
+
+class FeatureHasherOp extends MleapOp[FeatureHasher, FeatureHasherModel] {
+  override val Model: OpModel[MleapContext, FeatureHasherModel] = new OpModel[MleapContext, FeatureHasherModel] {
+    override val klazz: Class[FeatureHasherModel] = classOf[FeatureHasherModel]
+
+    override def opName: String = Bundle.BuiltinOps.feature.feature_hasher
+
+    override def store(model: Model, obj: FeatureHasherModel)
+                      (implicit context: BundleContext[MleapContext]): Model = {
+      model.withValue("num_features", Value.long(obj.numFeatures))
+        .withValue("categorical_cols", Value.stringList(obj.categoricalCols))
+        .withValue("input_shapes", Value.dataShapeList(obj.inputTypes.map(_.shape).map(mleapToBundleShape)))
+        .withValue("basic_types", Value.basicTypeList(obj.inputTypes.map(_.base).map(mleapToBundleBasicType)))
+        .withValue("input_names", Value.stringList(obj.inputNames))
+    }
+
+    override def load(model: Model)
+                     (implicit context: BundleContext[MleapContext]): FeatureHasherModel = {
+      val shapes = model.value("input_shapes").getDataShapeList.map(bundleToMleapShape)
+      val types = model.value("basic_types").getBasicTypeList.map(bundleToMleapBasicType)
+      val inputTypes = shapes.zip(types).map(tup ⇒ DataType(tup._2, tup._1))
+
+      FeatureHasherModel(numFeatures = model.value("num_features").getLong.toInt,
+        categoricalCols = model.value("categorical_cols").getStringList,
+        inputTypes = inputTypes,
+        inputNames = model.value("input_names").getStringList
+      )
+    }
+  }
+
+  override def model(node: FeatureHasher): FeatureHasherModel = node.model
+}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/MultiLayerPerceptronClassifier.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/MultiLayerPerceptronClassifier.scala
@@ -5,13 +5,40 @@ import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.function.UserDefinedFunction
 import ml.combust.mleap.tensor.Tensor
 import ml.combust.mleap.core.util.VectorConverters._
-import ml.combust.mleap.runtime.frame.{SimpleTransformer, Transformer}
+import ml.combust.mleap.runtime.frame.{MultiTransformer, Row, Transformer}
 
 /**
   * Created by hollinwilkins on 12/25/16.
   */
 case class MultiLayerPerceptronClassifier(override val uid: String = Transformer.uniqueName("multi_layer_perceptron"),
                                           override val shape: NodeShape,
-                                          override val model: MultiLayerPerceptronClassifierModel) extends SimpleTransformer {
-  override val exec: UserDefinedFunction = (features: Tensor[Double]) => model(features)
+                                          override val model: MultiLayerPerceptronClassifierModel) extends MultiTransformer {
+//  override val exec: UserDefinedFunction = (features: Tensor[Double]) => model(features)
+override val exec: UserDefinedFunction = {
+  val f = (shape.getOutput("raw_prediction"), shape.getOutput("probability")) match {
+    case (Some(_), Some(_)) =>
+      (features: Tensor[Double]) => {
+        val rawPrediction = model.predictRaw(features)
+        val probability = model.rawToProbability(rawPrediction)
+        val prediction = model.probabilityToPrediction(probability)
+        Row(rawPrediction: Tensor[Double], probability: Tensor[Double], prediction)
+      }
+    case (Some(_), None) =>
+      (features: Tensor[Double]) => {
+        val rawPrediction = model.predictRaw(features)
+        val prediction = model.rawToPrediction(rawPrediction)
+        Row(rawPrediction: Tensor[Double], prediction)
+      }
+    case (None, Some(_)) =>
+      (features: Tensor[Double]) => {
+        val probability = model.predictProbabilities(features)
+        val prediction = model.probabilityToPrediction(probability)
+        Row(probability: Tensor[Double], prediction)
+      }
+    case (None, None) =>
+      (features: Tensor[Double]) => Row(model(features))
+  }
+
+  UserDefinedFunction(f, outputSchema, inputSchema)
+}
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/FeatureHasher.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/FeatureHasher.scala
@@ -1,0 +1,30 @@
+package ml.combust.mleap.runtime.transformer.feature
+
+import ml.combust.mleap.core.feature.FeatureHasherModel
+import ml.combust.mleap.core.types.{NodeShape, SchemaSpec}
+import ml.combust.mleap.runtime.frame.{FrameBuilder, Row, Transformer}
+import ml.combust.mleap.runtime.function.{StructSelector, UserDefinedFunction}
+import ml.combust.mleap.tensor.Tensor
+import ml.combust.mleap.core.util.VectorConverters._
+
+import scala.util.Try
+
+case class FeatureHasher(override val uid: String = Transformer.uniqueName("feature_hasher"),
+                         override val shape: NodeShape,
+                         override val model: FeatureHasherModel) extends Transformer {
+  private val f = (values: Row) => {
+    model(values.toSeq): Tensor[Double]
+  }
+  val exec: UserDefinedFunction = UserDefinedFunction(f,
+    outputSchema.fields.head.dataType,
+    Seq(SchemaSpec(inputSchema)))
+
+  val outputCol: String = outputSchema.fields.head.name
+  val inputCols: Seq[String] = inputSchema.fields.map(_.name)
+  private val inputSelector: StructSelector = StructSelector(inputCols)
+
+  override def transform[TB <: FrameBuilder[TB]](builder: TB): Try[TB] = {
+    builder.withColumn(outputCol, inputSelector)(exec)
+  }
+
+}

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/FeatureHasherSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/FeatureHasherSpec.scala
@@ -1,0 +1,39 @@
+package ml.combust.mleap.runtime.transformer.feature
+
+import ml.combust.mleap.core.feature.FeatureHasherModel
+import ml.combust.mleap.core.types._
+import org.scalatest.FunSpec
+
+class FeatureHasherSpec extends FunSpec {
+
+  val inputSchema = Map(
+    "input0" → StructField("doubleCol", DataType(BasicType.Double, ScalarShape())),
+    "input1" → StructField("boolCol", DataType(BasicType.Boolean, ScalarShape())),
+    "input2" → StructField("intCol", DataType(BasicType.Int, ScalarShape())),
+    "input3" → StructField("stringCol", DataType(BasicType.String, ScalarShape()))
+  )
+  val outputSchema = Map(
+    "output" → StructField("features", TensorType.Double(262144))
+  )
+
+  val model = FeatureHasherModel(
+    categoricalCols = Seq.empty[String],
+    inputNames = inputSchema.values.map(_.name).toSeq,
+    inputTypes = inputSchema.values.map(_.dataType).toSeq
+  )
+
+  describe("input/output schema") {
+
+    val shape = inputSchema.foldLeft(NodeShape()) { (acc, item) ⇒
+      acc.withInput(item._1, item._2.name)
+    }.withOutput(outputSchema.head._1, outputSchema.head._2.name)
+
+    it("has the correct inputs and outputs") {
+      val transformer = FeatureHasher(
+        shape = shape,
+        model = model)
+
+      assert(transformer.schema.fields == inputSchema.values ++ outputSchema.values)
+    }
+  }
+}

--- a/mleap-spark-base/src/main/scala/org/apache/spark/ml/bundle/SparkBundleContext.scala
+++ b/mleap-spark-base/src/main/scala/org/apache/spark/ml/bundle/SparkBundleContext.scala
@@ -19,6 +19,8 @@ object SparkBundleContext {
       "ml.combust.mleap.spark.registry.v21"
     } else if(sparkVersion.startsWith("2.2")) {
       "ml.combust.mleap.spark.registry.v22"
+    } else if(sparkVersion.startsWith("2.3")) {
+      "ml.combust.mleap.spark.registry.v23"
     } else {
       throw new IllegalStateException(s"unsupported Spark version: $sparkVersion")
     }

--- a/mleap-spark-extension/src/main/resources/reference.conf
+++ b/mleap-spark-extension/src/main/resources/reference.conf
@@ -12,3 +12,4 @@ ml.combust.mleap.spark.extension.ops = [
 ml.combust.mleap.spark.registry.v20.ops += "ml.combust.mleap.spark.extension.ops"
 ml.combust.mleap.spark.registry.v21.ops += "ml.combust.mleap.spark.extension.ops"
 ml.combust.mleap.spark.registry.v22.ops += "ml.combust.mleap.spark.extension.ops"
+ml.combust.mleap.spark.registry.v23.ops += "ml.combust.mleap.spark.extension.ops"

--- a/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
+++ b/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
@@ -129,7 +129,9 @@ abstract class SparkParityBase extends FunSpec with BeforeAndAfterAll {
 
   def equalityTest(sparkDataset: DataFrame,
                    mleapDataset: DataFrame): Unit = {
-    assert(sparkDataset.collect() sameElements mleapDataset.collect())
+    val sparkElems = sparkDataset.collect()
+    val mleapElems = mleapDataset.collect()
+    assert(sparkElems sameElements mleapElems)
   }
 
   def parityTransformer(): Unit = {

--- a/mleap-spark/src/main/resources/reference.conf
+++ b/mleap-spark/src/main/resources/reference.conf
@@ -21,7 +21,8 @@ ml.combust.mleap.spark.registry.v23-ops = [
   "org.apache.spark.ml.bundle.ops.feature.MinHashLSHOp",
   "org.apache.spark.ml.bundle.ops.feature.BucketedRandomProjectionLSHOp",
   "org.apache.spark.ml.bundle.ops.classification.GBTClassifierOpV22",
-  "org.apache.spark.ml.bundle.ops.classification.LogisticRegressionOpV21"
+  "org.apache.spark.ml.bundle.ops.classification.LogisticRegressionOpV21",
+  "org.apache.spark.ml.bundle.ops.feature.FeatureHasherOp"
 ]
 
 ml.combust.mleap.spark.registry.v20.ops += "ml.combust.mleap.spark.registry.base-ops"

--- a/mleap-spark/src/main/resources/reference.conf
+++ b/mleap-spark/src/main/resources/reference.conf
@@ -17,6 +17,13 @@ ml.combust.mleap.spark.registry.v22-ops = [
   "org.apache.spark.ml.bundle.ops.classification.LogisticRegressionOpV21"
 ]
 
+ml.combust.mleap.spark.registry.v23-ops = [
+  "org.apache.spark.ml.bundle.ops.feature.MinHashLSHOp",
+  "org.apache.spark.ml.bundle.ops.feature.BucketedRandomProjectionLSHOp",
+  "org.apache.spark.ml.bundle.ops.classification.GBTClassifierOpV22",
+  "org.apache.spark.ml.bundle.ops.classification.LogisticRegressionOpV21"
+]
+
 ml.combust.mleap.spark.registry.v20.ops += "ml.combust.mleap.spark.registry.base-ops"
 ml.combust.mleap.spark.registry.v20.ops += "ml.combust.mleap.spark.registry.v20-ops"
 
@@ -25,6 +32,9 @@ ml.combust.mleap.spark.registry.v21.ops += "ml.combust.mleap.spark.registry.v21-
 
 ml.combust.mleap.spark.registry.v22.ops += "ml.combust.mleap.spark.registry.base-ops"
 ml.combust.mleap.spark.registry.v22.ops += "ml.combust.mleap.spark.registry.v22-ops"
+
+ml.combust.mleap.spark.registry.v23.ops += "ml.combust.mleap.spark.registry.base-ops"
+ml.combust.mleap.spark.registry.v23.ops += "ml.combust.mleap.spark.registry.v23-ops"
 
 ml.combust.mleap.spark.registry.base-ops = [
   "org.apache.spark.ml.bundle.ops.classification.DecisionTreeClassifierOp",

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/MultiLayerPerceptronClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/MultiLayerPerceptronClassifierOp.scala
@@ -38,8 +38,10 @@ class MultiLayerPerceptronClassifierOp extends SimpleSparkOp[MultilayerPerceptro
     Seq("features" -> obj.featuresCol)
   }
 
-  override def sparkOutputs(obj: MultilayerPerceptronClassificationModel): Seq[SimpleParamSpec] = {
-    Seq("prediction" -> obj.predictionCol)
+  override def sparkOutputs(obj: MultilayerPerceptronClassificationModel):  Seq[SimpleParamSpec] = {
+    Seq("raw_prediction" -> obj.rawPredictionCol,
+      "probability" -> obj.probabilityCol,
+      "prediction" -> obj.predictionCol)
   }
 }
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/FeatureHasherOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/FeatureHasherOp.scala
@@ -1,0 +1,54 @@
+package org.apache.spark.ml.bundle.ops.feature
+
+import ml.bundle.DataShape
+import ml.combust.bundle.BundleContext
+import ml.combust.bundle.dsl._
+import ml.combust.bundle.op.OpModel
+import org.apache.spark.ml.bundle.{ParamSpec, SimpleParamSpec, SimpleSparkOp, SparkBundleContext}
+import org.apache.spark.ml.feature.FeatureHasher
+import ml.combust.mleap.runtime.types.BundleTypeConverters._
+import org.apache.spark.sql.mleap.TypeConverters._
+
+class FeatureHasherOp extends SimpleSparkOp[FeatureHasher] {
+  override val Model: OpModel[SparkBundleContext, FeatureHasher] = new OpModel[SparkBundleContext, FeatureHasher] {
+    override val klazz: Class[FeatureHasher] = classOf[FeatureHasher]
+
+    override def opName: String = Bundle.BuiltinOps.feature.feature_hasher
+
+    override def store(model: Model, obj: FeatureHasher)
+                      (implicit context: BundleContext[SparkBundleContext]): Model = {
+      val categoricals = if (obj.isSet(obj.categoricalCols)) {
+        obj.getCategoricalCols
+      } else {
+        Array.empty[String]
+      }
+      val dataset = context.context.dataset.get
+      val inputShapes = obj.getInputCols.map(i ⇒ sparkToMleapDataShape(dataset.schema(i), dataset): DataShape)
+      val basicTypes = obj.getInputCols.map(i ⇒ sparkFieldToMleapField(dataset, dataset.schema(i)).dataType.base).map(mleapToBundleBasicType)
+
+      model.withValue("num_features", Value.long(obj.getNumFeatures))
+        .withValue("categorical_cols", Value.stringList(categoricals))
+        .withValue("input_shapes", Value.dataShapeList(inputShapes))
+        .withValue("basic_types", Value.basicTypeList(basicTypes))
+        .withValue("input_names", Value.stringList(obj.getInputCols))
+    }
+
+    override def load(model: Model)
+                     (implicit context: BundleContext[SparkBundleContext]): FeatureHasher = {
+      new FeatureHasher(uid = "").setNumFeatures(model.value("num_features").getLong.toInt).
+        setCategoricalCols(model.value("categorical_cols").getStringList.toArray)
+    }
+  }
+
+  override def sparkLoad(uid: String, shape: NodeShape, model: FeatureHasher): FeatureHasher = {
+    new FeatureHasher(uid = uid)
+  }
+
+  override def sparkInputs(obj: FeatureHasher): Seq[ParamSpec] = {
+    Seq("input" -> obj.inputCols)
+  }
+
+  override def sparkOutputs(obj: FeatureHasher): Seq[SimpleParamSpec] = {
+    Seq("output" -> obj.outputCol)
+  }
+}

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOp.scala
@@ -19,19 +19,24 @@ class StringIndexerOp extends SimpleSparkOp[StringIndexerModel] {
     override def store(model: Model, obj: StringIndexerModel)
                       (implicit context: BundleContext[SparkBundleContext]): Model = {
       model.withValue("labels", Value.stringList(obj.labels)).
-        withValue("handle_invalid", Value.string(obj.getHandleInvalid))
+        withValue("handle_invalid", Value.string(obj.getHandleInvalid)).
+        withValue("string_order_type", Value.string(obj.getStringOrderType))
     }
 
     override def load(model: Model)
                      (implicit context: BundleContext[SparkBundleContext]): StringIndexerModel = {
-      new StringIndexerModel(uid = "", labels = model.value("labels").getStringList.toArray).
+      val m = new StringIndexerModel(uid = "", labels = model.value("labels").getStringList.toArray).
         setHandleInvalid(model.value("handle_invalid").getString)
+      m.set(m.stringOrderType, model.value("string_order_type").getString)
+      m
     }
   }
 
   override def sparkLoad(uid: String, shape: NodeShape, model: StringIndexerModel): StringIndexerModel = {
-    new StringIndexerModel(uid = uid,
+    val m = new StringIndexerModel(uid = uid,
       labels = model.labels).setHandleInvalid(model.getHandleInvalid)
+    m.set(m.stringOrderType, model.getStringOrderType)
+    m
   }
 
   override def sparkInputs(obj: StringIndexerModel): Seq[ParamSpec] = {

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/classification/LogisticRegressionParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/classification/LogisticRegressionParitySpec.scala
@@ -20,5 +20,5 @@ class LogisticRegressionParitySpec extends SparkParityBase {
       setOutputCol("features"),
     new LogisticRegressionModel(uid = "logr",
       coefficients = Vectors.dense(0.44, 0.77),
-      intercept = 0.66).setFeaturesCol("features"))).fit(dataset)
+      intercept = 0.66).setThreshold(0.5).setFeaturesCol("features"))).fit(dataset)
 }

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/FeatureHasherParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/FeatureHasherParitySpec.scala
@@ -3,15 +3,33 @@ package org.apache.spark.ml.parity.feature
 import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.feature.FeatureHasher
 import org.apache.spark.ml.parity.SparkParityBase
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.types._
+
+import scala.util.Random
 
 class FeatureHasherParitySpec extends SparkParityBase {
-  import spark.implicits._
 
-  override val dataset: DataFrame = Seq(
-    (2.0, true, "1", "foo"),
-    (3.0, false, "2", "bar")
-  ).toDF("real", "bool", "stringNum", "string")
+  val categories = Seq(
+    "spark",
+    "and",
+    "mleap",
+    "are",
+    "super",
+    "dope",
+    "together"
+  )
+
+  def randomRow(): Row = Row(Random.nextDouble(), Random.nextBoolean(), Random.nextInt(20).toString, Random.shuffle(categories).head)
+
+  val rows = spark.sparkContext.parallelize(Seq.tabulate(100) { _ => randomRow() })
+  val schema = new StructType()
+    .add("real", DoubleType, nullable = false)
+    .add("bool", BooleanType, nullable = false)
+    .add("stringNum", StringType, nullable = true)
+    .add("string", StringType, nullable = true)
+
+  override val dataset: DataFrame = spark.sqlContext.createDataFrame(rows, schema)
 
   override val sparkTransformer: Transformer = new FeatureHasher()
     .setInputCols("real", "bool", "stringNum", "string")

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/FeatureHasherParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/FeatureHasherParitySpec.scala
@@ -1,0 +1,19 @@
+package org.apache.spark.ml.parity.feature
+
+import org.apache.spark.ml.Transformer
+import org.apache.spark.ml.feature.FeatureHasher
+import org.apache.spark.ml.parity.SparkParityBase
+import org.apache.spark.sql.DataFrame
+
+class FeatureHasherParitySpec extends SparkParityBase {
+  import spark.implicits._
+
+  override val dataset: DataFrame = Seq(
+    (2.0, true, "1", "foo"),
+    (3.0, false, "2", "bar")
+  ).toDF("real", "bool", "stringNum", "string")
+
+  override val sparkTransformer: Transformer = new FeatureHasher()
+    .setInputCols("real", "bool", "stringNum", "string")
+    .setOutputCol("features")
+}

--- a/mleap-xgboost-spark/src/main/resources/reference.conf
+++ b/mleap-xgboost-spark/src/main/resources/reference.conf
@@ -6,3 +6,4 @@ ml.combust.mleap.spark.xgboost.ops = [
 ml.combust.mleap.spark.registry.v20.ops += "ml.combust.mleap.spark.xgboost.ops"
 ml.combust.mleap.spark.registry.v21.ops += "ml.combust.mleap.spark.xgboost.ops"
 ml.combust.mleap.spark.registry.v22.ops += "ml.combust.mleap.spark.xgboost.ops"
+ml.combust.mleap.spark.registry.v23.ops += "ml.combust.mleap.spark.xgboost.ops"

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -17,7 +17,7 @@ object Common {
 
   lazy val buildSettings: Seq[Def.Setting[_]] = Seq(
     scalaVersion := "2.11.8",
-    crossScalaVersions := Seq("2.10.6", "2.11.8"),
+    crossScalaVersions := Seq("2.11.8"),
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
     fork in Test := true,
     javaOptions in test += sys.env.getOrElse("JVM_OPTS", ""),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ import Keys._
 object Dependencies {
   import DependencyHelpers._
 
-  val sparkVersion = "2.2.0"
+  val sparkVersion = "2.3.0"
   val scalaTestVersion = "3.0.0"
   val tensorflowVersion = "1.7.0"
   val akkaVersion = "2.4.16"


### PR DESCRIPTION
This PR updates the Spark dependency to `2.3.0` and ensures all existing functionality works and associated unit-tests pass.  As of writing, that is the case; all features present in latest version of MLeap are working.  ~~I have not yet added functionality for new transformers added in 2.3; that's my next goal.~~

Spark 2.3's `FeatureHasher` transformer is also included in this PR.

As always, comments and feedback are welcome.