### PR TITLE
add Spark test dependencies and change parity tooling to allow numerical tolerance

### DIFF
--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MaxAbsScalerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MaxAbsScalerModelSpec.scala
@@ -16,7 +16,7 @@ class MaxAbsScalerModelSpec extends FunSpec {
     it("Scales the vector based on absolute max value"){
       val inputVector = Vectors.dense(15.0, -5.0, 5.0, 19.0)
       val expectedVector = Vectors.dense(0.75, -0.5, 0.5, 0.95)
-      assert(scaler(inputVector) ~= expectedVector relTol 1E-3)
+      assert(scaler(inputVector) ~= expectedVector relTol 1E-9)
     }
 
     it("Has the right input schema") {

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MaxAbsScalerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MaxAbsScalerModelSpec.scala
@@ -4,6 +4,8 @@ import ml.combust.mleap.core.types.{StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
 import org.scalatest.FunSpec
 
+import org.apache.spark.ml.util.TestingUtils._
+
 /**
   * Created by mikhail on 9/18/16.
   */
@@ -12,10 +14,9 @@ class MaxAbsScalerModelSpec extends FunSpec {
     val scaler = MaxAbsScalerModel(Vectors.dense(Array(20.0, 10.0, 10.0, 20.0)))
 
     it("Scales the vector based on absolute max value"){
-      val inputArray = Array(15.0, -5.0, 5.0, 19.0)
-      val expectedVector = Array(0.75, -0.5, 0.5, 0.95)
-
-      assert(scaler(Vectors.dense(inputArray)).toArray.sameElements(expectedVector))
+      val inputVector = Vectors.dense(15.0, -5.0, 5.0, 19.0)
+      val expectedVector = Vectors.dense(0.75, -0.5, 0.5, 0.95)
+      assert(scaler(inputVector) ~= expectedVector relTol 1E-3)
     }
 
     it("Has the right input schema") {

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MinMaxScalerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MinMaxScalerModelSpec.scala
@@ -4,6 +4,8 @@ import ml.combust.mleap.core.types.{StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
 import org.scalatest.FunSpec
 
+import org.apache.spark.ml.util.TestingUtils._
+
 /**
   * Created by mikhail on 9/18/16.
   */
@@ -12,10 +14,9 @@ class MinMaxScalerModelSpec extends FunSpec{
     val scaler = MinMaxScalerModel(Vectors.dense(Array(1.0, 0.0, 5.0, 10.0)), Vectors.dense(Array(15.0, 10.0, 15.0, 20.0)))
 
     it("scales vector based on min/max range"){
-      val inputArray = Array(15.0, 5.0, 5.0, 19.0)
-      val expectedVector = Array(1.0, 0.5, 0.0, 0.9)
-
-      assert(scaler(Vectors.dense(inputArray)).toArray.sameElements(expectedVector))
+      val inputVector = Vectors.dense(15.0, 5.0, 5.0, 19.0)
+      val expectedVector = Vectors.dense(1.0, 0.5, 0.0, 0.9)
+      assert(scaler(inputVector) ~= expectedVector relTol 1E-3)
     }
 
     it("has the right input schema") {

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MinMaxScalerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MinMaxScalerModelSpec.scala
@@ -16,7 +16,7 @@ class MinMaxScalerModelSpec extends FunSpec{
     it("scales vector based on min/max range"){
       val inputVector = Vectors.dense(15.0, 5.0, 5.0, 19.0)
       val expectedVector = Vectors.dense(1.0, 0.5, 0.0, 0.9)
-      assert(scaler(inputVector) ~= expectedVector relTol 1E-3)
+      assert(scaler(inputVector) ~= expectedVector relTol 1E-9)
     }
 
     it("has the right input schema") {

--- a/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
+++ b/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
@@ -166,7 +166,7 @@ abstract class SparkParityBase extends FunSpec with BeforeAndAfterAll {
     }
   }
 
-  var relTolEps: Double = 1E-3
+  var relTolEps: Double = 1E-9
   def equalityTest(sparkDataset: DataFrame, mleapDataset: DataFrame): Unit = {
     val sparkCols = sparkDataset.columns.toSeq
     assert(mleapDataset.columns.toSet === sparkCols.toSet)

--- a/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
+++ b/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
@@ -18,6 +18,7 @@ import ml.combust.mleap.spark.SparkSupport._
 import ml.combust.mleap.runtime.transformer.Pipeline
 import resource._
 
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.Row
 import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.ml.util.TestingUtils._

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,7 +82,8 @@ object Dependencies {
     val akkaStreamTestKit = "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % "test"
     val junit = "junit" % "junit" % "4.12" % "test"
     val junitInterface = "com.novocode" % "junit-interface" % "0.10" % "test"
-    val spark = Compile.spark.map(_ % "test") ++ Compile.spark.map(_ % "test" classifier "tests")
+    val spark = Compile.spark.map(_ % "test")
+    val sparkTest = Compile.spark.map(_ % "test" classifier "tests")
   }
 
   object Provided {
@@ -102,7 +103,7 @@ object Dependencies {
 
   val base = l ++= Seq()
 
-  val core = l ++= Seq(sparkMllibLocal, jTransform, Test.scalaTest) ++ Test.spark
+  val core = l ++= Seq(sparkMllibLocal, jTransform, Test.scalaTest) ++ Test.sparkTest
 
   def runtime(scalaVersion: SettingKey[String]) = l ++= (Seq(Test.scalaTest, Test.junit, Test.junitInterface, commonsIo) ++ scalaReflect.modules(scalaVersion.value))
 
@@ -110,17 +111,17 @@ object Dependencies {
 
   val sparkTestkit = l ++= Provided.spark ++ Provided.sparkTestLib ++ Seq(scalaTest)
 
-  val spark = l ++= Provided.spark ++ Test.spark
+  val spark = l ++= Provided.spark ++ Test.sparkTest
 
-  val sparkExtension = l ++= Provided.spark ++ Seq(Test.scalaTest) ++ Test.spark
+  val sparkExtension = l ++= Provided.spark ++ Seq(Test.scalaTest) ++ Test.sparkTest
 
   val avro = l ++= Seq(avroDep, Test.scalaTest)
 
   val tensorflow = l ++= tensorflowDeps ++ Seq(Test.scalaTest)
 
-  val xgboostRuntime = l ++= Seq(xgboostDep) ++ Seq(xgboostPredictorDep) ++ Test.spark ++ Seq(Test.scalaTest)
+  val xgboostRuntime = l ++= Seq(xgboostDep) ++ Seq(xgboostPredictorDep) ++ Test.spark ++ Test.sparkTest ++ Seq(Test.scalaTest)
 
-  val xgboostSpark = l ++= Seq(xgboostSparkDep) ++ Provided.spark ++ Test.spark
+  val xgboostSpark = l ++= Seq(xgboostSparkDep) ++ Provided.spark ++ Test.spark ++ Test.sparkTest
 
   val serving = l ++= Seq(akkaHttp, akkaHttpSprayJson, config, Test.scalaTest, Test.akkaHttpTestkit)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,11 +82,12 @@ object Dependencies {
     val akkaStreamTestKit = "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % "test"
     val junit = "junit" % "junit" % "4.12" % "test"
     val junitInterface = "com.novocode" % "junit-interface" % "0.10" % "test"
-    val spark = Compile.spark.map(_ % "test")
+    val spark = Compile.spark.map(_ % "test" classifier "tests")
   }
 
   object Provided {
     val spark = Compile.spark.map(_.excludeAll(ExclusionRule(organization = "org.scalatest"))).map(_ % "provided")
+    val sparkTestLib = spark.map(_ classifier "tests")
     val hadoop = Compile.hadoop % "provided"
   }
 
@@ -101,13 +102,13 @@ object Dependencies {
 
   val base = l ++= Seq()
 
-  val core = l ++= Seq(sparkMllibLocal, jTransform, Test.scalaTest)
+  val core = l ++= Seq(sparkMllibLocal, jTransform, Test.scalaTest) ++ Test.spark
 
   def runtime(scalaVersion: SettingKey[String]) = l ++= (Seq(Test.scalaTest, Test.junit, Test.junitInterface, commonsIo) ++ scalaReflect.modules(scalaVersion.value))
 
   val sparkBase = l ++= Provided.spark ++ Seq(Test.scalaTest)
 
-  val sparkTestkit = l ++= Provided.spark ++ Seq(scalaTest)
+  val sparkTestkit = l ++= Provided.spark ++ Provided.sparkTestLib ++ Seq(scalaTest)
 
   val spark = l ++= Provided.spark
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -110,9 +110,9 @@ object Dependencies {
 
   val sparkTestkit = l ++= Provided.spark ++ Provided.sparkTestLib ++ Seq(scalaTest)
 
-  val spark = l ++= Provided.spark
+  val spark = l ++= Provided.spark ++ Test.spark
 
-  val sparkExtension = l ++= Provided.spark ++ Seq(Test.scalaTest)
+  val sparkExtension = l ++= Provided.spark ++ Seq(Test.scalaTest) ++ Test.spark
 
   val avro = l ++= Seq(avroDep, Test.scalaTest)
 
@@ -120,7 +120,7 @@ object Dependencies {
 
   val xgboostRuntime = l ++= Seq(xgboostDep) ++ Seq(xgboostPredictorDep) ++ Test.spark ++ Seq(Test.scalaTest)
 
-  val xgboostSpark = l ++= Seq(xgboostSparkDep) ++ Provided.spark
+  val xgboostSpark = l ++= Seq(xgboostSparkDep) ++ Provided.spark ++ Test.spark
 
   val serving = l ++= Seq(akkaHttp, akkaHttpSprayJson, config, Test.scalaTest, Test.akkaHttpTestkit)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,7 +82,7 @@ object Dependencies {
     val akkaStreamTestKit = "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % "test"
     val junit = "junit" % "junit" % "4.12" % "test"
     val junitInterface = "com.novocode" % "junit-interface" % "0.10" % "test"
-    val spark = Compile.spark.map(_ % "test" classifier "tests")
+    val spark = Compile.spark.map(_ % "test") ++ Compile.spark.map(_ % "test" classifier "tests")
   }
 
   object Provided {


### PR DESCRIPTION
add Spark test dependencies and change parity tooling to allow numerical tolerance.