### PR TITLE
Interaction pyspark wrapper in MLeap 2.4.x

### DIFF
--- a/python/mleap/pyspark/__init__.py
+++ b/python/mleap/pyspark/__init__.py
@@ -8,6 +8,9 @@ from mleap.pyspark.feature.string_map import StringMap
 from mleap.pyspark.feature.math_binary import MathBinary
 from mleap.pyspark.feature.math_unary import MathUnary
 
+# These monkeypatches make it so mleap.feature appears to be in pyspark.ml
+# This should be safe unless pyspark uses the namespace
+# pyspark.ml.mleap (unlikely). Then we would mask those modules (undesirable).
 sys.modules['pyspark.ml.mleap'] = mleap
 sys.modules['pyspark.ml.mleap.pyspark'] = sys.modules['mleap.pyspark']
 sys.modules['pyspark.ml.mleap.feature'] = sys.modules['mleap.pyspark.feature']
@@ -17,3 +20,29 @@ sys.modules['pyspark.ml'].mleap.feature = sys.modules['mleap.pyspark.feature']
 sys.modules['pyspark.ml'].mleap.feature.StringMap = StringMap
 sys.modules['pyspark.ml'].mleap.feature.MathUnary = MathUnary
 sys.modules['pyspark.ml'].mleap.feature.MathBinary = MathBinary
+
+
+class InteractionMaskedError(Exception):
+    """
+    If you got here, mleap is probably masking the pyspark Interaction
+    import. How to fix this?
+
+    Please remove the interaction.py file (and this code)
+    because it's masking the pyspark Interaction import.
+    """
+
+try:
+    # This is expected to fail for all pyspark < 3.0.0
+    from pyspark.ml.feature import Interaction as PysparkInteraction
+    # If instead it works and we get here, it means we probably managed
+    # to upgrade to spark 3.0.0! Hurray
+    # But hey, some more work to do..
+    raise InteractionMaskedError()
+
+except ImportError:
+    # Spark provides Interaction only starting from version 3.0.0
+    # I copy-pasted Interaction in mleap and monkeypatched it
+    # to pretend it's in pyspark so that this line works:
+    # https://github.com/apache/spark/blob/master/python/pyspark/ml/wrapper.py#L244
+    from mleap.pyspark.feature.interaction import Interaction
+    sys.modules['pyspark.ml'].feature.Interaction = Interaction

--- a/python/mleap/pyspark/feature/interaction.py
+++ b/python/mleap/pyspark/feature/interaction.py
@@ -1,0 +1,77 @@
+from enum import Enum
+
+from pyspark import keyword_only
+from pyspark.ml.param.shared import HasInputCols
+from pyspark.ml.param.shared import HasOutputCol
+from pyspark.ml.util import JavaMLReadable
+from pyspark.ml.util import JavaMLWritable
+from pyspark.ml.wrapper import JavaTransformer
+
+
+class Interaction(JavaTransformer, HasInputCols, HasOutputCol, JavaMLReadable, JavaMLWritable):
+    """
+    NOTE: copied from: Spark 3.0:
+        https://github.com/apache/spark/blob/branch-3.0/python/pyspark/ml/feature.py#L1702
+
+    Implements the feature interaction transform. This transformer takes in Double and Vector type
+    columns and outputs a flattened vector of their feature interactions. To handle interaction,
+    we first one-hot encode any nominal features. Then, a vector of the feature cross-products is
+    produced.
+    For example, given the input feature values `Double(2)` and `Vector(3, 4)`, the output would be
+    `Vector(6, 8)` if all input features were numeric. If the first feature was instead nominal
+    with four categories, the output would then be `Vector(0, 0, 0, 0, 3, 4, 0, 0)`.
+    >>> df = spark.createDataFrame([(0.0, 1.0), (2.0, 3.0)], ["a", "b"])
+    >>> interaction = Interaction()
+    >>> interaction.setInputCols(["a", "b"])
+    Interaction...
+    >>> interaction.setOutputCol("ab")
+    Interaction...
+    >>> interaction.transform(df).show()
+    +---+---+-----+
+    |  a|  b|   ab|
+    +---+---+-----+
+    |0.0|1.0|[0.0]|
+    |2.0|3.0|[6.0]|
+    +---+---+-----+
+    ...
+    >>> interactionPath = temp_path + "/interaction"
+    >>> interaction.save(interactionPath)
+    >>> loadedInteraction = Interaction.load(interactionPath)
+    >>> loadedInteraction.transform(df).head().ab == interaction.transform(df).head().ab
+    True
+    """
+
+    @keyword_only
+    def __init__(self, inputCols=None, outputCol=None):
+        """
+        __init__(self, inputCols=None, outputCol=None):
+        """
+
+        super(Interaction, self).__init__()
+        self._java_obj = self._new_java_obj(
+            "org.apache.spark.ml.feature.Interaction", self.uid
+        )
+        self._setDefault()
+        kwargs = self._input_kwargs
+        self.setParams(**kwargs)
+
+    @keyword_only
+    def setParams(self, inputCols=None, outputCol=None):
+        """
+        setParams(self, inputCols=None, outputCol=None)
+        Sets params for this Interaction.
+        """
+        kwargs = self._input_kwargs
+        return self._set(**kwargs)
+
+    def setInputCols(self, value):
+        """
+        Sets the value of :py:attr:`inputCols`.
+        """
+        return self._set(inputCols=value)
+
+    def setOutputCol(self, value):
+        """
+        Sets the value of :py:attr:`outputCol`.
+        """
+        return self._set(outputCol=value)

