### PR TITLE
Lower sklearn requirement to 0.17

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -42,7 +42,7 @@ REQUIRED_PACKAGES = [
       'six >= 1.10.0',
       'scipy>=0.13.0b1',
       'pandas>=0.18.1',
-      'scikit-learn>=0.18.dev0',
+      'scikit-learn>=0.17',
       'nose-exclude>=0.5.0'
 ]
 


### PR DESCRIPTION
I am currently limited to using scikit-learn 0.17 due to the fact that model persistence isn't guaranteed to work when models were trained/written to a file in one version and then loaded from another version (https://scikit-learn.org/stable/modules/model_persistence.html#security-maintainability-limitations).

I don't see any reason mleap requires scikit-learn >= 0.18.dev0 as opposed to 0.17, so would it be possible to relax that constraint slightly?