### PR TITLE
Fix declaration/assignment order

### DIFF
--- a/mleap-runtime/src/main/resources/reference.conf
+++ b/mleap-runtime/src/main/resources/reference.conf
@@ -1,5 +1,3 @@
-ml.combust.mleap.registry.default.ops += "ml.combust.mleap.registry.builtin-ops"
-
 ml.combust.mleap.registry.builtin-ops = [
   "ml.combust.mleap.bundle.ops.classification.DecisionTreeClassifierOp",
   "ml.combust.mleap.bundle.ops.classification.GBTClassifierOp",
@@ -69,3 +67,5 @@ ml.combust.mleap.registry.builtin-ops = [
 
   "ml.combust.mleap.bundle.ops.PipelineOp"
 ]
+
+ml.combust.mleap.registry.default.ops += "ml.combust.mleap.registry.builtin-ops"


### PR DESCRIPTION
This PR makes sure `builtin-ops` is declared before assigning it to `default.ops`