### PR TITLE
Fix "Failed to find a default value for link" error for GeneralizedLinearRegressionModel

### DIFF
--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/GeneralizedLinearRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/GeneralizedLinearRegressionOp.scala
@@ -29,11 +29,16 @@ class GeneralizedLinearRegressionOp extends MleapOp[GeneralizedLinearRegression,
 
     override def load(model: Model)
                      (implicit context: BundleContext[MleapContext]): GeneralizedLinearRegressionModel = {
-
+      val family = Family.fromName(model.value("family").getString)
+      val link = if (model.getValue("link").isDefined) {
+        Link.fromName(model.value("link").getString)
+      } else {
+        family.defaultLink
+      }
       GeneralizedLinearRegressionModel(coefficients = Vectors.dense(model.value("coefficients").getTensor[Double].toArray),
         intercept = model.value("intercept").getDouble,
-        fal = new FamilyAndLink(Family.fromName(model.value("family").getString),
-          Link.fromName(model.value("link").getString)))
+        fal = new FamilyAndLink(family, link)
+      )
     }
   }
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/GeneralizedLinearRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/GeneralizedLinearRegressionOp.scala
@@ -30,11 +30,7 @@ class GeneralizedLinearRegressionOp extends MleapOp[GeneralizedLinearRegression,
     override def load(model: Model)
                      (implicit context: BundleContext[MleapContext]): GeneralizedLinearRegressionModel = {
       val family = Family.fromName(model.value("family").getString)
-      val link = if (model.getValue("link").isDefined) {
-        Link.fromName(model.value("link").getString)
-      } else {
-        family.defaultLink
-      }
+      val link = model.getValue("link").map(v => Link.fromName(v.getString)).getOrElse(family.defaultLink)
       GeneralizedLinearRegressionModel(coefficients = Vectors.dense(model.value("coefficients").getTensor[Double].toArray),
         intercept = model.value("intercept").getDouble,
         fal = new FamilyAndLink(family, link)

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/GeneralizedLinearRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/GeneralizedLinearRegressionOp.scala
@@ -34,8 +34,8 @@ class GeneralizedLinearRegressionOp extends SimpleSparkOp[GeneralizedLinearRegre
         coefficients = Vectors.dense(model.value("coefficients").getTensor[Double].toArray),
         intercept = model.value("intercept").getDouble)
       m.set(m.family, model.value("family").getString)
-      if (model.getValue("link").isDefined) {
-        m.set(m.link, model.value("link").getString)
+      for (link <- model.getValue("link")) {
+        m.set(m.link, link.getString)
       }
       m
     }


### PR DESCRIPTION
The following code can't work: 

``` scala
import ml.combust.bundle.BundleFile
import ml.combust.bundle.serializer.SerializationFormat
import ml.combust.mleap.runtime.MleapSupport._
import ml.combust.mleap.spark.SparkSupport._
import org.apache.spark.ml.Pipeline
import org.apache.spark.ml.bundle.SparkBundleContext
import org.apache.spark.ml.regression.GeneralizedLinearRegression
import org.apache.spark.sql.SparkSession
import resource._

   // create spark session
    val spark: SparkSession = SparkSession
      .builder.master("local[*]")
      .appName("GLMTest")
      .getOrCreate()

    // load training data
    val training = spark.read.format("libsvm").load("/tmp/sample_linear_regression_data.txt")

    val glr = new GeneralizedLinearRegression()
      // .setFamily("gaussian")
      // .setLink("identity")
      .setMaxIter(10)
      .setRegParam(0.3)

    val model = new Pipeline().setStages(Array(glr)).fit(training)

    // save Spark model
    val transformedDataset = model.transform(training)
    implicit val sbc = SparkBundleContext().withDataset(transformedDataset)
    for (bundle <- managed(BundleFile("jar:file:/tmp/test.zip"))) {
      model.writeBundle.format(SerializationFormat.Json).save(bundle)
    }.get

    // load Spark model
    (for (bundle <- managed(BundleFile("jar:file:/tmp/test.zip"))) yield {
      bundle.loadSparkBundle().get
    }).opt.get

    // load MLeap model
    (for (bundle <- managed(BundleFile("jar:file:/tmp/test.zip"))) yield {
      bundle.loadMleapBundle().get
    }).opt.get
```

Error message:

```
Exception in thread "main" java.util.NoSuchElementException: Failed to find a default value for link
	at org.apache.spark.ml.param.Params$$anonfun$getOrDefault$2.apply(params.scala:652)
	at org.apache.spark.ml.param.Params$$anonfun$getOrDefault$2.apply(params.scala:652)
	at scala.Option.getOrElse(Option.scala:121)
	at org.apache.spark.ml.param.Params$class.getOrDefault(params.scala:651)
	at org.apache.spark.ml.PipelineStage.getOrDefault(Pipeline.scala:42)
	at org.apache.spark.ml.param.Params$class.$(params.scala:658)
	at org.apache.spark.ml.PipelineStage.$(Pipeline.scala:42)
	at org.apache.spark.ml.regression.GeneralizedLinearRegressionBase$class.getLink(GeneralizedLinearRegression.scala:108)
	at org.apache.spark.ml.regression.GeneralizedLinearRegressionModel.getLink(GeneralizedLinearRegression.scala:933)
	at org.apache.spark.ml.bundle.ops.regression.GeneralizedLinearRegressionOp$$anon$1.store(GeneralizedLinearRegressionOp.scala:25)
	at org.apache.spark.ml.bundle.ops.regression.GeneralizedLinearRegressionOp$$anon$1.store(GeneralizedLinearRegressionOp.scala:15)
	at ml.combust.bundle.serializer.ModelSerializer$$anonfun$write$1.apply(ModelSerializer.scala:87)
	at ml.combust.bundle.serializer.ModelSerializer$$anonfun$write$1.apply(ModelSerializer.scala:83)
	at scala.util.Try$.apply(Try.scala:191)
	at ml.combust.bundle.serializer.ModelSerializer.write(ModelSerializer.scala:83)
	at ml.combust.bundle.serializer.NodeSerializer$$anonfun$write$1.apply(NodeSerializer.scala:85)
	at ml.combust.bundle.serializer.NodeSerializer$$anonfun$write$1.apply(NodeSerializer.scala:81)
	at scala.util.Try$.apply(Try.scala:191)
	at ml.combust.bundle.serializer.NodeSerializer.write(NodeSerializer.scala:81)
	at ml.combust.bundle.serializer.GraphSerializer$$anonfun$writeNode$1.apply(GraphSerializer.scala:34)
	at ml.combust.bundle.serializer.GraphSerializer$$anonfun$writeNode$1.apply(GraphSerializer.scala:30)
	at scala.util.Try$.apply(Try.scala:191)
	at ml.combust.bundle.serializer.GraphSerializer.writeNode(GraphSerializer.scala:30)
	at ml.combust.bundle.serializer.GraphSerializer$$anonfun$write$2.apply(GraphSerializer.scala:21)
	at ml.combust.bundle.serializer.GraphSerializer$$anonfun$write$2.apply(GraphSerializer.scala:21)
	at scala.collection.IndexedSeqOptimized$class.foldl(IndexedSeqOptimized.scala:57)
	at scala.collection.IndexedSeqOptimized$class.foldLeft(IndexedSeqOptimized.scala:66)
	at scala.collection.mutable.WrappedArray.foldLeft(WrappedArray.scala:35)
	at ml.combust.bundle.serializer.GraphSerializer.write(GraphSerializer.scala:20)
	at org.apache.spark.ml.bundle.ops.PipelineOp$$anon$1.store(PipelineOp.scala:21)
	at org.apache.spark.ml.bundle.ops.PipelineOp$$anon$1.store(PipelineOp.scala:14)
	at ml.combust.bundle.serializer.ModelSerializer$$anonfun$write$1.apply(ModelSerializer.scala:87)
	at ml.combust.bundle.serializer.ModelSerializer$$anonfun$write$1.apply(ModelSerializer.scala:83)
	at scala.util.Try$.apply(Try.scala:191)
	at ml.combust.bundle.serializer.ModelSerializer.write(ModelSerializer.scala:83)
	at ml.combust.bundle.serializer.NodeSerializer$$anonfun$write$1.apply(NodeSerializer.scala:85)
	at ml.combust.bundle.serializer.NodeSerializer$$anonfun$write$1.apply(NodeSerializer.scala:81)
	at scala.util.Try$.apply(Try.scala:191)
	at ml.combust.bundle.serializer.NodeSerializer.write(NodeSerializer.scala:81)
	at ml.combust.bundle.serializer.BundleSerializer$$anonfun$write$1.apply(BundleSerializer.scala:34)
	at ml.combust.bundle.serializer.BundleSerializer$$anonfun$write$1.apply(BundleSerializer.scala:29)
	at scala.util.Try$.apply(Try.scala:191)
	at ml.combust.bundle.serializer.BundleSerializer.write(BundleSerializer.scala:29)
	at ml.combust.bundle.BundleWriter.save(BundleWriter.scala:26)
	at me.ihainan.dev.mleap.GLMSparkTest$$anonfun$main$2.apply(GLMSparkNewTest.scala:36)
	at me.ihainan.dev.mleap.GLMSparkTest$$anonfun$main$2.apply(GLMSparkNewTest.scala:35)
	at resource.AbstractManagedResource$$anonfun$5.apply(AbstractManagedResource.scala:88)
	at scala.util.control.Exception$Catch$$anonfun$either$1.apply(Exception.scala:125)
	at scala.util.control.Exception$Catch$$anonfun$either$1.apply(Exception.scala:125)
	at scala.util.control.Exception$Catch.apply(Exception.scala:103)
	at scala.util.control.Exception$Catch.either(Exception.scala:125)
	at resource.AbstractManagedResource.acquireFor(AbstractManagedResource.scala:88)
	at resource.ManagedResourceOperations$class.apply(ManagedResourceOperations.scala:26)
	at resource.AbstractManagedResource.apply(AbstractManagedResource.scala:50)
	at resource.ManagedResourceOperations$class.acquireAndGet(ManagedResourceOperations.scala:25)
	at resource.AbstractManagedResource.acquireAndGet(AbstractManagedResource.scala:50)
	at resource.ManagedResourceOperations$class.foreach(ManagedResourceOperations.scala:53)
	at resource.AbstractManagedResource.foreach(AbstractManagedResource.scala:50)
	at me.ihainan.dev.mleap.GLMSparkTest$.main(GLMSparkNewTest.scala:35)
	at me.ihainan.dev.mleap.GLMSparkTest.main(GLMSparkNewTest.scala)
```

The root cause of this issue is that the `link` parameter of `org.apache.spark.ml.regression.GeneralizedLinearRegressionBase` doesn't have a default value. If user didn't specify this parameter, we can't invoke the `getLink` method directly:

``` scala
// org.apache.spark.ml.bundle.ops.regression.GeneralizedLinearRegressionOp
val modelWithoutLink = model.withValue("coefficients", Value.vector(obj.coefficients.toArray)).
        withValue("intercept", Value.double(obj.intercept)).
        withValue("family", Value.string(obj.getFamily)).
        withValue("link", Value.string(obj.getLink))
```