### PR TITLE
FIX Pyspark removed non-existing import

### DIFF
--- a/python/mleap/pyspark/__init__.py
+++ b/python/mleap/pyspark/__init__.py
@@ -1,4 +1,4 @@
-import mleap.pyspark.feature
+import mleap.pyspark
 import sys
 
 sys.modules['pyspark.ml.mleap'] = mleap


### PR DESCRIPTION
When using with pyspark returns an error on library initialization.
Precisely on the import command since the feature class does not exist anymore.