### PR TITLE
fix java.io.NotSerializableException in tf model

### DIFF
--- a/mleap-tensorflow/src/main/scala/ml/combust/mleap/tensorflow/TensorflowTransformerOp.scala
+++ b/mleap-tensorflow/src/main/scala/ml/combust/mleap/tensorflow/TensorflowTransformerOp.scala
@@ -23,7 +23,7 @@ class TensorflowTransformerOp extends MleapOp[TensorflowTransformer, TensorflowM
 
     override def store(model: Model, obj: TensorflowModel)
                       (implicit context: BundleContext[MleapContext]): Model = {
-      Files.write(context.file("graph.pb"), obj.graph.toGraphDef)
+      Files.write(context.file("graph.pb"), obj.graph.get.toGraphDef)
       val (inputNames, inputMleapDataTypes) = obj.inputs.unzip
       val (inputBasicTypes, inputShapes) = inputMleapDataTypes.map {
         dt => (dt.base: BasicType, dt.shape: DataShape)
@@ -66,10 +66,11 @@ class TensorflowTransformerOp extends MleapOp[TensorflowTransformer, TensorflowM
 
       val graph = new org.tensorflow.Graph()
       graph.importGraphDef(graphBytes)
-      TensorflowModel(graph,
-        inputs,
-        outputs,
-        nodes)
+      TensorflowModel(graph = Some(graph),
+        inputs = inputs,
+        outputs = outputs,
+        nodes = nodes,
+        graphBytes = graphBytes)
     }
   }
 

--- a/mleap-tensorflow/src/test/scala/ml/combust/mleap/tensorflow/TensorflowModelSpec.scala
+++ b/mleap-tensorflow/src/test/scala/ml/combust/mleap/tensorflow/TensorflowModelSpec.scala
@@ -8,11 +8,15 @@ import org.scalatest.FunSpec
   * Created by hollinwilkins on 1/12/17.
   */
 class TensorflowModelSpec extends FunSpec {
+
   describe("with an adding tensorflow model") {
     it("adds two floats together") {
-      val model = TensorflowModel(TestUtil.createAddGraph(),
+      val graph = TestUtil.createAddGraph()
+      val model = TensorflowModel(graph = Some(graph),
         inputs = Seq(("InputA", TensorType.Float()), ("InputB", TensorType.Float())),
-        outputs = Seq(("MyResult", TensorType.Float())))
+        outputs = Seq(("MyResult", TensorType.Float())),
+        graphBytes = graph.toGraphDef
+      )
 
       assert(model(Tensor.scalar(23.4f), Tensor.scalar(45.6f)).head == Tensor.scalar(23.4f + 45.6f))
       assert(model(Tensor.scalar(42.3f), Tensor.scalar(99.9f)).head == Tensor.scalar(42.3f + 99.9f))
@@ -25,13 +29,17 @@ class TensorflowModelSpec extends FunSpec {
   describe("with a multiple tensorflow model") {
     describe("with a float and a float vector") {
       it("scales the float vector") {
-        val model = TensorflowModel(TestUtil.createMultiplyGraph(),
+        val graph = TestUtil.createMultiplyGraph()
+        val model = TensorflowModel(graph = Some(graph),
           inputs = Seq(("InputA", TensorType.Float()), ("InputB", TensorType.Float())),
-          outputs = Seq(("MyResult", TensorType.Float(3))))
+          outputs = Seq(("MyResult", TensorType.Float(3))),
+          graphBytes = graph.toGraphDef)
         val tensor1 = DenseTensor(Array(1.0f, 2.0f, 3.0f), Seq(3))
         val scale1 = Tensor.scalar(2.0f)
 
         assert(model(scale1, tensor1).head.asInstanceOf[DenseTensor[Float]].values sameElements Array(2.0f, 4.0f, 6.0f))
+
+        model.close()
       }
     }
   }

--- a/mleap-tensorflow/src/test/scala/ml/combust/mleap/tensorflow/TensorflowTransformerSpec.scala
+++ b/mleap-tensorflow/src/test/scala/ml/combust/mleap/tensorflow/TensorflowTransformerSpec.scala
@@ -17,11 +17,14 @@ import resource.managed
   * Created by hollinwilkins on 1/13/17.
   */
 class TensorflowTransformerSpec extends FunSpec {
+
   describe("with a scaling tensorflow model") {
     it("scales the vector using the model and returns the result") {
-      val model = TensorflowModel(TestUtil.createAddGraph(),
+      val graph = TestUtil.createAddGraph()
+      val model = TensorflowModel(graph = Some(graph),
         inputs = Seq(("InputA", TensorType.Float()), ("InputB", TensorType.Float())),
-        outputs = Seq(("MyResult", TensorType.Float())))
+        outputs = Seq(("MyResult", TensorType.Float())),
+        graphBytes = graph.toGraphDef)
       val shape = NodeShape().withInput("InputA", "input_a").
         withInput("InputB", "input_b").
         withOutput("MyResult", "my_result")
@@ -51,8 +54,8 @@ class TensorflowTransformerSpec extends FunSpec {
 
     it("can create transformer & bundle from a TF frozen graph") {
 
-      val model = TensorflowModel(graph, inputs = Seq(("dense_1_input", TensorType.Float(1, 11))),
-        outputs = Seq(("dense_3/Sigmoid", TensorType.Float(1, 9))))
+      val model = TensorflowModel(graph = Some(graph), inputs = Seq(("dense_1_input", TensorType.Float(1, 11))),
+        outputs = Seq(("dense_3/Sigmoid", TensorType.Float(1, 9))), graphBytes = graph.toGraphDef)
       val shape = NodeShape().withInput("dense_1_input", "features").withOutput("dense_3/Sigmoid", "score")
       val transformer = TensorflowTransformer(uid = "wine_quality", shape = shape, model = model)
 


### PR DESCRIPTION
Fixes the following exception seen when using TensorflowModel in Spark. 

``` Caused by: java.io.NotSerializableException: org.tensorflow.Graph
Serialization stack:
    - object not serializable (class: org.tensorflow.Graph, value: org.tensorflow.Graph@4fb39b40)
    - field (class: ml.combust.mleap.tensorflow.TensorflowModel, name: graph, type: class org.tensorf```