### PR TITLE
Feature/drilldown

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
@@ -79,6 +79,10 @@ object Bundle {
       val interaction = "interaction"
     }
 
+    object ensemble {
+      val categorical_drilldown = "categorical_drilldown"
+    }
+
     object classification {
       val naive_bayes = "naive_bayes"
       val logistic_regression = "logistic_regression"

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/types/Casting.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/types/Casting.scala
@@ -75,10 +75,10 @@ object Casting {
     },
     (BasicType.String, BasicType.Byte) -> { (v: String) => if (v == "null" || v == "") null else v.toByte },
     (BasicType.String, BasicType.Short) -> { (v: String) => if (v == "null" || v == "") null else v.toShort },
-    (BasicType.String, BasicType.Int) -> { (v: String) => if (v == "null" || v == "") null else  v.toInt },
-    (BasicType.String, BasicType.Long) -> { (v: String) => if (v == "null" || v == "") null else  v.toLong },
-    (BasicType.String, BasicType.Float) -> { (v: String) => if (v == "null" || v == "") null else  v.toFloat },
-    (BasicType.String, BasicType.Double) -> { (v: String) => if (v == "null" || v == "") null else  v.toDouble }
+    (BasicType.String, BasicType.Int) -> { (v: String) => if (v == "null" || v == "") null else v.toInt },
+    (BasicType.String, BasicType.Long) -> { (v: String) => if (v == "null" || v == "") null else v.toLong },
+    (BasicType.String, BasicType.Float) -> { (v: String) => if (v == "null" || v == "") null else v.toFloat },
+    (BasicType.String, BasicType.Double) -> { (v: String) => if (v == "null" || v == "") null else v.toDouble }
   ).map {
     case (k, v) => (k, v.asInstanceOf[(Any) => Any])
   }

