### PR TITLE
Remove unnecessary cast (xgboost 0.81)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   pip install --user -r ./python/requirements.txt
 
 script:
-  - nosetests ./python -v
+  - nosetests ./python -v --exclude-dir=./python/mleap/pyspark
   - travis/travis.sh
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ scala:
   - 2.11.8
 
 python:
-  - "2.7"
+  - "2.7.15"
 
 install:
   pip install --user -r ./python/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   pip install --user -r ./python/requirements.txt
 
 script:
-  - nosetests ./python -v --exclude-dir=./python/mleap/pyspark
+  - nosetests ./python -v
   - travis/travis.sh
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ scala:
   - 2.11.8
 
 python:
-  - "2.7.15"
+  - "2.7"
 
 install:
   pip install --user -r ./python/requirements.txt

--- a/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
+++ b/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
@@ -37,7 +37,7 @@ class XGBoostClassificationModelOp extends SimpleSparkOp[XGBoostClassificationMo
       model.withValue("thresholds", thresholds.map(_.toSeq).map(Value.doubleList)).
         withValue("num_classes", Value.int(obj.numClasses)).
         withValue("num_features", Value.int(numFeatures)).
-        withValue("tree_limit", Value.int(obj.getTreeLimit.toInt))
+        withValue("tree_limit", Value.int(obj.getTreeLimit))
     }
 
     override def load(model: Model)

--- a/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
+++ b/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
@@ -37,7 +37,7 @@ class XGBoostClassificationModelOp extends SimpleSparkOp[XGBoostClassificationMo
       model.withValue("thresholds", thresholds.map(_.toSeq).map(Value.doubleList)).
         withValue("num_classes", Value.int(obj.numClasses)).
         withValue("num_features", Value.int(numFeatures)).
-        withValue("tree_limit", Value.int(obj.getTreeLimit))
+        withValue("tree_limit", Value.int(obj.getOrDefault(obj.treeLimit)))
     }
 
     override def load(model: Model)

--- a/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelOp.scala
+++ b/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelOp.scala
@@ -30,7 +30,7 @@ class XGBoostRegressionModelOp extends SimpleSparkOp[XGBoostRegressionModel] {
 
       val numFeatures = context.context.dataset.get.select(obj.getFeaturesCol).first.getAs[Vector](0).size
       model.withValue("num_features", Value.int(numFeatures)).
-        withValue("tree_limit", Value.int(obj.getTreeLimit))
+        withValue("tree_limit", Value.int(obj.getOrDefault(obj.treeLimit)))
     }
 
     override def load(model: Model)

--- a/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelOp.scala
+++ b/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelOp.scala
@@ -30,7 +30,7 @@ class XGBoostRegressionModelOp extends SimpleSparkOp[XGBoostRegressionModel] {
 
       val numFeatures = context.context.dataset.get.select(obj.getFeaturesCol).first.getAs[Vector](0).size
       model.withValue("num_features", Value.int(numFeatures)).
-        withValue("tree_limit", Value.int(obj.getTreeLimit.toInt))
+        withValue("tree_limit", Value.int(obj.getTreeLimit))
     }
 
     override def load(model: Model)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val tensorflowVersion = "1.7.0"
   val akkaVersion = "2.4.16"
   val akkaHttpVersion = "10.0.3"
-  val xgboostVersion = "0.80"
+  val xgboostVersion = "0.81"
   val hadoopVersion = "2.6.5" // matches spark version
 
   object Compile {

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,3 +5,4 @@ pandas>=0.18.1
 scikit-learn>0.18.dev0,<0.20.0
 nose-exclude>=0.5.0
 gensim>=1.0.1
+urllib3==1.23


### PR DESCRIPTION
`getTreeLimit` of `XGBoostClassificationModel` now appropriately returns an `Int`