### PR TITLE
Make MLeap Spark 3.0 build work with XGBoost 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,15 @@ scala:
 jdk:
   - oraclejdk8  # sbt +compile fails on jdk11 (xenial's default)
 
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      # Used for xgboost test. (It require libgomp.so.1: version `GOMP_4.0')
+      - gcc-4.8
+      - g++-4.8
+
 jobs:
   include:
     - stage: "Mleap tests"

--- a/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
+++ b/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
@@ -166,7 +166,7 @@ abstract class SparkParityBase extends FunSpec with BeforeAndAfterAll {
     }
   }
 
-  var relTolEps: Double = 1E-30
+  var relTolEps: Double = 1E-7
   def equalityTest(sparkDataset: DataFrame, mleapDataset: DataFrame): Unit = {
     val sparkCols = sparkDataset.columns.toSeq
     assert(mleapDataset.columns.toSet === sparkCols.toSet)

--- a/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/XGBoostPredictorClassificationModel.scala
+++ b/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/XGBoostPredictorClassificationModel.scala
@@ -61,11 +61,11 @@ case class XGBoostPredictorMultinomialClassificationModel(
   }
 
   def predictProbabilities(data: FVec): Vector = {
-    Vectors.dense(predictor.predict(data,  false,  treeLimit))
+    Vectors.dense(predictor.predict(data,  false,  treeLimit).map(_.toDouble))
   }
 
   def predictRaw(data: FVec): Vector = {
-    Vectors.dense(predictor.predict(data, true, treeLimit))
+    Vectors.dense(predictor.predict(data, true, treeLimit).map(_.toDouble))
   }
 
   override def rawToProbabilityInPlace(raw: Vector): Vector = {

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -17,7 +17,7 @@ object Common {
 
   lazy val buildSettings: Seq[Def.Setting[_]] = Seq(
     scalaVersion := "2.12.10",
-    crossScalaVersions := Seq("2.11.12", "2.12.10"),
+    crossScalaVersions := Seq("2.12.10"),
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
     fork in Test := true,
     javaOptions in test += sys.env.getOrElse("JVM_OPTS", ""),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,7 +72,7 @@ object Dependencies {
     val kryo = "com.esotericsoftware" % "kryo" % kryoVersion
     // exclude jar "com.esotericsoftware.kryo % kryo" which conflicts with spark 3.0
     val xgboostDep = "ml.dmlc" %% "xgboost4j" % xgboostVersion exclude("com.esotericsoftware.kryo", "kryo")
-    val xgboostPredictorDep = "biz.k11i" % "xgboost-predictor" % "0.3.1" exclude("com.esotericsoftware.kryo", "kryo")
+    val xgboostPredictorDep = "ai.h2o" % "xgboost-predictor" % "0.3.17" exclude("com.esotericsoftware.kryo", "kryo")
     val xgboostSparkDep = "ml.dmlc" %% "xgboost4j-spark" % xgboostVersion exclude("com.esotericsoftware.kryo", "kryo")
 
     val hadoop = "org.apache.hadoop" % "hadoop-client" % hadoopVersion

--- a/travis/travis.sh
+++ b/travis/travis.sh
@@ -3,9 +3,7 @@
 if [[ $TRAVIS_BRANCH == 'master' ]] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
   source travis/extract.sh
   source travis/docker.sh
-  # TODO: Add back xgboost test when xgboost unit test fixed with spark 3.0
-  sbt "test" "mleap-executor-tests/test" "mleap-benchmark/test" "publishSigned" "mleap-serving/docker:publish" "mleap-spring-boot/docker:publish"
+  sbt "+ test" "+ mleap-executor-tests/test" "+ mleap-benchmark/test" "mleap-xgboost-runtime/test" "mleap-xgboost-spark/test" "+ publishSigned" "mleap-xgboost-runtime/publishSigned" "mleap-xgboost-spark/publishSigned" "mleap-serving/docker:publish" "mleap-spring-boot/docker:publish" 2>/dev/null
 else
-  # TODO: Add back xgboost test when xgboost unit test fixed with spark 3.0
-  sbt "test" "mleap-executor-tests/test" "mleap-benchmark/test"
+  sbt "+ test" "+ mleap-executor-tests/test" "+ mleap-benchmark/test" "mleap-xgboost-runtime/test" "mleap-xgboost-spark/test" 2>/dev/null
 fi


### PR DESCRIPTION
This is bug in xgboost-predictor library, they have been fixed in these PRs. 
https://github.com/h2oai/xgboost-predictor/pull/14
https://github.com/h2oai/xgboost-predictor/pull/15

Now I upgrade xgboost-predictor library and xgboost test passed.
