### PR TITLE
fix StringIndexer serialization and deserialization after changes for Spark 2.3

### DIFF
--- a/mleap-spark/src/main/resources/reference.conf
+++ b/mleap-spark/src/main/resources/reference.conf
@@ -1,20 +1,23 @@
 ml.combust.mleap.spark.registry.v20-ops = [
   "org.apache.spark.ml.bundle.ops.classification.GBTClassifierOpV20",
-  "org.apache.spark.ml.bundle.ops.classification.LogisticRegressionOpV20"
+  "org.apache.spark.ml.bundle.ops.classification.LogisticRegressionOpV20",
+  "org.apache.spark.ml.bundle.ops.feature.StringIndexerOpV22"
 ]
 
 ml.combust.mleap.spark.registry.v21-ops = [
   "org.apache.spark.ml.bundle.ops.feature.MinHashLSHOp",
   "org.apache.spark.ml.bundle.ops.feature.BucketedRandomProjectionLSHOp",
   "org.apache.spark.ml.bundle.ops.classification.GBTClassifierOpV20",
-  "org.apache.spark.ml.bundle.ops.classification.LogisticRegressionOpV21"
+  "org.apache.spark.ml.bundle.ops.classification.LogisticRegressionOpV21",
+  "org.apache.spark.ml.bundle.ops.feature.StringIndexerOpV22"
 ]
 
 ml.combust.mleap.spark.registry.v22-ops = [
   "org.apache.spark.ml.bundle.ops.feature.MinHashLSHOp",
   "org.apache.spark.ml.bundle.ops.feature.BucketedRandomProjectionLSHOp",
   "org.apache.spark.ml.bundle.ops.classification.GBTClassifierOpV22",
-  "org.apache.spark.ml.bundle.ops.classification.LogisticRegressionOpV21"
+  "org.apache.spark.ml.bundle.ops.classification.LogisticRegressionOpV21",
+  "org.apache.spark.ml.bundle.ops.feature.StringIndexerOpV22"
 ]
 
 ml.combust.mleap.spark.registry.v23-ops = [
@@ -22,7 +25,8 @@ ml.combust.mleap.spark.registry.v23-ops = [
   "org.apache.spark.ml.bundle.ops.feature.BucketedRandomProjectionLSHOp",
   "org.apache.spark.ml.bundle.ops.classification.GBTClassifierOpV22",
   "org.apache.spark.ml.bundle.ops.classification.LogisticRegressionOpV21",
-  "org.apache.spark.ml.bundle.ops.feature.FeatureHasherOp"
+  "org.apache.spark.ml.bundle.ops.feature.FeatureHasherOp",
+  "org.apache.spark.ml.bundle.ops.feature.StringIndexerOpV23"
 ]
 
 ml.combust.mleap.spark.registry.v20.ops += "ml.combust.mleap.spark.registry.base-ops"
@@ -68,7 +72,6 @@ ml.combust.mleap.spark.registry.base-ops = [
   "org.apache.spark.ml.bundle.ops.feature.ReverseStringIndexerOp",
   "org.apache.spark.ml.bundle.ops.feature.StandardScalerOp",
   "org.apache.spark.ml.bundle.ops.feature.StopWordsRemoverOp",
-  "org.apache.spark.ml.bundle.ops.feature.StringIndexerOp",
   "org.apache.spark.ml.bundle.ops.feature.TokenizerOp",
   "org.apache.spark.ml.bundle.ops.feature.VectorAssemblerOp",
   "org.apache.spark.ml.bundle.ops.feature.VectorIndexerOp",

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOpV22.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOpV22.scala
@@ -1,16 +1,15 @@
 package org.apache.spark.ml.bundle.ops.feature
 
 import ml.combust.bundle.BundleContext
-import ml.combust.bundle.op.OpModel
 import ml.combust.bundle.dsl._
-import org.apache.avro.generic.GenericData.StringType
+import ml.combust.bundle.op.OpModel
 import org.apache.spark.ml.bundle._
 import org.apache.spark.ml.feature.StringIndexerModel
 
 /**
   * Created by hollinwilkins on 8/21/16.
   */
-class StringIndexerOp extends SimpleSparkOp[StringIndexerModel] {
+class StringIndexerOpV22 extends SimpleSparkOp[StringIndexerModel] {
   override val Model: OpModel[SparkBundleContext, StringIndexerModel] = new OpModel[SparkBundleContext, StringIndexerModel] {
     override val klazz: Class[StringIndexerModel] = classOf[StringIndexerModel]
 
@@ -19,24 +18,19 @@ class StringIndexerOp extends SimpleSparkOp[StringIndexerModel] {
     override def store(model: Model, obj: StringIndexerModel)
                       (implicit context: BundleContext[SparkBundleContext]): Model = {
       model.withValue("labels", Value.stringList(obj.labels)).
-        withValue("handle_invalid", Value.string(obj.getHandleInvalid)).
-        withValue("string_order_type", Value.string(obj.getStringOrderType))
+        withValue("handle_invalid", Value.string(obj.getHandleInvalid))
     }
 
     override def load(model: Model)
                      (implicit context: BundleContext[SparkBundleContext]): StringIndexerModel = {
-      val m = new StringIndexerModel(uid = "", labels = model.value("labels").getStringList.toArray).
+      new StringIndexerModel(uid = "", labels = model.value("labels").getStringList.toArray).
         setHandleInvalid(model.value("handle_invalid").getString)
-      m.set(m.stringOrderType, model.value("string_order_type").getString)
-      m
     }
   }
 
   override def sparkLoad(uid: String, shape: NodeShape, model: StringIndexerModel): StringIndexerModel = {
-    val m = new StringIndexerModel(uid = uid,
+    new StringIndexerModel(uid = uid,
       labels = model.labels).setHandleInvalid(model.getHandleInvalid)
-    m.set(m.stringOrderType, model.getStringOrderType)
-    m
   }
 
   override def sparkInputs(obj: StringIndexerModel): Seq[ParamSpec] = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOpV23.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOpV23.scala
@@ -1,0 +1,48 @@
+package org.apache.spark.ml.bundle.ops.feature
+
+import ml.combust.bundle.BundleContext
+import ml.combust.bundle.op.OpModel
+import ml.combust.bundle.dsl._
+import org.apache.spark.ml.bundle._
+import org.apache.spark.ml.feature.StringIndexerModel
+
+/**
+  * Created by hollinwilkins on 8/21/16.
+  */
+class StringIndexerOpV23 extends SimpleSparkOp[StringIndexerModel] {
+  override val Model: OpModel[SparkBundleContext, StringIndexerModel] = new OpModel[SparkBundleContext, StringIndexerModel] {
+    override val klazz: Class[StringIndexerModel] = classOf[StringIndexerModel]
+
+    override def opName: String = Bundle.BuiltinOps.feature.string_indexer
+
+    override def store(model: Model, obj: StringIndexerModel)
+                      (implicit context: BundleContext[SparkBundleContext]): Model = {
+      model.withValue("labels", Value.stringList(obj.labels)).
+        withValue("handle_invalid", Value.string(obj.getHandleInvalid)).
+        withValue("string_order_type", Value.string(obj.getStringOrderType))
+    }
+
+    override def load(model: Model)
+                     (implicit context: BundleContext[SparkBundleContext]): StringIndexerModel = {
+      val m = new StringIndexerModel(uid = "", labels = model.value("labels").getStringList.toArray).
+        setHandleInvalid(model.value("handle_invalid").getString)
+      m.set(m.stringOrderType, model.value("string_order_type").getString)
+      m
+    }
+  }
+
+  override def sparkLoad(uid: String, shape: NodeShape, model: StringIndexerModel): StringIndexerModel = {
+    val m = new StringIndexerModel(uid = uid,
+      labels = model.labels).setHandleInvalid(model.getHandleInvalid)
+    m.set(m.stringOrderType, model.getStringOrderType)
+    m
+  }
+
+  override def sparkInputs(obj: StringIndexerModel): Seq[ParamSpec] = {
+    Seq("input" -> obj.inputCol)
+  }
+
+  override def sparkOutputs(obj: StringIndexerModel): Seq[SimpleParamSpec] = {
+    Seq("output" -> obj.outputCol)
+  }
+}


### PR DESCRIPTION
This addresses the issue raised in https://github.com/combust/mleap/issues/374, which started occurring after this merge https://github.com/combust/mleap/pull/364. 

Spark 2.3 introduces a new field called stringOrderType, that as far as I can see, is used only during training time, but which we want to serialize, in case we want to reload the pipeline back into Spark.

I've created an Op that works for Spark versions pre 2.3 and a different one for Spark 2.3. 

