### PR TITLE
1HE NodeShape backwards compatibility

### DIFF
--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/OneHotEncoderOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/OneHotEncoderOp.scala
@@ -1,5 +1,6 @@
 package ml.combust.mleap.bundle.ops.feature
 
+import ml.bundle.Socket
 import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.OpModel
@@ -7,6 +8,7 @@ import ml.combust.mleap.bundle.ops.MleapOp
 import ml.combust.mleap.core.feature.{HandleInvalid, OneHotEncoderModel}
 import ml.combust.mleap.runtime.MleapContext
 import ml.combust.mleap.runtime.transformer.feature.OneHotEncoder
+import ml.combust.mleap.runtime.types.BundleTypeConverters._
 
 /**
   * Created by hollinwilkins on 10/24/16.
@@ -42,4 +44,18 @@ class OneHotEncoderOp extends MleapOp[OneHotEncoder, OneHotEncoderModel] {
   }
 
   override def model(node: OneHotEncoder): OneHotEncoderModel = node.model
+
+  override def shape(node: OneHotEncoder)
+                    (implicit context: BundleContext[MleapContext]): NodeShape = {
+
+    node.shape.getInput(NodeShape.standardInputPort) match {
+        // Old version of 1HE -- need to translate serialized port names to new expectation (input -> input0)
+      case Some(_) ⇒
+        val i = node.shape.getInput(NodeShape.standardInputPort).get
+        val o = node.shape.getOutput(NodeShape.standardOutputPort).get
+        NodeShape(inputs = Seq(Socket(i.port + "0", i.name)), outputs = Seq(Socket(o.port + "0", o.name)))
+        // New version of 1HE
+      case None ⇒ NodeShape.fromBundle(node.shape)
+    }
+  }
 }

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,6 +2,6 @@ numpy>=1.8.2
 six>=1.10.0
 scipy>=0.13.0b1
 pandas>=0.18.1
-scikit-learn>0.18.dev0
+scikit-learn>0.18.dev0,<0.20.0
 nose-exclude>=0.5.0
 gensim>=1.0.1


### PR DESCRIPTION
Relates to #417.

I'm embarrassed to say that my previous PR wasn't entirely complete.  We had some problem with our legacy models and it took some digging to figure out why -- the legacy serialized `NodeShape` object needs to be massaged a bit at load to work with the new implementation.   This PR adds that massaging.  Sorry I overlooked this the first time!