### PR TITLE
Fix openjdk base image to java 8

### DIFF
--- a/project/DockerConfig.scala
+++ b/project/DockerConfig.scala
@@ -5,6 +5,7 @@ import com.typesafe.sbt.packager.linux.LinuxPlugin.autoImport._
 object DockerConfig {
   val baseSettings = Seq(daemonUser in Docker := "root",
     dockerExposedPorts := Seq(65327),
+    dockerBaseImage := "openjdk:8",
     dockerRepository := Some("combustml"),
     dockerBuildOptions := Seq("-t", dockerAlias.value.versioned) ++ (
       if (dockerUpdateLatest.value)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.16
+sbt.version = 0.13.18


### PR DESCRIPTION
The current implementation uses the latest Java which the GRPC server code currently does not support.

This commit fixes the baseImage in the docker build configuration to openjdk version 8