### PR TITLE
Changes from parity testing

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,7 +13,7 @@
 - Fix XGBoost sparse vector support
 - Fix MinMaxScalerModel outputs different in Spark vs MLeap
 - Fix Spark deserialization for CountVectorizer transformer
-- Fix setting HandleInvalid.Error by default to Bucketizer
+- Fix adding support for HandleInvalid.Error in Bucketizer
 - Fix setting HandleInvalid.Error by default to OneHotEncoder for backwards compatibility
 
 ### Improvements

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -48,4 +48,4 @@
 
 We make every effort for the serialization format to be backwards compatible between different versions of MLeap. Please note below some important notes regarding backwards compatibility. 
 
-- OneHotEncoder/OneHotEncoderEstimator unfortunately had breaking changes in a few releases (0.11, 0.12, 0.14, 0.15), if you need older Spark versions, please use MLeap version 0.10.3, 0.13 or else please use MLeap version 0.16.0 or higher.
+- The deprecated OneHotEncoder unfortunately had breaking changes in a few releases. In releases 0.11.0 and 0.12.0, the deserialization into MLeap was broken for OneHotEncoder. When using releases 0.13.0, 0.14.0, and 0.15.0, please ensure that the model returns the same results as before the upgrade, by potentially changing dropLast and handleInvalid values after deserialization. Alternatively, please use MLeap version 0.16.0 or higher, in case you have models serialized with other versions of MLeap that use OneHotEncoder. If your model uses OneHotEncoderEstimator or no one hot encoding, then you should not encounter any of the issues above. 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,14 +4,16 @@
 - Fix default ports when running grpc/http requests; default grpc port is 65328 and can be overridden via MLEAP_GRPC_PORT; default http port should be: 65327 and can be overridden via MLEAP_HTTP_PORT
 
 ### New Features
-- Scikit-learn support for Multinomial Logistic Regression
+- Scikit-learn support for MultinomialLogisticRegression
 - Support for min/max values other than defaults (i.e. 0.0 and 1.0) in MinMaxScalerModel
-- Support for custom transformers (StringMap, MathUnary) in Pyspark
+- Support for custom transformers (StringMap, MathUnary, MathBinary) in Pyspark
+- Upgrade to Spark version 2.4.5
 
 ### Bug Fixes
 - Fix XGBoost sparse vector support
 - Fix MinMaxScalerModel outputs different in Spark vs MLeap
 - Fix Spark deserialization for CountVectorizer transformer
+- Fix setting HandleInvalid.Error by default to Bucketizer
 
 ### Improvements
 - Minor documentation updates
@@ -40,12 +42,9 @@
 - Add default grpc port to docker config
 - General documentation improvements
 
-# Release 0.12.0
 
-### Breaking Changes
-- OneHotEncoder/OneHotEncoderEstimator unfortunately had breaking changes, if you need older Spark versions, please use MLeap version 0.10.3 or else please use MLeap version 0.13.0 or higher.
+# Older releases
 
-# Release 0.11.0
+We make every effort for the serialization format to be backwards compatible between different versions of MLeap. Please note below some important notes regarding backwards compatibility. 
 
-### Breaking Changes
-- OneHotEncoder/OneHotEncoderEstimator unfortunately had breaking changes, if you need older Spark versions, please use MLeap version 0.10.3 or else please use MLeap version 0.13.0 or higher.
+- OneHotEncoder/OneHotEncoderEstimator unfortunately had breaking changes in the past few releases, if you need older Spark versions, please use MLeap version 0.10.3 or else please use MLeap version 0.16.0 or higher.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@
 - Fix MinMaxScalerModel outputs different in Spark vs MLeap
 - Fix Spark deserialization for CountVectorizer transformer
 - Fix setting HandleInvalid.Error by default to Bucketizer
+- Fix setting HandleInvalid.Error by default to OneHotEncoder for backwards compatibility
 
 ### Improvements
 - Minor documentation updates
@@ -47,4 +48,4 @@
 
 We make every effort for the serialization format to be backwards compatible between different versions of MLeap. Please note below some important notes regarding backwards compatibility. 
 
-- OneHotEncoder/OneHotEncoderEstimator unfortunately had breaking changes in the past few releases, if you need older Spark versions, please use MLeap version 0.10.3 or else please use MLeap version 0.16.0 or higher.
+- OneHotEncoder/OneHotEncoderEstimator unfortunately had breaking changes in a few releases (0.11, 0.12, 0.14, 0.15), if you need older Spark versions, please use MLeap version 0.10.3, 0.13 or else please use MLeap version 0.16.0 or higher.

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/BucketizerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/BucketizerModel.scala
@@ -10,13 +10,13 @@ import ml.combust.mleap.core.types.{ScalarType, StructType}
   *
   * @param splits splits used to determine bucket
   */
