### PR TITLE
StringMap: new optional parameters handleInvalid & defaultValue

### DIFF
--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringMapModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringMapModel.scala
@@ -3,11 +3,56 @@ package ml.combust.mleap.core.feature
 import ml.combust.mleap.core.Model
 import ml.combust.mleap.core.types.{ScalarType, StructType}
 
-/**
-  * Created by hollinwilkins on 1/5/17.
-  */
-case class StringMapModel(labels: Map[String, Double]) extends Model {
-  def apply(label: String): Double = labels(label)
+sealed trait StringMapHandleInvalid {
+  def asParamString: String
+}
+
+object StringMapHandleInvalid {
+  val default = Error
+  val defaultValue = 0.0
+
+  case object Error extends StringMapHandleInvalid {
+    override def asParamString: String = "error"
+  }
+
+  case object Keep extends StringMapHandleInvalid {
+    override def asParamString: String = "keep"
+  }
+
+  def fromString(value: String): StringMapHandleInvalid = value match {
+    case "error" => StringMapHandleInvalid.Error
+    case "keep" => StringMapHandleInvalid.Keep
+    case _ => throw new IllegalArgumentException(s"Invalid handler: $value")
+  }
+}
+
+/** Class for string map model.
+ *
+ * Maps a string into a double.
+ *
+ * @param labels map of labels and values
+ * @param handleInvalid how to handle missing labels: 'error' (throw an error),
+ *                      or 'keep' (map to the default value)
+ * @param defaultValue value to use if label is not found in the map
+ */
+case class StringMapModel(labels: Map[String, Double],
+                          handleInvalid: StringMapHandleInvalid = StringMapHandleInvalid.default,
+                          defaultValue: Double = StringMapHandleInvalid.defaultValue) extends Model {
+
+  private val keepInvalid = handleInvalid == StringMapHandleInvalid.Keep
+
+  def apply(label: String): Double = {
+    if (keepInvalid) {
+      labels.getOrElse(label, defaultValue)
+    } else {
+      if (labels.contains(label)) {
+        labels(label)
+      } else {
+        throw new NoSuchElementException(s"Missing label: $label. To handle unseen labels, " +
+          s"set handleInvalid to ${StringMapHandleInvalid.Keep.asParamString} and optionally set a custom defaultValue")
+      }
+    }
+  }
 
   override def inputSchema: StructType = StructType("input" -> ScalarType.String).get
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/StringMapModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/StringMapModelSpec.scala
@@ -5,9 +5,38 @@ import org.scalatest.FunSpec
 
 class StringMapModelSpec extends FunSpec {
 
-  describe("string map model") {
-    val model = StringMapModel(Map("index1" -> 1.0, "index2" -> 1.0, "index3" -> 2.0))
+  val model = StringMapModel(Map("label1" -> 1.0, "label2" -> 1.0, "label3" -> 2.0))
 
+  describe("#apply") {
+    it("returns the mapped value by label") {
+      assert(model("label1") == 1.0)
+      assert(model("label2") == 1.0)
+      assert(model("label3") == 2.0)
+    }
+
+    it("throws NoSuchElementException when encounters a missing label and handleInvalid is not keep") {
+      val thrown =
+        intercept[NoSuchElementException] {
+          model("missing_label")
+        }
+      assert(thrown.getMessage == "Missing label: missing_label. To handle unseen labels, set handleInvalid to keep" +
+        " and optionally set a custom defaultValue")
+    }
+
+    it("returns default value for StringMapHandleInvalid.keep mode") {
+      val model = StringMapModel(Map("label1" -> 1.0), handleInvalid = StringMapHandleInvalid.Keep)
+      assert(model("label1") == 1.0)
+      assert(model("missing_label") == 0.0)
+    }
+
+    it("returns custom default value for StringMapHandleInvalid.keep mode") {
+      val model = StringMapModel(Map("label1" -> 1.0), handleInvalid = StringMapHandleInvalid.Keep, defaultValue = 2.0)
+      assert(model("label1") == 1.0)
+      assert(model("missing_label") == 2.0)
+    }
+  }
+
+  describe("string map model") {
     it("has the right input schema") {
       assert(model.inputSchema.fields ==
         Seq(StructField("input", ScalarType.String)))

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/StringMapOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/StringMapOp.scala
@@ -4,7 +4,7 @@ import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.OpModel
 import ml.combust.mleap.bundle.ops.MleapOp
-import ml.combust.mleap.core.feature.StringMapModel
+import ml.combust.mleap.core.feature.{StringMapHandleInvalid, StringMapModel}
 import ml.combust.mleap.runtime.MleapContext
 import ml.combust.mleap.runtime.transformer.feature.StringMap
 
@@ -28,8 +28,10 @@ class StringMapOp extends MleapOp[StringMap, StringMapModel] {
 
       // add the labels and values to the Bundle model that
       // will be serialized to our MLeap bundle
-      model.withValue("labels", Value.stringList(labels)).
-        withValue("values", Value.doubleList(values))
+      model.withValue("labels", Value.stringList(labels))
+        .withValue("values", Value.doubleList(values))
+        .withValue("handle_invalid", Value.string(obj.handleInvalid.asParamString))
+        .withValue("default_value", Value.double(obj.defaultValue))
     }
 
     override def load(model: Model)
@@ -40,8 +42,11 @@ class StringMapOp extends MleapOp[StringMap, StringMapModel] {
       // retrieve our list of values
       val values = model.value("values").getDoubleList
 
+      val handleInvalid = model.getValue("handle_invalid").map(_.getString).map(StringMapHandleInvalid.fromString).getOrElse(StringMapHandleInvalid.default)
+      val defaultValue = model.getValue("default_value").map(_.getDouble).getOrElse(StringMapHandleInvalid.defaultValue)
+
       // reconstruct the model using the parallel labels and values
-      StringMapModel(labels.zip(values).toMap)
+      StringMapModel(labels.zip(values).toMap, handleInvalid = handleInvalid, defaultValue = defaultValue)
     }
   }
 

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/StringMapOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/StringMapOp.scala
@@ -3,8 +3,7 @@ package org.apache.spark.ml.bundle.extension.ops.feature
 import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
-import ml.combust.mleap.core.feature.StringMapModel
-import ml.combust.mleap.runtime.MleapContext
+import ml.combust.mleap.core.feature.{StringMapHandleInvalid, StringMapModel}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.mleap.feature.StringMap
 
@@ -29,8 +28,10 @@ class StringMapOp extends OpNode[SparkBundleContext, StringMap, StringMapModel] 
 
       // add the labels and values to the Bundle model that
       // will be serialized to our MLeap bundle
-      model.withValue("labels", Value.stringList(labels)).
-        withValue("values", Value.doubleList(values))
+      model.withValue("labels", Value.stringList(labels))
+        .withValue("values", Value.doubleList(values))
+        .withValue("handle_invalid", Value.string(obj.handleInvalid.asParamString))
+        .withValue("default_value", Value.double(obj.defaultValue))
     }
 
     override def load(model: Model)
@@ -41,8 +42,11 @@ class StringMapOp extends OpNode[SparkBundleContext, StringMap, StringMapModel] 
       // retrieve our list of values
       val values = model.value("values").getDoubleList
 
+      val handleInvalid = model.getValue("handle_invalid").map(_.getString).map(StringMapHandleInvalid.fromString).getOrElse(StringMapHandleInvalid.default)
+      val defaultValue = model.getValue("default_value").map(_.getDouble).getOrElse(StringMapHandleInvalid.defaultValue)
+
       // reconstruct the model using the parallel labels and values
-      StringMapModel(labels.zip(values).toMap)
+      StringMapModel(labels.zip(values).toMap, handleInvalid = handleInvalid, defaultValue = defaultValue)
     }
   }
   override val klazz: Class[StringMap] = classOf[StringMap]

--- a/mleap-spark-extension/src/test/scala/org/apache/spark/ml/mleap/parity/feature/StringMapParitySpec.scala
+++ b/mleap-spark-extension/src/test/scala/org/apache/spark/ml/mleap/parity/feature/StringMapParitySpec.scala
@@ -1,6 +1,6 @@
 package org.apache.spark.ml.mleap.parity.feature
 
-import ml.combust.mleap.core.feature.StringMapModel
+import ml.combust.mleap.core.feature.{StringMapHandleInvalid, StringMapModel}
 import org.apache.spark.ml.mleap.feature.StringMap
 import org.apache.spark.ml.parity.SparkParityBase
 import org.apache.spark.ml.{Pipeline, Transformer}
@@ -17,5 +17,12 @@ class StringMapParitySpec extends SparkParityBase {
   override val sparkTransformer: Transformer = new Pipeline().setStages(Array(
     new StringMap(uid = "string_map", model = new StringMapModel(
       Map("alice" -> 0, "andy" -> 1, "kevin" -> 2)
-    )).setInputCol("name").setOutputCol("index"))).fit(dataset)
+    )).setInputCol("name").setOutputCol("index"),
+    new StringMap(uid = "string_map2", model = new StringMapModel(
+      // This map is missing the label "kevin". Exception is thrown unless StringMapHandleInvalid.Keep is set.
+      Map("alice" -> 0, "andy" -> 1),
+      handleInvalid = StringMapHandleInvalid.Keep, defaultValue = 1.0
+    )).setInputCol("name").setOutputCol("index2")
+
+  )).fit(dataset)
 }


### PR DESCRIPTION
Implements Github issue #555: StringMap to handle missing keys instead of throwing an exception.

----

### Why no `StringMapHandleInvalid.Skip`?

Eventually I ended up not including `StringMapHandleInvalid.Skip` as an option, because it wasn't trivial to return `null` as the return type of `StringMapModel` is `Double`.

I don't see much value in having a `null` value returned instead of a `Double` default: it's after all possible to uniquely identify that a mapping wasn't found, as long as the `defaultValue` does not exist also as an entry value in the labels Map.