### PR TITLE
MLeap Serving Parameters

### DIFF
--- a/mleap-serving/README.md
+++ b/mleap-serving/README.md
@@ -36,6 +36,18 @@ docker run -p 65327:65327 -v /tmp/models:/models combustml/mleap-serving:0.9.0-S
 
 This will expose the model server locally on port `65327`.
 
+NOTE: Outside of Docker, you can utilize the `MLEAP_SERVER_HOSTNAME`
+and the `MLEAP_SERVER_PORT` environment variables to explicitly control
+where MLeap serving listens. The below example will bind the RESTful
+web interface to the 127.0.0.1 interface on TCP port 12345, rather than
+the default, all interfaces (0.0.0.0) on TCP port 65327.
+
+```
+export MLEAP_SERVER_HOSTNAME=127.0.0.1
+export MLEAP_SERVER_PORT=12345
+/path/to/mleap-serving # update this with the real path to the mleap-serving binary
+```
+
 ### Load Model
 
 Use curl to load the model into memory. If you don't have your own

--- a/mleap-serving/src/main/resources/application.conf
+++ b/mleap-serving/src/main/resources/application.conf
@@ -1,6 +1,8 @@
 ml.combust.mleap.serving {
   http {
     bind-hostname = 0.0.0.0
+    bind-hostname = ${?MLEAP_SERVER_HOSTNAME}
     bind-port = 65327
+    bind-port = ${?MLEAP_SERVER_PORT}
   }
 }

--- a/mleap-serving/src/main/resources/application.conf
+++ b/mleap-serving/src/main/resources/application.conf
@@ -1,8 +1,6 @@
 ml.combust.mleap.serving {
   http {
-    hostname = 0.0.0.0
-    port = 65327
-    bind-hostname = ${ml.combust.mleap.serving.http.hostname}
-    bind-port = ${ml.combust.mleap.serving.http.port}
+    bind-hostname = 0.0.0.0
+    bind-port = 65327
   }
 }

--- a/mleap-serving/src/main/scala/ml/combust/mleap/serving/MleapConfig.scala
+++ b/mleap-serving/src/main/scala/ml/combust/mleap/serving/MleapConfig.scala
@@ -1,15 +1,16 @@
 package ml.combust.mleap.serving
 
 import com.typesafe.config.Config
+import scala.util.Properties
 
 /**
   * Created by hollinwilkins on 1/31/17.
   */
 case class HttpConfig(config: Config) {
   val hostname = config.getString("hostname")
-  val port = config.getInt("port")
+  val port = scala.util.Properties.envOrElse("MLEAP_SERVER_PORT", config.getInt("port"))
   val bindHostname = config.getString("bind-hostname")
-  val bindPort = config.getInt("bind-port")
+  val bindPort = scala.util.Properties.envOrElse("MLEAP_SERVER_PORT", config.getInt("bind-port"))
 }
 
 case class MleapConfig(config: Config) {

--- a/mleap-serving/src/main/scala/ml/combust/mleap/serving/MleapConfig.scala
+++ b/mleap-serving/src/main/scala/ml/combust/mleap/serving/MleapConfig.scala
@@ -1,14 +1,13 @@
 package ml.combust.mleap.serving
 
 import com.typesafe.config.Config
-import scala.util.Properties
 
 /**
   * Created by hollinwilkins on 1/31/17.
   */
 case class HttpConfig(config: Config) {
-  val bindHostname = scala.util.Properties.envOrElse("MLEAP_SERVER_HOSTNAME", config.getString("bind-hostname"))
-  val bindPort = scala.util.Properties.envOrElse("MLEAP_SERVER_PORT", config.getString("bind-port")).toInt
+  val bindHostname = config.getString("bind-hostname")
+  val bindPort = config.getInt("bind-port")
 }
 
 case class MleapConfig(config: Config) {

--- a/mleap-serving/src/main/scala/ml/combust/mleap/serving/MleapConfig.scala
+++ b/mleap-serving/src/main/scala/ml/combust/mleap/serving/MleapConfig.scala
@@ -8,9 +8,9 @@ import scala.util.Properties
   */
 case class HttpConfig(config: Config) {
   val hostname = config.getString("hostname")
-  val port = scala.util.Properties.envOrElse("MLEAP_SERVER_PORT", config.getInt("port"))
+  val port = scala.util.Properties.envOrElse("MLEAP_SERVER_PORT", config.getString("port")).toInt
   val bindHostname = config.getString("bind-hostname")
-  val bindPort = scala.util.Properties.envOrElse("MLEAP_SERVER_PORT", config.getInt("bind-port"))
+  val bindPort = scala.util.Properties.envOrElse("MLEAP_SERVER_PORT", config.getString("bind-port")).toInt
 }
 
 case class MleapConfig(config: Config) {

--- a/mleap-serving/src/main/scala/ml/combust/mleap/serving/MleapConfig.scala
+++ b/mleap-serving/src/main/scala/ml/combust/mleap/serving/MleapConfig.scala
@@ -7,9 +7,7 @@ import scala.util.Properties
   * Created by hollinwilkins on 1/31/17.
   */
 case class HttpConfig(config: Config) {
-  val hostname = config.getString("hostname")
-  val port = scala.util.Properties.envOrElse("MLEAP_SERVER_PORT", config.getString("port")).toInt
-  val bindHostname = config.getString("bind-hostname")
+  val bindHostname = scala.util.Properties.envOrElse("MLEAP_SERVER_HOSTNAME", config.getString("bind-hostname"))
   val bindPort = scala.util.Properties.envOrElse("MLEAP_SERVER_PORT", config.getString("bind-port")).toInt
 }
 


### PR DESCRIPTION
Motivation for this PR:  I needed a convenient way to manage what interface and port the MLeap serving binary listens on in order to facilitate an automated approach to having multiple MLeap serving instances running on the same server (e.g. by using different ports).  The primary objective is to host multiple instances each with their own unique model.

A few disclaimers:
- I am NOT a Scala developer! This is my first foray in it... :)
- The port/bind-port and hostname/bind-hostname variables seemed redundant? I removed the one that wasn't used by the MleapServer.scala code.  I didn't see any evidence that the "redundant" variables were used anywhere else, so please correct me if I'm wrong there.
- Just realized.... prior to doing Http().bindAndHandle(), the variables (maybe?) should be validated for at least format, since they could have been passed in via the shell environment.

Thanks!