### PR TITLE
Fix python test failure using virtualenv<20.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,50 @@ dist: trusty
 services:
   - docker
 
-language: scala
 scala:
   - 2.11.8
+jdk:
+  - oraclejdk8  # sbt +compile fails on jdk11 (xenial's default)
 
-python:
-  - "2.7"
-  - "3.6"
-  - "3.7"
+jobs:
+  include:
+    - stage: "Mleap tests"
+      name: "Scala Tests"
+      language: scala
+      script:
+        - travis/travis.sh
 
-install:
-    -   pip install --user tox
-script:
-  - travis/travis.sh
-  - tox -c python/tox.ini -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d .) -v
+    - name: "Python 2.7 tests"
+      language: python
+      python: 2.7
+      install:
+        - pip install "virtualenv<20.0.0" tox  # Bug https://github.com/pypa/virtualenv/issues/1551
+      script:
+        - sbt +compile
+        - tox -c python/tox.ini -e py27 -v
+
+    - name: "Python 3.6 tests"
+      language: python
+      python: 3.6
+      install:
+        - pip install "virtualenv<20.0.0" tox  # Bug https://github.com/pypa/virtualenv/issues/1551
+      script:
+        - sbt +compile
+        - tox -c python/tox.ini -e py36 -v
+
+    - name: "Python 3.7 tests"
+      language: python  # This can't be java and python at the same time
+      python: 3.7
+      env:
+        # Required when not setting 'language: java' to force the correct jdk8
+        - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
+        - JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk-amd64"
+      dist: xenial  # Travis won't install py37 on trusty
+      install:
+        - pip install "virtualenv<20.0.0" tox  # Bug https://github.com/pypa/virtualenv/issues/1551
+      script:
+        - sbt +compile
+        - tox -c python/tox.ini -e py37 -v
 
 notifications:
   on_success: change
@@ -32,8 +62,6 @@ notifications:
     on_success: change
     on_failure: always
 
-jdk:
-  - oraclejdk8
 cache:
   directories:
     - $HOME/.ivy2/cache


### PR DESCRIPTION
Fixes #640  and #642  and **improves tests running time from ~24min down to ~15min.**

1. Fixes recent virtualenv==20.0.0 bug that broke Travis builds 3 days ago (https://github.com/pypa/virtualenv/issues/1551).
2. Runs all python tests with all virtualenvs (for real! We were not running all of py27, py36, py37).
3. Python 2.7 is officially deprecated. **Let me know if you'd rather remove this**
4. Runs tests using Travis stages, so that we can run them in parallel and that we can actually use the correct system python version == tox python version. The problem seems to be that `$TRAVIS_PYTHON_VERSION` is unset (see #642). It looks like other projects on Github are using Travis stages to install the correct python version in each VM that is compatible to a specific tox environment.


One thing to note, unfortunately, due to some python tests relying on these jars: https://github.com/combust/mleap/blob/master/mleap-spark-extension/build.sbt#L9
I am forced to run `sbt +compile` before python tests in all stages (running in different VMs) and this makes them all slower because they are all compiling the entire project.

@talalryz @lydian @voganrc  for review