### PR TITLE
Validation & API improvements to string_map pyspark wrapper

### DIFF
--- a/python/mleap/pyspark/feature/string_map.py
+++ b/python/mleap/pyspark/feature/string_map.py
@@ -1,17 +1,35 @@
 from pyspark.ml.util import JavaMLReadable, JavaMLWritable, _jvm
 from pyspark.ml.wrapper import JavaTransformer
 from pyspark.ml.param.shared import HasInputCol, HasOutputCol
+from pyspark.sql import DataFrame
 
 
 class StringMap(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, JavaMLWritable):
     def __init__(self, labels, inputCol=None, outputCol=None, handleInvalid='error', defaultValue=0.0):
         """
         __init__(self, labels, inputCol=None, outputCol=None, handleInvalid='error', defaultValue=0.0)
-        labels is a dict {string: double}
+        labels must be a dict {string: double} or a spark DataFrame with columns inputCol & outputCol
         handleInvalid: how to handle missing labels: 'error' (throw an error), or 'keep' (map to the default value)
         """
-        assert handleInvalid in ['error', 'keep'], 'Invalid value for handleInvalid: {}'.format(handleInvalid)
         super(StringMap, self).__init__()
+
+        if isinstance(labels, DataFrame):
+            assert inputCol, 'inputCol is required when labels is a DataFrame'
+            assert outputCol, 'outputCol is required when labels is a DataFrame'
+            labels = {row[0]: float(row[1]) for row in labels.select([inputCol, outputCol]).collect()}
+
+        def validate_args():
+            """
+            validate args early to avoid failing at Py4j with some hard to interpret error message
+            """
+            assert handleInvalid in ['error', 'keep'], 'Invalid value for handleInvalid: {}'.format(handleInvalid)
+            assert isinstance(labels, dict), 'labels must be a dict or a DataFrame'
+            for (key, value) in labels.items():
+                assert isinstance(key, str), 'label keys must be string'
+                assert isinstance(value, float), 'label values must be float'
+
+        validate_args()
+
         labels_scala_map = _jvm() \
             .scala \
             .collection \
@@ -26,14 +44,3 @@ class StringMap(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, Java
         self._java_obj = self._new_java_obj("org.apache.spark.ml.mleap.feature.StringMap", self.uid, string_map_model)
         self.setInputCol(inputCol)
         self.setOutputCol(outputCol)
-
-    @classmethod
-    def from_dataframe(cls, df, key_col, value_col, handleInvalid='error', defaultValue=0.0):
-        """
-        from_dataframe(self, df, key_col, value_col)
-        Creates StringMap from a DataFrame.
-        """
-        dict_from_df = {row[0]: float(row[1]) for row in
-                        df.select([key_col, value_col]).collect()}
-        return cls(dict_from_df, inputCol=key_col, outputCol=value_col, handleInvalid=handleInvalid,
-                   defaultValue=defaultValue)


### PR DESCRIPTION
- Remove separate `from_dataframe` method. Allow passing a `DataFrame` as an alternative to a `dict` in the same constructor.
- Validate the args as much as possible before passing to JVM, because otherwise user gets some hard to interpret Py4j error

This code has been unit-tested. See https://github.com/combust/mleap/pull/571 for details. The test tooling for pyspark is not yet in a shape to be merged in. 