### PR TITLE
[ML-10977] Shading mleap jars and add test on mleap fat-jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ metastore_db/
 unsafe.*
 /python/**/*.pyc
 .sbtopts
+/mleap-databricks-runtime-fat-tests/src/test/

--- a/build.sbt
+++ b/build.sbt
@@ -27,3 +27,4 @@ lazy val springBoot = MleapProject.springBootServing
 lazy val databricksRuntimeFat = MleapProject.databricksRuntimeFat
 lazy val databricksRuntime = MleapProject.databricksRuntime
 lazy val databricksRuntimeTestkit = MleapProject.databricksRuntimeTestkit
+lazy val databricksRuntimeFatTests = MleapProject.databricksRuntimeFatTests

--- a/mleap-databricks-runtime-fat-tests/README.md
+++ b/mleap-databricks-runtime-fat-tests/README.md
@@ -1,0 +1,1 @@
+# MLeap Databricks ML Runtime Fat JAR test

--- a/mleap-databricks-runtime-fat-tests/build.sbt
+++ b/mleap-databricks-runtime-fat-tests/build.sbt
@@ -14,5 +14,3 @@ genTestCodeTask := {
 }
 
 (test in Test) <<= (test in Test).dependsOn(genTestCodeTask)
-
-//compile in Compile <<= (compile in Compile).dependsOn(genTestCodeTask)

--- a/mleap-databricks-runtime-fat-tests/build.sbt
+++ b/mleap-databricks-runtime-fat-tests/build.sbt
@@ -1,7 +1,18 @@
 import ml.combust.mleap.{Common, Dependencies}
 
 Common.defaultMleapSettings
+Common.noPublishSettings
 
-Dependencies.sparkExtension
+Dependencies.runtime(scalaVersion)
+Dependencies.spark
 Dependencies.tensorflow
 
+lazy val genTestCodeTask = TaskKey[Unit]("removeCacheFile", "Deletes a cache file")
+genTestCodeTask := {
+  import sys.process._
+  Seq("mleap-databricks-runtime-fat-tests/genTestCode.sh")!
+}
+
+(test in Test) <<= (test in Test).dependsOn(genTestCodeTask)
+
+//compile in Compile <<= (compile in Compile).dependsOn(genTestCodeTask)

--- a/mleap-databricks-runtime-fat-tests/build.sbt
+++ b/mleap-databricks-runtime-fat-tests/build.sbt
@@ -1,0 +1,7 @@
+import ml.combust.mleap.{Common, Dependencies}
+
+Common.defaultMleapSettings
+
+Dependencies.sparkExtension
+Dependencies.tensorflow
+

