### PR TITLE
Math binary pyspark wrapper

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -107,7 +107,7 @@ You can run them from the top-level makefile:
 make py37_test
 ```
 
-If you'd rather use the inner `python/Makfile`, remember to source SCALA_CLASS_PATH by running:
+If you'd rather use the inner `python/Makefile`, remember to source SCALA_CLASS_PATH by running:
 
 ```bash
 source scripts/scala_classpath_for_python.sh

--- a/python/mleap/pyspark/__init__.py
+++ b/python/mleap/pyspark/__init__.py
@@ -5,6 +5,7 @@ import pyspark.ml
 import mleap.pyspark
 import mleap.pyspark.feature
 from mleap.pyspark.feature.string_map import StringMap
+from mleap.pyspark.feature.math_binary import MathBinary
 from mleap.pyspark.feature.math_unary import MathUnary
 
 sys.modules['pyspark.ml.mleap'] = mleap
@@ -15,3 +16,4 @@ sys.modules['pyspark.ml'].mleap = mleap
 sys.modules['pyspark.ml'].mleap.feature = sys.modules['mleap.pyspark.feature']
 sys.modules['pyspark.ml'].mleap.feature.StringMap = StringMap
 sys.modules['pyspark.ml'].mleap.feature.MathUnary = MathUnary
+sys.modules['pyspark.ml'].mleap.feature.MathBinary = MathBinary

--- a/python/mleap/pyspark/feature/math_binary.py
+++ b/python/mleap/pyspark/feature/math_binary.py
@@ -48,8 +48,6 @@ class MathBinary(JavaTransformer, HasOutputCol, JavaMLReadable, JavaMLWritable):
         inputA=None,
         inputB=None,
         outputCol=None,
-        # defaultA=None,
-        # defaultB=None,
     ):
         """
         Computes the mathematical binary `operation` over
@@ -59,18 +57,15 @@ class MathBinary(JavaTransformer, HasOutputCol, JavaMLReadable, JavaMLWritable):
         :param inputA: column name for the left side of operation (string)
         :param inputB: column name for the right side of operation (string)
         :param outputCol: output column name (string)
-        :param defaultA: default value to use when a cell in inputA is None (float)
-        :param defaultB: default value to use when a cell in inputB is None (float)
 
-        NOTE: `operation`, `defaultA` and `defaultB` are not JavaParams
-        because the underlying MathBinary scala object uses a MathBinaryModel
-        to store the info about the binary operation and the default values.
+        NOTE: `operation` is not a JavaParam because the underlying MathBinary
+        scala object uses a MathBinaryModel to store the info about the binary
+        operation.
 
         `operation` has a None default value even though it should *never* be
         None. A None value is necessary upon deserialization to instantiate a
         MathBinary without errors. Afterwards, pyspark sets the _java_obj to
-        the deserialized scala object, which encodes the operation (as well
-        as the default values for A and B).
+        the deserialized scala object, which encodes the operation.
         """
         super(MathBinary, self).__init__()
 
@@ -85,8 +80,12 @@ class MathBinary(JavaTransformer, HasOutputCol, JavaMLReadable, JavaMLWritable):
                 operation.name
             )
 
