### PR TITLE
Mark provided testkit datasets as lazy

### DIFF
--- a/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
+++ b/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
@@ -50,9 +50,9 @@ object SparkParityBase extends FunSpec {
 }
 
 abstract class SparkParityBase extends FunSpec with BeforeAndAfterAll {
-  val baseDataset: DataFrame = SparkParityBase.dataset(spark)
-  val textDataset: DataFrame = SparkParityBase.textDataset(spark)
-  val recommendationDataset: DataFrame = SparkParityBase.recommendationDataset(spark)
+  lazy val baseDataset: DataFrame = SparkParityBase.dataset(spark)
+  lazy val textDataset: DataFrame = SparkParityBase.textDataset(spark)
+  lazy val recommendationDataset: DataFrame = SparkParityBase.recommendationDataset(spark)
 
   val dataset: DataFrame
   val sparkTransformer: Transformer


### PR DESCRIPTION
As written, if folks require `mleap-spark-testkit` as a test requirement for their own projects, `SparkParityBase` will throw errors when initializing the provided datasets.  This is because the code for loading those datasets cannot handle the URI of the source file when it originates inside of a JAR file.

This PR completely dodges the actual solution to that problem and instead marks those datasets as `lazy`,  preventing their loading if they are not needed.

In the short term, if folks do want to use them, they can just duplicate them locally into `test/resources/datasets`.