--- a/mleap-databricks-runtime-fat-tests/genTestCode.sh
+++ b/mleap-databricks-runtime-fat-tests/genTestCode.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+rm -rf mleap-databricks-runtime-fat-tests/src
+mkdir -p mleap-databricks-runtime-fat-tests/src/test
+
+cp -R mleap-core/src/test mleap-databricks-runtime-fat-tests/src
+cp -R mleap-avro/src/test mleap-databricks-runtime-fat-tests/src
+# cp -R mleap-executor-tests/src/test mleap-databricks-runtime-fat-tests/src
+cp -R mleap-runtime/src/test mleap-databricks-runtime-fat-tests/src
+cp -R mleap-spark/src/test mleap-databricks-runtime-fat-tests/src
+cp -R mleap-spark-extension/src/test mleap-databricks-runtime-fat-tests/src
+# cp -R mleap-spring-boot/src/test mleap-databricks-runtime-fat-tests/src
+cp -R mleap-tensor/src/test mleap-databricks-runtime-fat-tests/src
+cp -R mleap-tensorflow/src/test mleap-databricks-runtime-fat-tests/src
+cp -R mleap-xgboost-runtime/src/test mleap-databricks-runtime-fat-tests/src
+cp -R mleap-xgboost-spark/src/test mleap-databricks-runtime-fat-tests/src
+cp -R mleap-spark-testkit/src/main/* mleap-databricks-runtime-fat-tests/src/test/

--- a/mleap-databricks-runtime-fat/build.sbt
+++ b/mleap-databricks-runtime-fat/build.sbt
@@ -7,28 +7,35 @@ Common.noPublishSettings
 enablePlugins(AssemblyPlugin)
 
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
-assemblyShadeRules in assembly := Seq(
-  ShadeRule.rename("spray.json.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("com.google.protobuf.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("com.trueaccord.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("au.com.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("com.github.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("com.typesafe.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("edu.emory.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("fastparse.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("google.protobuf.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("machinist.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("macrocompat.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("org.apache.commons.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("org.netlib.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("org.j_paine.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("resource.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("scalapb.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("scalaxy.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("shapeless.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("spire.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("sourcecode.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("buildinfo.**" -> "ml.combust.mleap.shaded.@0").inAll,
 
-  ShadeRule.zap("org.slf4j.**").inAll
-)
+assemblyShadeRules in assembly := Seq(
+  "spray.json.**",
+  "com.google.protobuf.**",
+  "com.trueaccord.**",
+  "au.com.**",
+  "com.github.**",
+  "com.typesafe.**",
+  "edu.emory.**",
+  "fastparse.**",
+  "google.protobuf.**",
+  "machinist.**",
+  "macrocompat.**",
+  "org.apache.commons.**",
+  "org.netlib.**",
+  "org.j_paine.**",
+  "resource.**",
+  "scalapb.**",
+  "scalaxy.**",
+  "shapeless.**",
+  "spire.**",
+  "sourcecode.**",
+  "buildinfo.**",
+  "ai.h2o.**",
+  "biz.k11i.**",
+  "com.esotericsoftware.**",
+  "net.jafama.**",
+  "org.objectweb.**",
+  "org.objenesis.**"
+).map { pattern =>
+  ShadeRule.rename(pattern -> "ml.combust.mleap.shaded.@0").inAll
+} :+ ShadeRule.zap("org.slf4j.**").inAll

--- a/project/MleapProject.scala
+++ b/project/MleapProject.scala
@@ -213,4 +213,11 @@ object MleapProject {
       xgboostSpark % "provided",
       tensorflow % "provided")
   )
+
+  lazy val databricksRuntimeFatTests = Project(
+    id = "mleap-databricks-runtime-fat-tests",
+    base = file("mleap-databricks-runtime-fat-tests"),
+    dependencies = Seq(
+      databricksRuntimeFat)
+  )
 }

--- a/project/MleapProject.scala
+++ b/project/MleapProject.scala
@@ -184,6 +184,7 @@ object MleapProject {
     id = "mleap-databricks-runtime-fat",
     base = file("mleap-databricks-runtime-fat"),
     dependencies = Seq(baseProject,
+      avro,
       tensor,
       core,
       runtime,

--- a/travis/travis.sh
+++ b/travis/travis.sh
@@ -5,5 +5,5 @@ if [[ $TRAVIS_BRANCH == 'master' ]] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; the
   source travis/docker.sh
   sbt "+ test" "+ mleap-executor-tests/test" "+ mleap-benchmark/test" "mleap-xgboost-runtime/test" "mleap-xgboost-spark/test" "+ publishSigned" "mleap-xgboost-runtime/publishSigned" "mleap-xgboost-spark/publishSigned" "mleap-serving/docker:publish" "mleap-spring-boot/docker:publish" 2>/dev/null
 else
-  sbt "+ test" "+ mleap-executor-tests/test" "+ mleap-benchmark/test" "mleap-xgboost-runtime/test" "mleap-xgboost-spark/test" 2>/dev/null
+  sbt "+ test" "+ mleap-executor-tests/test" "+ mleap-benchmark/test" "mleap-xgboost-runtime/test" "mleap-xgboost-spark/test" "mleap-databricks-runtime-fat-tests/test" 2>/dev/null
 fi


### PR DESCRIPTION
Take over #692
closes #692 

### Test fat-jar
sbt "mleap-databricks-runtime-fat-tests/test"

### Note
I add mleap-avro into fat-jar.
there're some components such as mleap-executor, mleap-spring-boot not included in fat jar, is this intentional ?
