### PR TITLE
Fix typo in README. Add a link to PyPI page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,10 @@ $ bin/spark-shell --packages ml.combust.mleap:mleap-spark_2.11:0.15.0
 
 ### PySpark Integration
 
-Install MLeap from pypy
+Install MLeap from [PyPI](https://pypi.org/project/mleap/)
 ```bash
 $ pip install mleap
 ```
-
 
 ## Using the Library
 


### PR DESCRIPTION
Btw, PyPI only seems to have this old version:

> mleap 0.8.1
> Last released: Oct 9, 2017

While this in git:

https://github.com/combust/mleap/blob/31db771ae26ec7b1e75864bb29361deaaa79c3f8/python/mleap/version.py#L19

Are you going to publish the latest version to PyPI?