--- a/mleap-runtime/src/main/resources/reference.conf
+++ b/mleap-runtime/src/main/resources/reference.conf
@@ -63,6 +63,8 @@ ml.combust.mleap.registry.builtin-ops = [
   "ml.combust.mleap.bundle.ops.regression.LinearRegressionOp",
   "ml.combust.mleap.bundle.ops.regression.RandomForestRegressionOp",
 
+  "ml.combust.mleap.bundle.ops.ensemble.CategoricalDrilldownOp",
+
   "ml.combust.mleap.bundle.ops.recommendation.ALSOp",
 
   "ml.combust.mleap.bundle.ops.PipelineOp"

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/ensemble/CategoricalDrilldownOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/ensemble/CategoricalDrilldownOp.scala
@@ -1,0 +1,45 @@
+package ml.combust.mleap.bundle.ops.ensemble
+
+import ml.combust.bundle.BundleContext
+import ml.combust.bundle.dsl.{Bundle, Model, Value}
+import ml.combust.bundle.op.OpModel
+import ml.combust.bundle.serializer.ModelSerializer
+import ml.combust.mleap.bundle.ops.MleapOp
+import ml.combust.mleap.runtime.MleapContext
+import ml.combust.mleap.runtime.frame.Transformer
+import ml.combust.mleap.runtime.transformer.ensemble.{CategoricalDrilldown, CategoricalDrilldownModel}
+
+class CategoricalDrilldownOp extends MleapOp[CategoricalDrilldown, CategoricalDrilldownModel] {
+  override val Model: OpModel[MleapContext, CategoricalDrilldownModel] = new OpModel[MleapContext, CategoricalDrilldownModel] {
+    override val klazz: Class[CategoricalDrilldownModel] = classOf[CategoricalDrilldownModel]
+
+    override def opName: String = Bundle.BuiltinOps.ensemble.categorical_drilldown
+
+    override def store(model: Model, obj: CategoricalDrilldownModel)
+                      (implicit context: BundleContext[MleapContext]): Model = {
+      val indexedTransformers = obj.transformers.toSeq.zipWithIndex
+      val labels = indexedTransformers.map(_._1._1)
+
+      for(((_, transformer), i) <- indexedTransformers) {
+        val name = s"model$i"
+        ModelSerializer(context.bundleContext(name)).write(transformer).get
+        name
+      }
+
+      model.withValue("labels", Value.stringList(labels))
+    }
+
+    override def load(model: Model)
+                     (implicit context: BundleContext[MleapContext]): CategoricalDrilldownModel = {
+      val labels = model.value("labels").getStringList
+      val transformers = labels.indices.map {
+        i => ModelSerializer(context.bundleContext(s"model$i")).read().get.asInstanceOf[Transformer]
+      }
+      val lookup = labels.zip(transformers).toMap
+
+      CategoricalDrilldownModel(lookup)
+    }
+  }
+
+  override def model(node: CategoricalDrilldown): CategoricalDrilldownModel = node.model
+}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/ensemble/CategoricalDrilldown.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/ensemble/CategoricalDrilldown.scala
@@ -1,0 +1,58 @@
+package ml.combust.mleap.runtime.transformer.ensemble
+
+import ml.combust.mleap.core.Model
+import ml.combust.mleap.core.types._
+import ml.combust.mleap.runtime.frame.{FrameBuilder, RowTransformer, Transformer, Row}
+import ml.combust.mleap.runtime.function.{Selector, UserDefinedFunction}
+
+import scala.util.Try
+
+/**
+  * Created by hollinwilkins on 9/22/17.
+  */
+case class CategoricalDrilldownModel(transformers: Map[String, Transformer]) extends Model {
+  override def inputSchema: StructType = StructType(StructField("label", ScalarType.String.nonNullable) +: transformers.head._2.model.inputSchema.fields.map {
+    f => f.copy(name = s"drilldown.${f.name}")
+  }).get
+
+  override def outputSchema: StructType = StructType(transformers.head._2.model.outputSchema.fields.map {
+    f => f.copy(name = s"drilldown.${f.name}")
+  }).get
+
+  private val rowTransformers: Map[String, (Transformer, RowTransformer)] = {
+    transformers.map {
+      case (label, transformer) =>
+        (label, (transformer, transformer.transform(RowTransformer(transformer.inputSchema)).get))
+    }
+  }
+
+  private val outputIndices: Map[String, Seq[Int]] = {
+    rowTransformers.map {
+      case (label, (transformer, rowTransformer)) =>
+        val indices = transformer.outputSchema.fields.map(_.name).map {
+          name => rowTransformer.outputSchema.indexOf(name).get
+        }
+        (label, indices)
+    }
+  }
+
+  def apply(label: String, row: Row): Row = {
+    rowTransformers(label)._2.transform(row).selectIndices(outputIndices(label): _*)
+  }
+}
+
+case class CategoricalDrilldown(override val uid: String = Transformer.uniqueName("categorical_drilldown"),
+                                override val shape: NodeShape,
+                                override val model: CategoricalDrilldownModel) extends Transformer {
+  private val f = (label: String, row: Row) => model(label, row)
+  val exec: UserDefinedFunction = UserDefinedFunction(f,
+    outputSchema,
+    Seq(DataTypeSpec(ScalarType.String.nonNullable), SchemaSpec(StructType(inputSchema.fields.tail).get)))
+
+  val outputCols: Seq[String] = shape.outputs.values.map(_.name).toSeq
+  val inputSelectors: Seq[Selector] = Seq(inputSchema.fields.head.name, inputSchema.fields.tail.map(_.name))
+
+  override def transform[TB <: FrameBuilder[TB]](builder: TB): Try[TB] = {
+    builder.withColumns(outputCols, inputSelectors: _*)(exec)
+  }
+}

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/ensemble/CategoricalDrilldownSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/ensemble/CategoricalDrilldownSpec.scala
@@ -1,0 +1,75 @@
+package ml.combust.mleap.runtime.transformer.ensemble
+
+import ml.combust.mleap.core.Model
+import ml.combust.mleap.core.types.{NodeShape, ScalarType, StructType}
+import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, MultiTransformer, Row, Transformer}
+import ml.combust.mleap.runtime.function.UserDefinedFunction
+import org.scalatest.FunSpec
+
+case class TestClassifierModel(shift: Int) extends Model {
+  def apply(feature: Int): Double = {
+    feature + shift
+  }
+  def predictProbability(feature: Int): Double = 1.0
+
+  override def inputSchema: StructType = StructType("input" -> ScalarType.Int.nonNullable).get
+
+  override def outputSchema: StructType = StructType("output" -> ScalarType.Double.nonNullable,
+    "probability" -> ScalarType.Double.nonNullable).get
+}
+
+case class TestClassifier(override val uid: String = Transformer.uniqueName("drilldown_classification"),
+                          override val shape: NodeShape,
+                          override val model: TestClassifierModel) extends MultiTransformer {
+  override val exec: UserDefinedFunction = UserDefinedFunction(
+    (feature: Int) => Row(model(feature), model.predictProbability(feature)),
+    outputSchema,
+    inputSchema)
+}
+
+class CategoricalDrilldownSpec extends FunSpec {
+  val classifier1 = TestClassifier(shape = NodeShape().withStandardInput("feature").
+    withOutput("output", "prediction").
+    withOutput("probability", "probability"),
+    model = TestClassifierModel(10))
+  val classifier2 = TestClassifier(shape = NodeShape().withStandardInput("feature").
+    withOutput("output", "prediction").
+    withOutput("probability", "probability"),
+    model = TestClassifierModel(100))
+  val classifier3 = TestClassifier(shape = NodeShape().withStandardInput("feature").
+    withOutput("output", "prediction").
+    withOutput("probability", "probability"),
+    model = TestClassifierModel(1000))
+  val classifier4 = TestClassifier(shape = NodeShape().withStandardInput("feature").
+    withOutput("output", "prediction").
+    withOutput("probability", "probability"),
+    model = TestClassifierModel(10000))
+  val drilldownModel = CategoricalDrilldownModel(Map("class1" -> classifier1,
+    "class2" -> classifier2,
+    "class3" -> classifier3,
+    "class4" -> classifier4))
+
+  val drilldown = CategoricalDrilldown(shape = NodeShape().
+    withInput("label", "label").
+    withInput("drilldown.input", "feature").
+    withOutput("drilldown.output", "prediction").
+    withOutput("drilldown.probability", "probability"),
+    model = drilldownModel)
+
+  val schema = StructType("feature" -> ScalarType.Int.nonNullable,
+    "label" -> ScalarType.String.nonNullable).get
+  val data = Seq(Row(10, "class2"), Row(100, "class3"), Row(1000, "class1"), Row(10000, "class4"))
+  val frame = DefaultLeapFrame(schema, data)
+
+  describe("transforming") {
+    it("uses the input field to drill down using a different model") {
+      val data = (for (frame2 <- drilldown.transform(frame);
+                       frame3 <- frame2.select("prediction", "probability")) yield {
+        frame3.dataset
+      }).get
+
+      assert(data.map(_.getDouble(0)) == Seq(110.0, 1100.0, 1010.0, 20000.0))
+      assert(data.map(_.getDouble(1)) == Seq(1.0, 1.0, 1.0, 1.0))
+    }
+  }
+}


### PR DESCRIPTION
This adds a drilldown model, which will execute a different transformer for each row in a data frame depending on a string label.

This is useful for when you have a classifier for broad classes, and then within each class you want to further divide it into more specific classes.

Current restriction is that each drilldown transformer must have the exact same inputs and outputs.