+            # IMPORTANT: defaults for missing values are forced to None.
+            # I've found an issue when setting default values for A and B,
+            # Remember to treat your missing values before the MathBinary
+            # (for example, you could use an Imputer)
             scalaMathBinaryModel = _jvm().ml.combust.mleap.core.feature.MathBinaryModel(
-                scalaBinaryOperation, Some(defaultA), Some(defaultB)
+                scalaBinaryOperation, Some(None), Some(None)
             )
 
             self._java_obj = self._new_java_obj(

--- a/python/mleap/pyspark/feature/math_binary.py
+++ b/python/mleap/pyspark/feature/math_binary.py
@@ -1,0 +1,105 @@
+from enum import Enum
+
+from pyspark import keyword_only
+from pyspark.ml.param.shared import HasInputCol
+from pyspark.ml.param.shared import HasOutputCol
+from pyspark.ml.param.shared import Param
+from pyspark.ml.param.shared import Params
+from pyspark.ml.param.shared import TypeConverters
+from pyspark.ml.util import JavaMLReadable
+from pyspark.ml.util import JavaMLWritable
+from pyspark.ml.util import _jvm
+from pyspark.ml.wrapper import JavaTransformer
+
+from mleap.pyspark.py2scala import jvm_scala_object
+
+
+class BinaryOperation(Enum):
+    Add = 1
+    Subtract = 2
+    Multiply = 3
+    Divide = 4
+    Remainder = 5
+    LogN = 6
+    Pow = 7
+
+
+class MathBinary(JavaTransformer, HasOutputCol, JavaMLReadable, JavaMLWritable):
+
+    inputA = Param(
+        Params._dummy(),
+        "inputA",
+        "the inputA column name",
+        typeConverter=TypeConverters.toString,
+    )
+
+    inputB = Param(
+        Params._dummy(),
+        "inputB",
+        "the inputB column name",
+        typeConverter=TypeConverters.toString,
+    )
+
+    @keyword_only
+    def __init__(self, operation=None, inputA=None, inputB=None, outputCol=None):
+        """
+        Computes the mathematical binary `operation` over the input column.
+
+        NOTE: we can't make `operation` a JavaParam (as in pyspark) because the
+            underlying scala object MathBinary uses a MathBinaryModel to store
+            the info about the unary operation (add, mul, etc.)
+
+            If operation is a JavaParam, py4j will fail trying to set it on the
+            underlying scala object.
+
+            If operation doesn't have a default value, then pyspark will fail
+            upon deserialization trying to instantiate this object without args:
+                (it just runs py_type() where py_type is the class name)
+
+        """
+        super(MathBinary, self).__init__()
+
+        # if operation=None, it means that pyspark is reloading the model
+        # from disk and calling this method without args. In such case we don't
+        # need to set _java_obj here because pyspark will set it after creation
+        #
+        # if operation is not None, we can proceed to instantiate the scala classes
+        if operation:
+            scalaBinaryOperation = jvm_scala_object(
+                _jvm().ml.combust.mleap.core.feature.BinaryOperation,
+                operation.name
+            )
+
+            scalaMathBinaryModel = _jvm().ml.combust.mleap.core.feature.MathBinaryModel(
+                scalaBinaryOperation, None, None
+            )
+
+            self._java_obj = self._new_java_obj(
+                "org.apache.spark.ml.mleap.feature.MathBinary",
+                self.uid,
+                scalaMathBinaryModel,
+            )
+
+        self._setDefault()
+        self.setParams(inputA=inputA, inputB=inputB, outputCol=outputCol)
+
+    @keyword_only
+    def setParams(self, inputA=None, inputB=None, outputCol=None):
+        """
+        Sets params for this MathBinary.
+        """
+        kwargs = self._input_kwargs
+        return self._set(**kwargs)
+
+    # def setInputCol(self, value):
+        # """
+        # Sets the value of :py:attr:`inputCol`.
+        # """
+        # return self._set(inputCol=value)
+
+    # def setOutputCol(self, value):
+        # """
+        # Sets the value of :py:attr:`outputCol`.
+        # """
+        # return self._set(outputCol=value)
+

--- a/python/mleap/pyspark/feature/math_unary.py
+++ b/python/mleap/pyspark/feature/math_unary.py
@@ -27,17 +27,14 @@ class MathUnary(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, Java
         """
         Computes the mathematical unary `operation` over the input column.
 
-        NOTE: we can't make `operation` a JavaParam (as in pyspark) because the
-            underlying scala object MathUnary uses a MathUnaryModel to store
-            the info about the unary operation (sin, tan, etc.)
+        NOTE: `operation` is not a JavaParam because the underlying 
+        MathUnary scala object uses a MathUnaryModel to store the info about
+        the unary operation (sin, tan, etc.), not a JavaParam string.
 
-            If operation is a JavaParam, py4j will fail trying to set it on the
-            underlying scala object.
-
-            If operation doesn't have a default value, then pyspark will fail
-            upon deserialization trying to instantiate this object without args:
-                (it just runs py_type() where py_type is the class name)
-
+        `operation` has a None default value even though it should *never* be
+        None. A None value is necessary upon deserialization to instantiate a
+        MathUnary without errors. Afterwards, pyspark sets the _java_obj to
+        the deserialized scala object, which encodes the operation.
         """
         super(MathUnary, self).__init__()
 

--- a/python/mleap/pyspark/py2scala.py
+++ b/python/mleap/pyspark/py2scala.py
@@ -1,3 +1,5 @@
+from pyspark.ml.util import _jvm
+
 
 def jvm_scala_object(jpkg, obj):
     """
@@ -14,3 +16,10 @@ def jvm_scala_object(jpkg, obj):
         getattr(jpkg, obj + "$"),  # JavaClass
         "MODULE$",  # JavaObject
     )
+
+def Some(value):
+    """
+    Instantiate a scala Some object. Useful when scala code takes in
+    an Option[<value>]
+    """
+    return _jvm().scala.Some(value)

--- a/python/tests/pyspark/feature/math_binary_test.py
+++ b/python/tests/pyspark/feature/math_binary_test.py
@@ -1,0 +1,163 @@
+import math
+import os
+import shutil
+import tempfile
+import unittest
+
+import mleap.pyspark  # noqa
+from mleap.pyspark.spark_support import SimpleSparkSerializer  # noqa
+
+import pandas as pd
+from pandas.testing import assert_frame_equal
+from pyspark.ml import Pipeline
+from pyspark.sql.types import FloatType
+from pyspark.sql.types import StructType
+from pyspark.sql.types import StructField
+
+from mleap.pyspark.feature.math_binary import MathBinary
+from mleap.pyspark.feature.math_binary import BinaryOperation
+from tests.pyspark.lib.spark_session import spark_session
+
+
+INPUT_SCHEMA = StructType([
+    StructField('f1', FloatType()),
+    StructField('f2', FloatType()),
+])
+
+
+class MathBinaryTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.spark = spark_session()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.spark.stop()
+
+    def setUp(self):
+        self.input = self.spark.createDataFrame([
+            (
+                float(i),
+                float(i * 2),
+            )
+            for i in range(1, 10)
+        ], INPUT_SCHEMA)
+
+        self.expected_add = pd.DataFrame(
+            [(
+                float(i + i * 2)
+            )
+            for i in range(1, 10)],
+            columns=['add(f1, f2)'],
+        )
+
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir)
+
+    def test_add_math_binary(self):
+        add_transformer = MathBinary(
+            operation=BinaryOperation.Add,
+            inputA="f1",
+            inputB="f2",
+            outputCol="add(f1, f2)",
+        )
+
+        result = add_transformer.transform(self.input).toPandas()[['add(f1, f2)']]
+        assert_frame_equal(self.expected_add, result)
+
+    def test_math_binary_pipeline(self):
+        add_transformer = MathBinary(
+            operation=BinaryOperation.Add,
+            inputA="f1",
+            inputB="f2",
+            outputCol="add(f1, f2)",
+        )
+
+        mul_transformer = MathBinary(
+            operation=BinaryOperation.Multiply,
+            inputA="f1",
+            inputB="add(f1, f2)",
+            outputCol="mul(f1, add(f1, f2))",
+        )
+
+        expected = pd.DataFrame(
+            [(
+                float(i * (i + i * 2))
+            )
+            for i in range(1, 10)],
+            columns=['mul(f1, add(f1, f2))'],
+        )
+
+        pipeline = Pipeline(
+            stages=[add_transformer, mul_transformer]
+        )
+
+        pipeline_model = pipeline.fit(self.input)
+        result = pipeline_model.transform(self.input).toPandas()[['mul(f1, add(f1, f2))']]
+        assert_frame_equal(expected, result)
+
+    def test_can_instantiate_all_math_binary(self):
+        for binary_operation in BinaryOperation:
+            transformer = MathBinary(
+                operation=binary_operation,
+                inputA="f1",
+                inputB="f2",
+                outputCol="operation",
+            )
+
+    def test_serialize_deserialize_math_binary(self):
+        add_transformer = MathBinary(
+            operation=BinaryOperation.Add,
+            inputA="f1",
+            inputB="f2",
+            outputCol="add(f1, f2)",
+        )
+
+        file_path = '{}{}'.format('jar:file:', os.path.join(self.tmp_dir, 'math_binary.zip'))
+
+        __import__('ipdb').set_trace()
+        add_transformer.serializeToBundle(file_path, self.input)
+        deserialized_math_binary = SimpleSparkSerializer().deserializeFromBundle(file_path)
+
+        result = deserialized_math_binary.transform(self.input).toPandas()[['add(f1, f2)']]
+        assert_frame_equal(self.expected_add, result)
+
+    # def test_serialize_deserialize_pipeline(self):
+        # sin_transformer = MathBinary(
+            # operation=UnaryOperation.Sin,
+            # inputCol="f1",
+            # outputCol="sin(f1)",
+        # )
+
+        # exp_transformer = MathBinary(
+            # operation=UnaryOperation.Exp,
+            # inputCol="sin(f1)",
+            # outputCol="exp(sin(f1))",
+        # )
+
+        # expected = pd.DataFrame(
+            # [(
+                # math.exp(math.sin(i)),
+            # )
+            # for i in range(1, 10)],
+            # columns=['exp(sin(f1))'],
+        # )
+
+        # pipeline = Pipeline(
+            # stages=[sin_transformer, exp_transformer]
+        # )
+
+        # pipeline_model = pipeline.fit(self.input)
+
+        # file_path = '{}{}'.format('jar:file:', os.path.join(self.tmp_dir, 'math_unary_pipeline.zip'))
+
+        # pipeline_model.serializeToBundle(file_path, self.input)
+        # deserialized_pipeline = SimpleSparkSerializer().deserializeFromBundle(file_path)
+
+        # result = pipeline_model.transform(self.input).toPandas()[['exp(sin(f1))']]
+        # assert_frame_equal(expected, result)
+
+

--- a/python/tests/pyspark/feature/math_binary_test.py
+++ b/python/tests/pyspark/feature/math_binary_test.py
@@ -70,46 +70,6 @@ class MathBinaryTest(unittest.TestCase):
         result = add_transformer.transform(self.input).toPandas()[['add(f1, f2)']]
         assert_frame_equal(self.expected_add, result)
 
-    def test_add_math_binary_defaults_none(self):
-        add_transformer = self._new_add_math_binary()
-
-        none_df = self.spark.createDataFrame([
-            (None, float(i * 2))
-            for i in range(1, 3)
-        ], INPUT_SCHEMA)
-
-        # Summing None + int yields Nones
-        expected_df = pd.DataFrame([
-            (None,)
-            for i in range(1, 3)
-        ], columns=['add(f1, f2)'])
-
-        result = add_transformer.transform(none_df).toPandas()[['add(f1, f2)']]
-        assert_frame_equal(expected_df, result)
-
-    def test_add_math_binary_default_zero(self):
-        add_transformer = MathBinary(
-            operation=BinaryOperation.Add,
-            inputA="f1",
-            inputB="f2",
-            outputCol="add(f1, f2)",
-            defaultA=1.0,
-            defaultB=1.0,
-        )
-
-        none_df = self.spark.createDataFrame([
-            (None, float(i * 2))
-            for i in range(1, 3)
-        ], INPUT_SCHEMA)
-
-        expected_df = pd.DataFrame([
-            (float(i * 2),)
-            for i in range(1, 3)
-        ], columns=['add(f1, f2)'])
-
-        result = add_transformer.transform(none_df).toPandas()[['add(f1, f2)']]
-        assert_frame_equal(expected_df, result)
-
     def test_math_binary_pipeline(self):
         add_transformer = self._new_add_math_binary()
 


### PR DESCRIPTION
Very straightforward change, the MathBinary follows the MathUnary pattern from #666 

**Note**
I didn't manage to get the default values to work. In scala they are `da` and `db` [here](https://github.com/combust/mleap/blob/master/mleap-core/src/main/scala/ml/combust/mleap/core/feature/MathBinaryModel.scala#L40).
After setting defaults for missing values to zero:  `da=0.0` and `db=0.0` I run into the following.
When summing up using the scala MathBinary I get:
`None + 3.0 = 3.0` 

But when using the python MathBinary, I get:
`None + 3.0 = None`

I think something gets lost when converting a python `None` to scala and [this line](https://github.com/combust/mleap/blob/master/mleap-core/src/main/scala/ml/combust/mleap/core/feature/MathBinaryModel.scala#L45) won't work. Intuitively I think the problem lies in the many ways Scala does Nones, (None, null, Option.empty). 

I have an intermediate commit where I implemented those but the test fails. I am not sure if it's worth digging into this because devs can just use an Imputer before running this transformer, and treat all missing values there (eg. convert all None to zeros).

@ancasarb @talalryz @voganrc for review