--- a/python/tests/pyspark/feature/interaction_test.py
+++ b/python/tests/pyspark/feature/interaction_test.py
@@ -1,0 +1,125 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+import mleap.pyspark  # noqa
+from mleap.pyspark.spark_support import SimpleSparkSerializer  # noqa
+
+import pandas as pd
+from pandas.testing import assert_frame_equal
+from pyspark.ml import Pipeline
+from pyspark.ml.feature import VectorAssembler
+
+from mleap.pyspark.feature.interaction import Interaction
+from tests.pyspark.lib.spark_session import spark_session
+
+
+class InteractionTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.spark = spark_session()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.spark.stop()
+
+    def setUp(self):
+        self.input = self.spark.createDataFrame([
+            (1, 1, 2, 3, 8),
+            (2, 4, 3, 8, 7),
+            (3, 6, 1, 9, 2),
+            (4, 10, 8, 6, 9),
+            (5, 9, 2, 7, 10),
+            (6, 1, 1, 4, 2)
+        ], ["f1", "f2", "f3", "f4", "f5"])
+
+        self.expected_result = pd.DataFrame([
+            (1, (1, 2), (3, 8), [3.0, 8.0, 6.0, 16.0]),
+            (2, (4, 3), (8, 7), [64.0, 56.0, 48.0, 42.0]),
+            (3, (6, 1), (9, 2), [162.0, 36.0, 27.0, 6.0]),
+            (4, (10, 8), (6, 9), [240.0, 360.0, 192.0, 288.0]),
+            (5, (9, 2), (7, 10), [315.0, 450.0, 70.0, 100.0]),
+            (6, (1, 1), (4, 2), [24.0, 12.0, 24.0, 12.0]),
+        ], columns=['f1', 'vec1', 'vec2', 'interactedCol'])
+
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir)
+
+    # def _new_add_math_binary(self):
+        # return MathBinary(
+            # operation=BinaryOperation.Add,
+            # inputA="f1",
+            # inputB="f2",
+            # outputCol="add(f1, f2)",
+        # )
+
+    def test_vectors_interaction(self):
+
+        assembler1 = VectorAssembler(inputCols=["f2", "f3"], outputCol="vec1")
+        assembled1 = assembler1.transform(self.input)
+
+        assembler2 = VectorAssembler(inputCols=["f4", "f5"], outputCol="vec2")
+        assembled2 = assembler2.transform(assembled1).select("f1", "vec1", "vec2")
+
+        interaction = Interaction(inputCols=["f1", "vec1", "vec2"], outputCol="interactedCol")
+        result = interaction.transform(assembled2).toPandas()
+
+        assert_frame_equal(self.expected_result, result)
+
+    def test_interaction_pipeline(self):
+        assembler1 = VectorAssembler(inputCols=["f2", "f3"], outputCol="vec1")
+        assembler2 = VectorAssembler(inputCols=["f4", "f5"], outputCol="vec2")
+        interaction = Interaction(inputCols=["f1", "vec1", "vec2"], outputCol="interactedCol")
+
+        pipeline = Pipeline(
+            stages=[assembler1, assembler2, interaction]
+        )
+
+        pipeline_model = pipeline.fit(self.input)
+        result = pipeline_model.transform(
+            self.input).toPandas()[['f1', 'vec1', 'vec2', 'interactedCol']]
+        assert_frame_equal(self.expected_result, result)
+
+    def test_serialize_deserialize_interaction(self):
+        assembler1 = VectorAssembler(inputCols=["f2", "f3"], outputCol="vec1")
+        assembled1 = assembler1.transform(self.input)
+
+        assembler2 = VectorAssembler(inputCols=["f4", "f5"], outputCol="vec2")
+        assembled2 = assembler2.transform(assembled1).select("f1", "vec1", "vec2")
+
+        interaction = Interaction(inputCols=["f1", "vec1", "vec2"], outputCol="interactedCol")
+        datasetForSerialize = interaction.transform(assembled2)
+
+        file_path = '{}{}'.format('jar:file:', os.path.join(self.tmp_dir, 'interaction.zip'))
+
+        interaction.serializeToBundle(file_path, datasetForSerialize)
+        deserialized_interaction = SimpleSparkSerializer().deserializeFromBundle(file_path)
+
+        result = deserialized_interaction.transform(assembled2).toPandas()
+        assert_frame_equal(self.expected_result, result)
+
+    def test_serialize_deserialize_pipeline(self):
+        assembler1 = VectorAssembler(inputCols=["f2", "f3"], outputCol="vec1")
+        assembler2 = VectorAssembler(inputCols=["f4", "f5"], outputCol="vec2")
+        interaction = Interaction(inputCols=["f1", "vec1", "vec2"], outputCol="interactedCol")
+
+        pipeline = Pipeline(
+            stages=[assembler1, assembler2, interaction]
+        )
+
+        pipeline_model = pipeline.fit(self.input)
+        dataset_to_serialize = pipeline_model.transform(self.input)
+
+        file_path = '{}{}'.format('jar:file:', os.path.join(self.tmp_dir, 'interaction.zip'))
+
+        pipeline_model.serializeToBundle(file_path, dataset_to_serialize)
+        deserialized_pipeline = SimpleSparkSerializer().deserializeFromBundle(file_path)
+
+        result = deserialized_pipeline.transform(
+            self.input
+        ).toPandas()[['f1', 'vec1', 'vec2', 'interactedCol']]
+        assert_frame_equal(self.expected_result, result)


### PR DESCRIPTION
**NOTE: I'm putting this out here, in case anyone needs it, I don't expect it to be necessarily merged due to the nature of this special monkeypatching.**


------------------
**Main change:**
* I'm copying the pyspark3.0 [Interaction](https://github.com/apache/spark/blob/branch-3.0/python/pyspark/ml/feature.py#L1702) to MLeap. Since "Interaction" is only available in spark **3.0**, this PR allows anyone to use it in MLeap **2.4.x**

**Special remarks:**
* Unfortunately, I had to monkeypatch `sys.module` in order for this to work, because [this line](https://github.com/apache/spark/blob/master/python/pyspark/ml/wrapper.py#L244) in pyspark does a `replace` for a specific string. More details in why-comments in the code.
* The monkeypatching masks the "Interaction" import from pyspark3.0, so I added a try-catch to explicitly fail whenever MLeap upgrades to spark3.0 to remember removing the file . 
* Note that this monkeypatching is different from the others (MathUnary etc) because those add the `mleap` namespace to pyspark, and therefore don't mask any pyspark objects.