-@SparkCode(uri = "https://github.com/apache/spark/blob/v2.0.0/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala")
-case class BucketizerModel(splits: Array[Double], handleInvalid: String = "error") extends Model {
+@SparkCode(uri = "https://github.com/apache/spark/blob/v2.4.5/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala")
+case class BucketizerModel(splits: Array[Double], handleInvalid: HandleInvalid = HandleInvalid.Error) extends Model {
   def apply(feature: Double): Double = {
-    if (handleInvalid == "skip") {
+    if (handleInvalid == HandleInvalid.Skip) {
       -1
     } else {
-      binarySearchForBuckets(splits, feature, keepInvalid = handleInvalid == "keep")
+      binarySearchForBuckets(splits, feature, keepInvalid = handleInvalid == HandleInvalid.Keep)
     }
   }
 

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/BucketizerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/BucketizerModel.scala
@@ -13,11 +13,7 @@ import ml.combust.mleap.core.types.{ScalarType, StructType}
 @SparkCode(uri = "https://github.com/apache/spark/blob/v2.4.5/mllib/src/main/scala/org/apache/spark/ml/feature/Bucketizer.scala")
 case class BucketizerModel(splits: Array[Double], handleInvalid: HandleInvalid = HandleInvalid.Error) extends Model {
   def apply(feature: Double): Double = {
-    if (handleInvalid == HandleInvalid.Skip) {
-      -1
-    } else {
       binarySearchForBuckets(splits, feature, keepInvalid = handleInvalid == HandleInvalid.Keep)
-    }
   }
 
   def binarySearchForBuckets(splits: Array[Double], feature: Double, keepInvalid: Boolean): Double = {

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/HandleInvalid.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/HandleInvalid.scala
@@ -19,9 +19,9 @@ object HandleInvalid {
     override def asParamString: String = "keep"
   }
 
-  def fromString(value: String): HandleInvalid = value match {
+  def fromString(value: String, canSkip: Boolean = true): HandleInvalid = value match {
     case "error" => HandleInvalid.Error
-    case "skip" => HandleInvalid.Skip
+    case "skip" => if (canSkip) HandleInvalid.Skip else throw new IllegalArgumentException(s"Invalid handler: $value")
     case "keep" => HandleInvalid.Keep
     case _ => throw new IllegalArgumentException(s"Invalid handler: $value")
   }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/HandleInvalid.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/HandleInvalid.scala
@@ -1,0 +1,28 @@
+package ml.combust.mleap.core.feature
+
+sealed trait HandleInvalid {
+  def asParamString: String
+}
+
+object HandleInvalid {
+  val default = Error
+
+  case object Error extends HandleInvalid {
+    override def asParamString: String = "error"
+  }
+
+  case object Skip extends HandleInvalid {
+    override def asParamString: String = "skip"
+  }
+
+  case object Keep extends HandleInvalid {
+    override def asParamString: String = "keep"
+  }
+
+  def fromString(value: String): HandleInvalid = value match {
+    case "error" => HandleInvalid.Error
+    case "skip" => HandleInvalid.Skip
+    case "keep" => HandleInvalid.Keep
+    case _ => throw new IllegalArgumentException(s"Invalid handler: $value")
+  }
+}

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/OneHotEncoderModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/OneHotEncoderModel.scala
@@ -11,7 +11,6 @@ import org.apache.spark.ml.linalg.{Vector, Vectors}
   * logistic regression where binary and not multinomial features
   * are supported in the feature vector.
   *
-  * @param size size of the output one hot vectors
   */
 case class OneHotEncoderModel(categorySizes: Array[Int],
                               handleInvalid: HandleInvalid = HandleInvalid.Error,

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringIndexerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringIndexerModel.scala
@@ -3,33 +3,6 @@ package ml.combust.mleap.core.feature
 import ml.combust.mleap.core.Model
 import ml.combust.mleap.core.types.{ScalarType, StructType}
 
-sealed trait HandleInvalid {
-  def asParamString: String
-}
-
-object HandleInvalid {
-  val default = Error
-
-  case object Error extends HandleInvalid {
-    override def asParamString: String = "error"
-  }
-
-  case object Skip extends HandleInvalid {
-    override def asParamString: String = "skip"
-  }
-
-  case object Keep extends HandleInvalid {
-    override def asParamString: String = "keep"
-  }
-
-  def fromString(value: String): HandleInvalid = value match {
-    case "error" => HandleInvalid.Error
-    case "skip" => HandleInvalid.Skip
-    case "keep" => HandleInvalid.Keep
-    case _ => throw new IllegalArgumentException(s"Invalid handler: $value")
-  }
-}
-
 /** Class for string indexer model.
   *
   * String indexer converts a string into an integer representation.

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringMapModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringMapModel.scala
@@ -3,29 +3,6 @@ package ml.combust.mleap.core.feature
 import ml.combust.mleap.core.Model
 import ml.combust.mleap.core.types.{ScalarType, StructType}
 
-sealed trait StringMapHandleInvalid {
-  def asParamString: String
-}
-
-object StringMapHandleInvalid {
-  val default = Error
-  val defaultValue = 0.0
-
-  case object Error extends StringMapHandleInvalid {
-    override def asParamString: String = "error"
-  }
-
-  case object Keep extends StringMapHandleInvalid {
-    override def asParamString: String = "keep"
-  }
-
-  def fromString(value: String): StringMapHandleInvalid = value match {
-    case "error" => StringMapHandleInvalid.Error
-    case "keep" => StringMapHandleInvalid.Keep
-    case _ => throw new IllegalArgumentException(s"Invalid handler: $value")
-  }
-}
-
 /** Class for string map model.
  *
  * Maps a string into a double.
@@ -36,10 +13,10 @@ object StringMapHandleInvalid {
  * @param defaultValue value to use if label is not found in the map
  */
 case class StringMapModel(labels: Map[String, Double],
-                          handleInvalid: StringMapHandleInvalid = StringMapHandleInvalid.default,
-                          defaultValue: Double = StringMapHandleInvalid.defaultValue) extends Model {
+                          handleInvalid: HandleInvalid = HandleInvalid.default,
+                          defaultValue: Double = StringMapModel.defaultValue) extends Model {
 
-  private val keepInvalid = handleInvalid == StringMapHandleInvalid.Keep
+  private val keepInvalid = handleInvalid == HandleInvalid.Keep
 
   def apply(label: String): Double = {
     if (keepInvalid) {
@@ -49,7 +26,7 @@ case class StringMapModel(labels: Map[String, Double],
         labels(label)
       } else {
         throw new NoSuchElementException(s"Missing label: $label. To handle unseen labels, " +
-          s"set handleInvalid to ${StringMapHandleInvalid.Keep.asParamString} and optionally set a custom defaultValue")
+          s"set handleInvalid to ${HandleInvalid.Keep.asParamString} and optionally set a custom defaultValue")
       }
     }
   }
@@ -57,4 +34,8 @@ case class StringMapModel(labels: Map[String, Double],
   override def inputSchema: StructType = StructType("input" -> ScalarType.String).get
 
   override def outputSchema: StructType = StructType("output" -> ScalarType.Double.nonNullable).get
+}
+
+object StringMapModel {
+  val defaultValue = 0.0
 }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/StringMapModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/StringMapModelSpec.scala
@@ -23,14 +23,14 @@ class StringMapModelSpec extends FunSpec {
         " and optionally set a custom defaultValue")
     }
 
-    it("returns default value for StringMapHandleInvalid.keep mode") {
-      val model = StringMapModel(Map("label1" -> 1.0), handleInvalid = StringMapHandleInvalid.Keep)
+    it("returns default value for HandleInvalid.Keep mode") {
+      val model = StringMapModel(Map("label1" -> 1.0), handleInvalid = HandleInvalid.Keep)
       assert(model("label1") == 1.0)
       assert(model("missing_label") == 0.0)
     }
 
-    it("returns custom default value for StringMapHandleInvalid.keep mode") {
-      val model = StringMapModel(Map("label1" -> 1.0), handleInvalid = StringMapHandleInvalid.Keep, defaultValue = 2.0)
+    it("returns custom default value for HandleInvalid.keep mode") {
+      val model = StringMapModel(Map("label1" -> 1.0), handleInvalid = HandleInvalid.Keep, defaultValue = 2.0)
       assert(model("label1") == 1.0)
       assert(model("missing_label") == 2.0)
     }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/BucketizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/BucketizerOp.scala
@@ -4,7 +4,7 @@ import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.OpModel
 import ml.combust.mleap.bundle.ops.MleapOp
-import ml.combust.mleap.core.feature.BucketizerModel
+import ml.combust.mleap.core.feature.{BucketizerModel, HandleInvalid}
 import ml.combust.mleap.runtime.MleapContext
 import ml.combust.mleap.runtime.transformer.feature.Bucketizer
 import ml.combust.mleap.runtime.transformer.feature.BucketizerUtil._
@@ -21,15 +21,15 @@ class BucketizerOp extends MleapOp[Bucketizer, BucketizerModel]{
     override def store(model: Model, obj: BucketizerModel)
                       (implicit context: BundleContext[MleapContext]): Model = {
       model.withValue("splits", Value.doubleList(obj.splits)).
-        withValue("handle_invalid", Value.string(obj.handleInvalid))
+        withValue("handle_invalid", Value.string(obj.handleInvalid.asParamString))
     }
 
     override def load(model: Model)
                      (implicit context: BundleContext[MleapContext]): BucketizerModel = {
-      val handleInvalid = model.getValue("handle_invalid").map(_.getString).getOrElse("error")
-      val m = BucketizerModel(splits = restoreSplits(model.value("splits").getDoubleList.toArray),
+      val handleInvalid = model.getValue("handle_invalid").map(_.getString).map(HandleInvalid.fromString).getOrElse(HandleInvalid.default)
+
+      BucketizerModel(splits = restoreSplits(model.value("splits").getDoubleList.toArray),
         handleInvalid = handleInvalid)
-      m
     }
   }
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/BucketizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/BucketizerOp.scala
@@ -26,7 +26,7 @@ class BucketizerOp extends MleapOp[Bucketizer, BucketizerModel]{
 
     override def load(model: Model)
                      (implicit context: BundleContext[MleapContext]): BucketizerModel = {
-      val handleInvalid = model.getValue("handle_invalid").map(_.getString).map(HandleInvalid.fromString).getOrElse(HandleInvalid.default)
+      val handleInvalid = model.getValue("handle_invalid").map(_.getString).map(HandleInvalid.fromString(_)).getOrElse(HandleInvalid.default)
 
       BucketizerModel(splits = restoreSplits(model.value("splits").getDoubleList.toArray),
         handleInvalid = handleInvalid)

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/OneHotEncoderOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/OneHotEncoderOp.scala
@@ -33,7 +33,8 @@ class OneHotEncoderOp extends MleapOp[OneHotEncoder, OneHotEncoderModel] {
       if (model.getValue("size").nonEmpty) {
         // Old version of 1HE.
         OneHotEncoderModel(categorySizes = Array(model.value("size").getLong.toInt),
-          dropLast = model.value("drop_last").getBoolean)
+          dropLast = model.value("drop_last").getBoolean,
+          handleInvalid = HandleInvalid.default)
       } else {
         // New version of 1HE.
         OneHotEncoderModel(

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/OneHotEncoderOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/OneHotEncoderOp.scala
@@ -39,7 +39,7 @@ class OneHotEncoderOp extends MleapOp[OneHotEncoder, OneHotEncoderModel] {
         // New version of 1HE.
         OneHotEncoderModel(
           categorySizes = model.value("category_sizes").getIntList.toArray,
-          handleInvalid = HandleInvalid.fromString(model.value("handle_invalid").getString),
+          handleInvalid = HandleInvalid.fromString(model.value("handle_invalid").getString, false),
           dropLast = model.value("drop_last").getBoolean)
       }
     }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/OneHotEncoderOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/OneHotEncoderOp.scala
@@ -33,8 +33,6 @@ class OneHotEncoderOp extends MleapOp[OneHotEncoder, OneHotEncoderModel] {
       if (model.getValue("size").nonEmpty) {
         // Old version of 1HE.
         OneHotEncoderModel(categorySizes = Array(model.value("size").getLong.toInt),
-          // assume HandleInvalid.Keep always since old version of 1HE didn't have a way to specify this
-          handleInvalid = HandleInvalid.Keep,
           dropLast = model.value("drop_last").getBoolean)
       } else {
         // New version of 1HE.

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/OneHotEncoderOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/OneHotEncoderOp.scala
@@ -33,10 +33,13 @@ class OneHotEncoderOp extends MleapOp[OneHotEncoder, OneHotEncoderModel] {
       val dropLast = model.value("drop_last").getBoolean
       if (model.getValue("size").nonEmpty) {
         // Old version of 1HE.
-        val handleInvalid = if (dropLast) HandleInvalid.Keep else HandleInvalid.default
-        OneHotEncoderModel(categorySizes = Array(model.value("size").getLong.toInt),
-          dropLast = dropLast,
-          handleInvalid = handleInvalid)
+        OneHotEncoderModel(
+          categorySizes = Array(model.value("size").getLong.toInt),
+          handleInvalid =
+            model.getValue("handle_invalid").map(_.getString).map(HandleInvalid.fromString(_, false))
+              //this maintains backwards compatibility for models that don't have handle_invalid serialized
+              .getOrElse(if (dropLast) HandleInvalid.Keep else HandleInvalid.default),
+          dropLast = dropLast)
       } else {
         // New version of 1HE.
         OneHotEncoderModel(

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/OneHotEncoderOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/OneHotEncoderOp.scala
@@ -30,17 +30,19 @@ class OneHotEncoderOp extends MleapOp[OneHotEncoder, OneHotEncoderModel] {
 
     override def load(model: Model)
                      (implicit context: BundleContext[MleapContext]): OneHotEncoderModel = {
+      val dropLast = model.value("drop_last").getBoolean
       if (model.getValue("size").nonEmpty) {
         // Old version of 1HE.
+        val handleInvalid = if (dropLast) HandleInvalid.Keep else HandleInvalid.default
         OneHotEncoderModel(categorySizes = Array(model.value("size").getLong.toInt),
-          dropLast = model.value("drop_last").getBoolean,
-          handleInvalid = HandleInvalid.default)
+          dropLast = dropLast,
+          handleInvalid = handleInvalid)
       } else {
         // New version of 1HE.
         OneHotEncoderModel(
           categorySizes = model.value("category_sizes").getIntList.toArray,
           handleInvalid = HandleInvalid.fromString(model.value("handle_invalid").getString, false),
-          dropLast = model.value("drop_last").getBoolean)
+          dropLast = dropLast)
       }
     }
   }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/StringIndexerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/StringIndexerOp.scala
@@ -26,7 +26,7 @@ class StringIndexerOp extends MleapOp[StringIndexer, StringIndexerModel] {
 
     override def load(model: Model)
                      (implicit context: BundleContext[MleapContext]): StringIndexerModel = {
-      val handleInvalid = model.getValue("handle_invalid").map(_.getString).map(HandleInvalid.fromString).getOrElse(HandleInvalid.default)
+      val handleInvalid = model.getValue("handle_invalid").map(_.getString).map(HandleInvalid.fromString(_)).getOrElse(HandleInvalid.default)
 
       StringIndexerModel(labels = model.value("labels").getStringList,
         handleInvalid = handleInvalid)

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/StringMapOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/StringMapOp.scala
@@ -4,7 +4,7 @@ import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.OpModel
 import ml.combust.mleap.bundle.ops.MleapOp
-import ml.combust.mleap.core.feature.{StringMapHandleInvalid, StringMapModel}
+import ml.combust.mleap.core.feature.{HandleInvalid, StringMapModel}
 import ml.combust.mleap.runtime.MleapContext
 import ml.combust.mleap.runtime.transformer.feature.StringMap
 
@@ -42,8 +42,8 @@ class StringMapOp extends MleapOp[StringMap, StringMapModel] {
       // retrieve our list of values
       val values = model.value("values").getDoubleList
 
-      val handleInvalid = model.getValue("handle_invalid").map(_.getString).map(StringMapHandleInvalid.fromString).getOrElse(StringMapHandleInvalid.default)
-      val defaultValue = model.getValue("default_value").map(_.getDouble).getOrElse(StringMapHandleInvalid.defaultValue)
+      val handleInvalid = model.getValue("handle_invalid").map(_.getString).map(HandleInvalid.fromString(_, false)).getOrElse(HandleInvalid.default)
+      val defaultValue = model.getValue("default_value").map(_.getDouble).getOrElse(StringMapModel.defaultValue)
 
       // reconstruct the model using the parallel labels and values
       StringMapModel(labels.zip(values).toMap, handleInvalid = handleInvalid, defaultValue = defaultValue)

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Bucketizer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Bucketizer.scala
@@ -12,11 +12,10 @@ import scala.util.Try
   */
 case class Bucketizer(override val uid: String = Transformer.uniqueName("bucketizer"),
                       override val shape: NodeShape,
-                      override val model: BucketizerModel) extends Transformer {
+                      override val model: BucketizerModel) extends SimpleTransformer {
   val input: String = inputSchema.fields.head.name
   val inputSelector: FieldSelector = input
-  val output: String = outputSchema.fields.head.name
-  val exec: UserDefinedFunction = (value: Double) => model(value).toDouble
+  val exec: UserDefinedFunction = (value: Double) => model(value)
 
   override def transform[FB <: FrameBuilder[FB]](builder: FB): Try[FB] = {
     if(model.handleInvalid == HandleInvalid.Skip) {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/OneHotEncoder.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/OneHotEncoder.scala
@@ -16,7 +16,6 @@ case class OneHotEncoder(override val uid: String =
                          override val shape: NodeShape,
                          override val model: OneHotEncoderModel)
     extends SimpleTransformer {
-//  override val exec: UserDefinedFunction = (value: Double) => model(Array(value)).head: Tensor[Double]
 // Lot of things going on here:
 // o Convert values into an array
 // o Invoke 1HE model

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/javadsl/JavaDSLSpec.java
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/javadsl/JavaDSLSpec.java
@@ -43,7 +43,7 @@ public class JavaDSLSpec {
                     withStandardInput("string").
                     withStandardOutput("string_index"),
             new StringIndexerModel(JavaConversions.asScalaBuffer(Collections.singletonList("hello")).toSeq(),
-                    HandleInvalid$.MODULE$.fromString("error")));
+                    HandleInvalid$.MODULE$.fromString("error", true)));
 
     DefaultLeapFrame buildFrame() {
         List<StructField> fields = Arrays.asList(frameBuilder.createField("bool", frameBuilder.createBoolean()),

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/StringMapOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/StringMapOp.scala
@@ -3,7 +3,7 @@ package org.apache.spark.ml.bundle.extension.ops.feature
 import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
-import ml.combust.mleap.core.feature.{StringMapHandleInvalid, StringMapModel}
+import ml.combust.mleap.core.feature.{HandleInvalid, StringMapModel}
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.mleap.feature.StringMap
 
@@ -42,8 +42,8 @@ class StringMapOp extends OpNode[SparkBundleContext, StringMap, StringMapModel] 
       // retrieve our list of values
       val values = model.value("values").getDoubleList
 
-      val handleInvalid = model.getValue("handle_invalid").map(_.getString).map(StringMapHandleInvalid.fromString).getOrElse(StringMapHandleInvalid.default)
-      val defaultValue = model.getValue("default_value").map(_.getDouble).getOrElse(StringMapHandleInvalid.defaultValue)
+      val handleInvalid = model.getValue("handle_invalid").map(_.getString).map(HandleInvalid.fromString(_, false)).getOrElse(HandleInvalid.default)
+      val defaultValue = model.getValue("default_value").map(_.getDouble).getOrElse(StringMapModel.defaultValue)
 
       // reconstruct the model using the parallel labels and values
       StringMapModel(labels.zip(values).toMap, handleInvalid = handleInvalid, defaultValue = defaultValue)

--- a/mleap-spark-extension/src/test/scala/org/apache/spark/ml/mleap/parity/feature/StringMapParitySpec.scala
+++ b/mleap-spark-extension/src/test/scala/org/apache/spark/ml/mleap/parity/feature/StringMapParitySpec.scala
@@ -1,6 +1,6 @@
 package org.apache.spark.ml.mleap.parity.feature
 
-import ml.combust.mleap.core.feature.{StringMapHandleInvalid, StringMapModel}
+import ml.combust.mleap.core.feature.{HandleInvalid, StringMapModel}
 import org.apache.spark.ml.mleap.feature.StringMap
 import org.apache.spark.ml.parity.SparkParityBase
 import org.apache.spark.ml.{Pipeline, Transformer}
@@ -19,9 +19,9 @@ class StringMapParitySpec extends SparkParityBase {
       Map("alice" -> 0, "andy" -> 1, "kevin" -> 2)
     )).setInputCol("name").setOutputCol("index"),
     new StringMap(uid = "string_map2", model = new StringMapModel(
-      // This map is missing the label "kevin". Exception is thrown unless StringMapHandleInvalid.Keep is set.
+      // This map is missing the label "kevin". Exception is thrown unless HandleInvalid.Keep is set.
       Map("alice" -> 0, "andy" -> 1),
-      handleInvalid = StringMapHandleInvalid.Keep, defaultValue = 1.0
+      handleInvalid = HandleInvalid.Keep, defaultValue = 1.0
     )).setInputCol("name").setOutputCol("index2")
 
   )).fit(dataset)

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketizerOp.scala
@@ -26,7 +26,7 @@ class BucketizerOp extends SimpleSparkOp[Bucketizer] {
     override def load(model: Model)
                      (implicit context: BundleContext[SparkBundleContext]): Bucketizer = {
       val m = new Bucketizer(uid = "").setSplits(restoreSplits(model.value("splits").getDoubleList.toArray))
-      val handleInvalid = model.getValue("handle_invalid").map(_.getString).map(HandleInvalid.fromString).getOrElse(HandleInvalid.default)
+      val handleInvalid = model.getValue("handle_invalid").map(_.getString).getOrElse(HandleInvalid.default.asParamString)
 
       m.set(m.handleInvalid, handleInvalid)
       m

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketizerOp.scala
@@ -3,6 +3,7 @@ package org.apache.spark.ml.bundle.ops.feature
 import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.OpModel
+import ml.combust.mleap.core.feature.HandleInvalid
 import ml.combust.mleap.runtime.transformer.feature.BucketizerUtil._
 import org.apache.spark.ml.bundle.{ParamSpec, SimpleParamSpec, SimpleSparkOp, SparkBundleContext}
 import org.apache.spark.ml.feature.Bucketizer
@@ -25,7 +26,8 @@ class BucketizerOp extends SimpleSparkOp[Bucketizer] {
     override def load(model: Model)
                      (implicit context: BundleContext[SparkBundleContext]): Bucketizer = {
       val m = new Bucketizer(uid = "").setSplits(restoreSplits(model.value("splits").getDoubleList.toArray))
-      val handleInvalid = model.getValue("handle_invalid").map(_.getString).getOrElse("error")
+      val handleInvalid = model.getValue("handle_invalid").map(_.getString).map(HandleInvalid.fromString).getOrElse(HandleInvalid.default)
+
       m.set(m.handleInvalid, handleInvalid)
       m
     }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/OneHotEncoderOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/OneHotEncoderOp.scala
@@ -45,7 +45,6 @@ class OneHotEncoderOp extends SimpleSparkOp[OneHotEncoderModel] {
 
       val df = context.context.dataset.get
       val categorySizes = obj.getInputCols.map { f ⇒ OneHotEncoderOp.sizeForField(df.schema(f)) }
-      val dropLast = obj.getDropLast
 
       model.withValue("category_sizes", Value.intList(categorySizes))
         .withValue("drop_last", Value.boolean(obj.getDropLast))

--- a/mleap-xgboost-spark/README.md
+++ b/mleap-xgboost-spark/README.md
@@ -2,55 +2,7 @@
 
 This is the XGBoost Spark integration for MLeap. It provides Bundle Ops for serializing/deserialize XGBoostClassificationModel and XGBoostRegressionModel to a Bundle.ML file.
 
-## Installation
-
-The first thing to do is follow the [xgboost4j-spark installation](http://xgboost.readthedocs.io/en/latest/jvm/) documents to get a copy of the `xgboost4j-spark` jars in your local maven repository. At the time of writing this document, `xgboost4j` libraries are not provided on any public repositories such as maven central or bintray.
-
-**IMPORTANT NOTES**
-
-1. If you see an issue during `mvn install` about "Training failed", add your hostname to `/etc/hosts`: `127.0.0.1 your-computers-hostname`
-
-After you have installed the local `xgboost4j-spark` library, test to make sure everything is working by running the unit tests.
-
-```
-# Use --recursive to get the submodule with MLeap protobuf definitions
-git clone --recursive https://github.com/combust/mleap.git
-cd mleap
-
-# Run XGBoost Spark tests
-sbt mleap-xgboost-spark/test
-```
-
-In order to use `mleap-xgboost-spark` you will have to install it as a local library in either your local maven repository or local ivy2 repository.
-
-### Install to Local Ivy2
-
-```
-sbt mleap-xgboost-spark/publishLocal
-```
-
-### Install to Local Maven
-
-```
-sbt mleap-xgboost-spark/publishM2
-```
-
-## Usage
-
-Once you have installed to either ivy2 or maven, the next step is to include `mleap-xgboost-spark` as a dependency in your training job.
-
-### SBT Dependency
-
-```
-// Make sure to set mleapVersion, at the time of this writing
-// mleapVersion should be "0.9.0"
-libraryDependencies += "ml.combust.mleap" %% "mleap-xgboost-spark" % mleapVersion
-```
-
-### Maven Dependency
-
 Make sure to set `ml.combust.mleap.version` to the desired MLeap version.
-As of the time of this writing, the value should be `0.9.0`.
 
 ```
 <dependency>
@@ -63,16 +15,6 @@ As of the time of this writing, the value should be `0.9.0`.
 Once you have added `mleap-xgboost-spark` as a dependency to your project, you should be able to train an `XGBoostClassificationModel` or `XGBoostRegressionModel` using the `XGBoostEstimator`. You will then be able to export the classifier or regression to MLeap along with the rest of your Spark pipeline.
 
 [Exporting Spark pipelines with MLeap](http://mleap-docs.combust.ml/spark/)
-
-## Usage in Notebook
-
-To use `mleap-xgboost-spark` from a notebook, make sure you include all required dependencies for your interpreter. A good set of dependencies for working with MLeap and XGBoost could be these:
-
-1. `mleap-spark` - Support for all out-of-the-box Spark transformers
-2. `mleap-xgboost-spark` - Support for XGBoost Spark transformer serialization/deserialization to MLeap bundle
-3. `xgboost4j-spark` - Required by `mleap-xgboost-spark`, as it is marked as a provided dependency
-4. `mleap-runtime` - Support for all out-of-the-box MLeap transformers
-5. `mleap-xgboost-java` - Support for XGBoost MLeap runtime transformers
 
 ## Thank You
 

--- a/python/mleap/pyspark/feature/string_map.py
+++ b/python/mleap/pyspark/feature/string_map.py
@@ -45,7 +45,7 @@ class StringMap(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, Java
             .toMap(_jvm().scala.Predef.conforms())
 
         handle_invalid_jvm = jvm_scala_object(
-            _jvm().ml.combust.mleap.core.feature.StringMapHandleInvalid,
+            _jvm().ml.combust.mleap.core.feature.HandleInvalid,
             handleInvalid.capitalize(),
         )
 

--- a/python/mleap/sklearn/extensions/data.py
+++ b/python/mleap/sklearn/extensions/data.py
@@ -16,59 +16,11 @@
 #
 
 from sklearn.preprocessing.data import BaseEstimator, TransformerMixin
-from sklearn.preprocessing import OneHotEncoder
-from sklearn.preprocessing.data import _transform_selected
 from mleap.sklearn.preprocessing.data import MLeapSerializer, FeatureExtractor
-import numpy as np
 import uuid
 from sklearn.preprocessing import Imputer as SklearnImputer
 from mleap.sklearn.preprocessing.data import ImputerSerializer
 import pandas as pd
-
-class OneHotEncoder(OneHotEncoder, MLeapSerializer):
-    def __init__(self, input_features, output_features, drop_last=False, n_values="auto", categorical_features="all",
-                 dtype=np.float, sparse=True, handle_unknown='error'):
-        self.op = 'one_hot_encoder'
-        self.name = "{}_{}".format(self.op, uuid.uuid4())
-        self.serializable = True
-        self.drop_last = drop_last
-        self.n_values = n_values
-        self.categorical_features = categorical_features
-        self.dtype = dtype
-        self.sparse = sparse
-        self.handle_unknown = handle_unknown
-        self.input_features = input_features
-        self.output_features = output_features
-
-    def fit_transform(self, X, y=None):
-        res = _transform_selected(X, self._fit_transform, self.categorical_features, copy=True)
-        if self.drop_last:
-            res = res[:,:-1]
-
-        if self.sparse:
-            return res.todense()
-        return res
-
-    def serialize_to_bundle(self, path, model_name):
-
-        # compile tuples of mode attributes to serialize
-        attributes = list()
-        attributes.append(['size', self.n_values_.tolist()[0]])
-        attributes.append(['drop_last', self.drop_last])
-
-        # define node inputs and outputs
-        inputs = [{
-            "name": self.input_features,
-            "port": "input"
-        }]
-
-        outputs = [{
-            "name": self.output_features,
-            "port": "output"
-        }]
-
-        self.serialize(self, path, model_name, attributes, inputs, outputs)
-
 
 class DefineEstimator(BaseEstimator, TransformerMixin):
     def __init__(self, transformer):

--- a/python/mleap/sklearn/preprocessing/data.py
+++ b/python/mleap/sklearn/preprocessing/data.py
@@ -628,9 +628,8 @@ class OneHotEncoderSerializer(MLeapSerializer, MLeapDeserializer):
         # compile tuples of model attributes to serialize
         attributes = list()
         attributes.append(('size', transformer.n_values_.tolist()[0]))
-        # the default sklearn OneHotEncoder doesn't support 'drop_last'
-        # see mleap.sklearn.extensions.data for OneHotEncoder that does support 'drop_last'
-        attributes.append(('drop_last', False))
+        # setting drop_last to True, so to that 1HE maintains parity with MLeap/Spark
+        attributes.append(('drop_last', True))
 
         # define node inputs and outputs
         inputs = [{

--- a/python/mleap/sklearn/preprocessing/data.py
+++ b/python/mleap/sklearn/preprocessing/data.py
@@ -631,6 +631,11 @@ class OneHotEncoderSerializer(MLeapSerializer, MLeapDeserializer):
         # setting drop_last to True, so to that 1HE maintains parity with MLeap/Spark
         attributes.append(('drop_last', True))
 
+        if transformer.handle_unknown == 'error':
+            attributes.append('handle_invalid', 'error')
+        else:
+            attributes.append('handle_invalid', 'keep')
+
         # define node inputs and outputs
         inputs = [{
                   "name": transformer.input_features,

--- a/python/mleap/sklearn/preprocessing/data.py
+++ b/python/mleap/sklearn/preprocessing/data.py
@@ -632,9 +632,9 @@ class OneHotEncoderSerializer(MLeapSerializer, MLeapDeserializer):
         attributes.append(('drop_last', True))
 
         if transformer.handle_unknown == 'error':
-            attributes.append('handle_invalid', 'error')
+            attributes.append(('handle_invalid', 'error'))
         else:
-            attributes.append('handle_invalid', 'keep')
+            attributes.append(('handle_invalid', 'keep'))
 
         # define node inputs and outputs
         inputs = [{

--- a/python/mleap/sklearn/preprocessing/data.py
+++ b/python/mleap/sklearn/preprocessing/data.py
@@ -630,6 +630,10 @@ class OneHotEncoderSerializer(MLeapSerializer, MLeapDeserializer):
         attributes.append(('size', transformer.n_values_.tolist()[0]))
         # setting drop_last to True, so to that 1HE maintains parity with MLeap/Spark
         attributes.append(('drop_last', True))
+        if transformer.handle_unknown == 'ignore':
+            attributes.append(('handle_invalid', 'keep'))
+        else:
+            attributes.append(('handle_invalid', 'error'))
 
         # define node inputs and outputs
         inputs = [{

--- a/python/mleap/sklearn/preprocessing/data.py
+++ b/python/mleap/sklearn/preprocessing/data.py
@@ -631,11 +631,6 @@ class OneHotEncoderSerializer(MLeapSerializer, MLeapDeserializer):
         # setting drop_last to True, so to that 1HE maintains parity with MLeap/Spark
         attributes.append(('drop_last', True))
 
-        if transformer.handle_unknown == 'error':
-            attributes.append(('handle_invalid', 'error'))
-        else:
-            attributes.append(('handle_invalid', 'keep'))
-
         # define node inputs and outputs
         inputs = [{
                   "name": transformer.input_features,

--- a/python/tests/sklearn/extensions/data_test.py
+++ b/python/tests/sklearn/extensions/data_test.py
@@ -1,11 +1,9 @@
 import json
 import numpy as np
-import os
 import pandas as pd
 import shutil
 import tempfile
 import unittest
-import uuid
 
 from mleap.sklearn.extensions.data import Imputer
 

--- a/python/tests/sklearn/preprocessing/data_test.py
+++ b/python/tests/sklearn/preprocessing/data_test.py
@@ -392,7 +392,7 @@ class TransformerTests(unittest.TestCase):
         self.assertEqual(one_hot_encoder_tf.op, model['op'])
         self.assertEqual(3, model['attributes']['size']['long'])
         self.assertEqual(True, model['attributes']['drop_last']['boolean'])
-        self.assertEqual('keep', model['attributes']['handle_invalid']['string'])
+        self.assertEqual('error', model['attributes']['handle_invalid']['string'])
 
     def one_hot_encoder_deserializer_test(self):
 

--- a/python/tests/sklearn/preprocessing/data_test.py
+++ b/python/tests/sklearn/preprocessing/data_test.py
@@ -391,7 +391,7 @@ class TransformerTests(unittest.TestCase):
 
         self.assertEqual(one_hot_encoder_tf.op, model['op'])
         self.assertEqual(3, model['attributes']['size']['long'])
-        self.assertEqual(False, model['attributes']['drop_last']['boolean'])
+        self.assertEqual(True, model['attributes']['drop_last']['boolean'])
 
     def one_hot_encoder_deserializer_test(self):
 

--- a/python/tests/sklearn/preprocessing/data_test.py
+++ b/python/tests/sklearn/preprocessing/data_test.py
@@ -392,6 +392,7 @@ class TransformerTests(unittest.TestCase):
         self.assertEqual(one_hot_encoder_tf.op, model['op'])
         self.assertEqual(3, model['attributes']['size']['long'])
         self.assertEqual(True, model['attributes']['drop_last']['boolean'])
+        self.assertEqual('keep', model['attributes']['handle_invalid']['string'])
 
     def one_hot_encoder_deserializer_test(self):
 

--- a/python/tests/sklearn/preprocessing/data_test.py
+++ b/python/tests/sklearn/preprocessing/data_test.py
@@ -394,7 +394,7 @@ class TransformerTests(unittest.TestCase):
         self.assertEqual(True, model['attributes']['drop_last']['boolean'])
         self.assertEqual('error', model['attributes']['handle_invalid']['string'])
 
-def one_hot_encoder_deserializer_test(self):
+    def one_hot_encoder_deserializer_test(self):
 
         labels = ['a', 'b', 'c']
 

--- a/python/tests/sklearn/preprocessing/data_test.py
+++ b/python/tests/sklearn/preprocessing/data_test.py
@@ -392,7 +392,6 @@ class TransformerTests(unittest.TestCase):
         self.assertEqual(one_hot_encoder_tf.op, model['op'])
         self.assertEqual(3, model['attributes']['size']['long'])
         self.assertEqual(True, model['attributes']['drop_last']['boolean'])
-        self.assertEqual('error', model['attributes']['handle_invalid']['string'])
 
     def one_hot_encoder_deserializer_test(self):
 

--- a/python/tests/sklearn/preprocessing/data_test.py
+++ b/python/tests/sklearn/preprocessing/data_test.py
@@ -392,8 +392,9 @@ class TransformerTests(unittest.TestCase):
         self.assertEqual(one_hot_encoder_tf.op, model['op'])
         self.assertEqual(3, model['attributes']['size']['long'])
         self.assertEqual(True, model['attributes']['drop_last']['boolean'])
+        self.assertEqual('error', model['attributes']['handle_invalid']['string'])
 
-    def one_hot_encoder_deserializer_test(self):
+def one_hot_encoder_deserializer_test(self):
 
         labels = ['a', 'b', 'c']
 


### PR DESCRIPTION
These changes (the ones around OneHotEncoder) are after I've tested roughly 50 models serialized using MLeap 0.10.3 for parity (especially around OneHotEncoder). Attempts to fix https://github.com/combust/mleap/issues/667 as well. 

Main changes:
- make all transformers that support handleInvalid use the trait HandleInvalid (including the ones that only support only keep and error)
- ensure transformers like Bucketizer(s) support skip correctly, by skipping the row in the result
- attempt again to fix parity of old/deprecated in 2.4.x OneHotEncoder between Spark, Mleap and Scikit-learn
- documentation updates (removing also outdated xgboost documentation)
- updating the release notes

Note: to be merged after https://github.com/combust/mleap/pull/673 is reviewed and merged, so that VectorIndexer can use HandleInvalid as well. 