### PR TITLE
Fix bug: include xgboost-runtime classes in databricks-runtime jar

### DIFF
--- a/mleap-xgboost-spark/build.sbt
+++ b/mleap-xgboost-spark/build.sbt
@@ -1,6 +1,6 @@
 import ml.combust.mleap.{Dependencies, Common}
 
-Common.defaultMleapSettings
+Common.defaultMleapXgboostSparkSettings
 Dependencies.xgboostSpark
 
 javaOptions in Test ++= sys.env.get("XGBOOST_JNI").map {

--- a/project/MleapProject.scala
+++ b/project/MleapProject.scala
@@ -16,7 +16,8 @@ object MleapProject {
     sparkTestkit,
     spark,
     sparkExtension,
-    tensorflow,
+    xgboostRuntime,
+    xgboostSpark,
     executor,
     executorTestKit,
     grpc,
@@ -189,6 +190,7 @@ object MleapProject {
       spark,
       sparkExtension,
       tensorflow,
+      xgboostRuntime,
       xgboostSpark)
   ).settings(excludeDependencies ++= Seq(
     SbtExclusionRule("org.tensorflow"),


### PR DESCRIPTION
### What's the PR ?
Fix bug: include xgboost-runtime classes in databricks-runtime jar

The `databricksRuntime` depend on `databricksRuntimeFat`, and `databricksRuntimeFat` should directly depend on `xgboostRuntime` otherwise it won't be included into `databricksRuntimeFat`, that's the cause of this bug.

### Test
Run

```
export SBT_OPTS="-XX:MaxPermSize=4G -Xmx4G"   # mleap building require large memory size
sbt publish-local
```
Then check the generated databricks-runtime jar in sbt local repo by following command:
```
jar tf ~/.ivy2/local/ml.combust.mleap/mleap-databricks-runtime_2.11/0.14.1-SNAPSHOT | grep XGBoost
```

Check the output, it should include classes in `mleap-xgboost-runtime` project. Such as:
```
ml/combust/mleap/xgboost/runtime/XGBoostRegression$$anonfun$1.class
ml/combust/mleap/xgboost/runtime/XGBoostRegression$$anonfun$2$$anonfun$apply$1.class
ml/combust/mleap/xgboost/runtime/XGBoostRegression$$anonfun$2.class
ml/combust/mleap/xgboost/runtime/XGBoostRegression$$anonfun$3$$anonfun$apply$2.class
ml/combust/mleap/xgboost/runtime/XGBoostRegression$$anonfun$3.class
ml/combust/mleap/xgboost/runtime/XGBoostRegression$$anonfun$4$$anonfun$apply$3.class
ml/combust/mleap/xgboost/runtime/XGBoostRegression$$anonfun$4.class
ml/combust/mleap/xgboost/runtime/XGBoostRegression$$anonfun$5$$anonfun$apply$4.class
ml/combust/mleap/xgboost/runtime/XGBoostRegression$$anonfun$5.class
ml/combust/mleap/xgboost/runtime/XGBoostRegression$$anonfun$6$$anonfun$7.class
ml/combust/mleap/xgboost/runtime/XGBoostRegression$$anonfun$6$$anonfun$8.class
ml/combust/mleap/xgboost/runtime/XGBoostRegression$$anonfun$6$$anonfun$9.class
ml/combust/mleap/xgboost/runtime/XGBoostRegression$$anonfun$6.class
ml/combust/mleap/xgboost/runtime/XGBoostRegression$.class
ml/combust/mleap/xgboost/runtime/XGBoostRegression.class
ml/combust/mleap/xgboost/runtime/XGBoostRegressionModel$$anonfun$predictContrib$1.class
ml/combust/mleap/xgboost/runtime/XGBoostRegressionModel$$anonfun$predictLeaf$1.class
ml/combust/mleap/xgboost/runtime/XGBoostRegressionModel$.class
ml/combust/mleap/xgboost/runtime/XGBoostRegressionModel.class
ml/combust/mleap/xgboost/runtime/bundle/ops/XGBoostClassificationOp$$anon$1.class
ml/combust/mleap/xgboost/runtime/bundle/ops/XGBoostClassificationOp.class
ml/combust/mleap/xgboost/runtime/bundle/ops/XGBoostRegressionOp$$anon$1.class
ml/combust/mleap/xgboost/runtime/bundle/ops/XGBoostRegressionOp.class
```

### Note
This should backport to mleap 0.13 version.