### PR TITLE
Serialize additional xgboost params so we can deserialize back to spark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,36 @@
 SHELL := /bin/bash
-
-.PHONY: test_executor test_benchmark test_xgboost_runtime test_xgboost_spark test_root_sbt_project py36_test py37_test
+SBT ?= sbt
 
 all: test
 
+.PHONY: test_executor
 test_executor:
-	sbt "+ mleap-executor-tests/test"
+	$(SBT) "+ mleap-executor-tests/test"
 
+.PHONY: test_benchmark
 test_benchmark:
-	sbt "+ mleap-benchmark/test"
+	$(SBT) "+ mleap-benchmark/test"
 
+.PHONY: test_root_sbt_project
 test_root_sbt_project:
-	sbt "+ test"
+	$(SBT) "+ test"
 
+.PHONY: test_xgboost_runtime
+test_xgboost_runtime:
+	$(SBT) "+ mleap-xgboost-runtime/test"
+
+.PHONY: test_xgboost_spark
+test_xgboost_spark:
+	$(SBT) "+ mleap-xgboost-spark/test"
+
+.PHONY: py36_test
 py36_test:
 	source scripts/scala_classpath_for_python.sh && make -C python py36_test
 
+.PHONY: py37_test
 py37_test:
 	source scripts/scala_classpath_for_python.sh && make -C python py37_test
 
+.PHONY: test
 test: test_executor test_benchmark test_xgboost_runtime test_xgboost_spark test_root_sbt_project py36_test py37_test
 	@echo "All tests run successfully"

--- a/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
+++ b/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
@@ -20,7 +20,7 @@ import ml.combust.mleap.runtime.transformer.Pipeline
 import resource._
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.Row
-import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.util.TestingUtils._
 
 /**
@@ -111,31 +111,28 @@ abstract class SparkParityBase extends FunSpec with BeforeAndAfterAll {
   }
 
   def assertModelTypesMatchTransformerTypes(model: Model, shape: NodeShape, exec: UserDefinedFunction): Unit = {
-    val modelInputTypes = shape.inputs.
-      map(_._2.port).
-      map(n => model.inputSchema.getField(n).get.dataType).
-      toSeq
+    val inputFields = model.inputSchema.fields.map(_.name)
+    val modelInputTypes = model.inputSchema.fields.map(_.dataType)
     val transformerInputTypes = exec.inputs.flatMap(_.dataTypes)
 
-    val modelOutputTypes = shape.outputs.
-      map(_._2.port).
-      map(n => model.outputSchema.getField(n).get.dataType).
-      toSeq
+    val outputFields = model.outputSchema.fields.map(_.name)
+    val modelOutputTypes = model.outputSchema.fields.map(_.dataType)
     val transformerOutputTypes = exec.outputTypes
 
-    checkTypes(modelInputTypes, transformerInputTypes)
-    checkTypes(modelOutputTypes, transformerOutputTypes)
+    checkTypes(modelInputTypes, transformerInputTypes, inputFields)
+    checkTypes(modelOutputTypes, transformerOutputTypes, outputFields)
   }
 
-  def checkTypes(modelTypes: Seq[DataType], transformerTypes: Seq[DataType]): Unit = {
+  def checkTypes(modelTypes: Seq[DataType], transformerTypes: Seq[DataType], fields: Seq[String]): Unit = {
     assert(modelTypes.size == modelTypes.size)
-    modelTypes.zip(transformerTypes).foreach {
-      case (modelType, transformerType) => {
+    modelTypes.zip(transformerTypes).zip(fields).foreach {
+      case ((modelType, transformerType), field) => {
         if (modelType.isInstanceOf[TensorType]) {
-          assert(transformerType.isInstanceOf[TensorType] &&
-            modelType.base == transformerType.base)
+          assert(
+            transformerType.isInstanceOf[TensorType] && modelType.base == transformerType.base,
+            s"Type of ${field} does not match, $transformerType")
         } else {
-          assert(modelType == transformerType)
+          assert(modelType == transformerType, s"Type of ${field} does not match")
         }
       }
     }
@@ -145,14 +142,17 @@ abstract class SparkParityBase extends FunSpec with BeforeAndAfterAll {
     assert(actualAnswer.length == expectedAnswer.length,
       s"actual answer length ${actualAnswer.length} != " +
         s"expected answer length ${expectedAnswer.length}")
-
+    var rowIdx = 0
     actualAnswer.toSeq.zip(expectedAnswer.toSeq).foreach {
       case (actual: Double, expected: Double) =>
         assert(actual ~== expected relTol eps)
+        rowIdx += 1
       case (actual: Float, expected: Float) =>
         assert(actual ~== expected relTol eps)
+        rowIdx += 1
       case (actual: Vector, expected: Vector) =>
         assert(actual ~= expected relTol eps)
+        rowIdx += 1
       case (actual: Seq[_], expected: Seq[_]) =>
         assert(actual.length == expected.length, s"actual length ${actual.length} != " +
           s"expected length ${expected.length}")
@@ -162,12 +162,15 @@ abstract class SparkParityBase extends FunSpec with BeforeAndAfterAll {
           case (actualElem: Float, expectedElem: Float) =>
             assert(actualElem ~== expectedElem relTol eps)
           case (actualElem, expectedElem) =>
-            assert(actualElem == expectedElem, s"$actualElem did not equal $expectedElem")
+            assert(actualElem == expectedElem, s"Field ${actualAnswer.schema(rowIdx)} differs.")
         }
+        rowIdx += 1
       case (actual: Row, expected: Row) =>
         checkRowWithRelTol(actual, expected, eps)
+        rowIdx += 1
       case (actual, expected) =>
         assert(actual == expected, s"$actual did not equal $expected")
+        rowIdx += 1
     }
   }
 
@@ -235,7 +238,6 @@ abstract class SparkParityBase extends FunSpec with BeforeAndAfterAll {
 
     it("model input/output schema matches transformer UDF") {
       val mTransformer = mleapTransformer(sparkTransformer)
-
       mTransformer match {
         case transformer: SimpleTransformer =>
           assertModelTypesMatchTransformerTypes(transformer.model, transformer.shape, transformer.typedExec)

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/classification/OneVsRestParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/classification/OneVsRestParitySpec.scala
@@ -1,5 +1,8 @@
 package org.apache.spark.ml.parity.classification
 
+import ml.combust.mleap.core.Model
+import ml.combust.mleap.core.types.NodeShape
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 import org.apache.spark.ml.{Pipeline, Transformer}
 import org.apache.spark.ml.classification.{LogisticRegression, OneVsRest}
 import org.apache.spark.ml.feature.{StringIndexer, VectorAssembler}
@@ -23,4 +26,12 @@ class OneVsRestParitySpec extends SparkParityBase {
       setPredictionCol("prediction"))).fit(dataset)
 
   override val unserializedParams = Set("stringOrderType", "classifier", "labelCol")
+
+  override def assertModelTypesMatchTransformerTypes(model: Model, shape: NodeShape, exec: UserDefinedFunction): Unit = {
+    /* OneVsRestModel intentionally does not have the same output schema as its exec */
+    val inputFields = model.inputSchema.fields.map(_.name)
+    val modelInputTypes = model.inputSchema.fields.map(_.dataType)
+    val transformerInputTypes = exec.inputs.flatMap(_.dataTypes)
+    checkTypes(modelInputTypes, transformerInputTypes, inputFields)
+  }
 }

--- a/mleap-xgboost-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelParitySpec.scala
+++ b/mleap-xgboost-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelParitySpec.scala
@@ -33,8 +33,12 @@ class XGBoostClassificationModelParitySpec extends SparkParityBase {
     "numClasses" -> 2,
     "nWorkers" -> 2,
     "missing" -> 0.0f,
-    "allowNonZeroFor_Missing" -> true
+    "allowNonZeroForMissing" -> true
   )
+
+  // These params are not needed for making predictions, so we don't serialize them
+  override val unserializedParams = Set("labelCol", "evalMetric", "objective")
+
   val sparkTransformer: Transformer = {
     val featureAssembler = new VectorAssembler()
       .setInputCols(Array("AT", "V", "AP", "RH"))

--- a/mleap-xgboost-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelParitySpec.scala
+++ b/mleap-xgboost-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelParitySpec.scala
@@ -1,61 +1,20 @@
 package ml.dmlc.xgboost4j.scala.spark.mleap
 
-import java.io.File
-import java.nio.file.{Files, Path}
-
-import ml.combust.bundle.BundleFile
-import ml.combust.bundle.serializer.SerializationFormat
-import ml.combust.mleap.runtime.frame
-import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.dmlc.xgboost4j.scala.spark.XGBoostClassifier
-import org.apache.spark.ml.bundle.SparkBundleContext
-import org.apache.spark.ml.{Pipeline, Transformer}
-import org.apache.spark.ml.feature.{StringIndexer, VectorAssembler}
-import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.ml.Transformer
+import org.apache.spark.ml.feature.VectorAssembler
 import org.apache.spark.ml.mleap.SparkUtil
 import org.apache.spark.ml.parity.SparkParityBase
-import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.mleap.TypeConverters
-import org.scalatest.{BeforeAndAfterAll, FunSpec}
-import resource.managed
-
-import scala.collection.mutable
+import org.apache.spark.sql.DataFrame
 
 /**
   * Created by hollinwilkins on 9/16/17.
   */
 case class PowerPlantTableForClassifier(AT: Double, V : Double, AP : Double, RH : Double, PE : Int)
 
-class XGBoostClassificationModelParitySpec extends FunSpec
-  with BeforeAndAfterAll {
+class XGBoostClassificationModelParitySpec extends SparkParityBase {
 
-  val spark = SparkSession.builder().
-    master("local[2]").
-    appName("XGBoostRegressionModelParitySpec").
-    getOrCreate()
-
-  override protected def afterAll(): Unit = {
-    spark.stop()
-  }
-
-  private val xgboostParams: Map[String, Any] = Map(
-    "eta" -> 0.3,
-    "max_depth" -> 2,
-    "objective" -> "binary:logistic",
-    "early_stopping_rounds" ->2,
-    "num_round" -> 15,
-    "num_classes" -> 2,
-    "nworkers" -> 2
-  )
-
-  private val denseDataset: DataFrame = {
-    SparkParityBase.dataset(spark).select("fico_score_group_fnl", "dti").
-      filter(col("fico_score_group_fnl") === "500 - 550" ||
-        col("fico_score_group_fnl") === "600 - 650")
-  }
-
-  private val sparseDataset: DataFrame = {
+  val dataset: DataFrame = {
     import spark.sqlContext.implicits._
 
     spark.sqlContext.sparkContext.textFile(this.getClass.getClassLoader.getResource("datasources/xgboost_training.csv").toString)
@@ -64,152 +23,37 @@ class XGBoostClassificationModelParitySpec extends FunSpec
       .toDF
   }
 
-  private val featurePipelineForDenseDataset: Transformer = {
-    new Pipeline().setStages(Array(new StringIndexer().
-      setInputCol("fico_score_group_fnl").
-      setOutputCol("fico_index"),
-      new VectorAssembler().
-        setInputCols(Array("dti")).
-        setOutputCol("features"))).fit(denseDataset)
-  }
-
-  private val sparkTransformerForSparseDataset: Transformer = {
+  val xgboostParams = Map(
+    "eta" -> 0.3,
+    "maxDepth" -> 2,
+    "objective" -> "binary:logistic",
+    "treeMethod" -> "approx",
+    "earlyStoppingRounds" -> 2,
+    "numRound" -> 15,
+    "numClasses" -> 2,
+    "nWorkers" -> 2,
+    "missing" -> 0.0f,
+    "allowNonZeroFor_Missing" -> true
+  )
+  val sparkTransformer: Transformer = {
     val featureAssembler = new VectorAssembler()
       .setInputCols(Array("AT", "V", "AP", "RH"))
       .setOutputCol("features")
-
-    val params = xgboostParams + ("missing"-> 0.0f)
-    val classifier = createClassifier(params, featureAssembler, sparseDataset, "PE")
+    val classifier = createClassifier(xgboostParams, featureAssembler, dataset, "PE")
     SparkUtil.createPipelineModel(Array(featureAssembler, classifier))
   }
 
-  private val sparkTransformerForDenseDataset: Transformer = {
-
-    val classifier = createClassifier(xgboostParams, featurePipelineForDenseDataset, denseDataset, "fico_index")
-    SparkUtil.createPipelineModel(Array(featurePipelineForDenseDataset, classifier))
-  }
-
-  def createClassifier(
-                        xgboostParams: Map[String, Any],
-                        featurePipeline: Transformer,
-                        dataset: DataFrame,
-                        outputCol: String
-                      ): Transformer ={
+  private def createClassifier(xgboostParams: Map[String, Any],
+                       featurePipeline: Transformer,
+                       dataset: DataFrame,
+                       labelCol: String): Transformer ={
     new XGBoostClassifier(xgboostParams).
       setFeaturesCol("features").
       setProbabilityCol("probabilities").
-      setLabelCol(outputCol).
+      setLabelCol(labelCol).
       fit(featurePipeline.transform(dataset)).
       setLeafPredictionCol("leaf_prediction").
       setContribPredictionCol("contrib_prediction").
       setTreeLimit(2)
-  }
-
-
-
-  def equalityTest(sparkDataset: DataFrame,
-                   mleapDataset: DefaultLeapFrame): Unit = {
-    val sparkFeaturesCol = sparkDataset.schema.fieldIndex("features")
-    val mleapFeaturesCol = mleapDataset.schema.indexOf("features").get
-
-    val sparkProbabilityCol = sparkDataset.schema.fieldIndex("probabilities")
-    val mleapProbabilityCol = mleapDataset.schema.indexOf("probabilities").get
-
-    val sparkPredictionCol = sparkDataset.schema.fieldIndex("prediction")
-    val mleapPredictionCol = mleapDataset.schema.indexOf("prediction").get
-
-    val sparkLeafPredictionCol = sparkDataset.schema.fieldIndex("leaf_prediction")
-    val mleapLeafPredictionCol = mleapDataset.schema.indexOf("leaf_prediction").get
-
-    val sparkContribPredictionCol = sparkDataset.schema.fieldIndex("contrib_prediction")
-    val mleapContribPredictionCol = mleapDataset.schema.indexOf("contrib_prediction").get
-
-    assert(sparkDataset.schema.fields.length == mleapDataset.schema.fields.length)
-
-    sparkDataset.collect().zip(mleapDataset.collect()).foreach {
-      case (sp, ml) =>
-        assert(sp.getAs[Vector](sparkFeaturesCol).toDense.values sameElements ml.getTensor[Double](mleapFeaturesCol).toDense.rawValues)
-
-        val sparkProbabilities = sp.getAs[Vector](sparkProbabilityCol).toArray
-        val mleapProbabilities = ml.getTensor[Double](mleapProbabilityCol).toArray
-
-        sparkProbabilities.zip(mleapProbabilities).foreach {
-          case (v1, v2) =>
-            if (Math.abs(v2 - v1) > 0.0000001) {
-              println("SPARK: " + sparkProbabilities.mkString(","))
-              println("MLEAP: " + mleapProbabilities.mkString(","))
-            }
-
-            assert(Math.abs(v2 - v1) < 0.0000001)
-        }
-        val sparkPrediction = sp.getDouble(sparkPredictionCol)
-        val mleapPrediction = ml.getDouble(mleapPredictionCol)
-        assert(sparkPrediction == mleapPrediction)
-
-        val sparkLeafPrediction = sp.getAs[mutable.WrappedArray[Double]](sparkLeafPredictionCol)
-        val mleapLeafPrediction = ml.getSeq[Double](mleapLeafPredictionCol)
-        assert(sparkLeafPrediction == mleapLeafPrediction)
-
-        val sparkContribPrediction = sp.getAs[mutable.WrappedArray[Double]](sparkContribPredictionCol)
-        val mleapContribPrediction = ml.getSeq[Double](mleapContribPredictionCol)
-        assert(sparkContribPrediction == mleapContribPrediction)
-    }
-  }
-
-  var bundleCacheSparse : Option[File] = None
-  var bundleCacheDense : Option[File] = None
-
-  def serializeModelToMleapBundle(transformer: Transformer, dataset: DataFrame): File = {
-    import ml.combust.mleap.spark.SparkSupport._
-
-    implicit val sbc = SparkBundleContext.defaultContext.withDataset(transformer.transform(dataset))
-
-    val tempDirPath = {
-      val temp: Path = Files.createTempDirectory("mleap-spark-parity")
-      temp.toFile.deleteOnExit()
-      temp.toAbsolutePath
-    }
-
-    val file = new File(s"${tempDirPath}/${classOf[XGBoostClassificationModelParitySpec].getName}.zip")
-    file.delete()
-
-    for(bf <- managed(BundleFile(file))) {
-      transformer.writeBundle.format(SerializationFormat.Json).save(bf).get
-    }
-    file
-  }
-
-  def loadMleapTransformerFromBundle(bundleFile: File)
-                                    (implicit context: SparkBundleContext): frame.Transformer = {
-    import ml.combust.mleap.runtime.MleapSupport._
-    (for(bf <- managed(BundleFile(bundleFile))) yield {
-      bf.loadMleapBundle().get.root
-    }).tried.get
-  }
-
-  def constructLeapFrameFromSparkDataFrame(dataFrame: DataFrame): DefaultLeapFrame ={
-    val mleapSchema = TypeConverters.sparkSchemaToMleapSchema(dataFrame)
-    val data = dataFrame.collect().map {
-      r => Row(r.toSeq: _*)
-    }
-    DefaultLeapFrame(mleapSchema, data)
-  }
-
-  def doTest(sparkTransformer: Transformer, dataset: DataFrame, bundleCache: Option[File]): Unit ={
-    val sparkDataset = sparkTransformer.transform(dataset)
-    val leapFrame = constructLeapFrameFromSparkDataFrame(dataset)
-    val mleapBundle = bundleCache.getOrElse(serializeModelToMleapBundle(sparkTransformer, dataset))
-    val mleapTransformer = loadMleapTransformerFromBundle(mleapBundle)
-    val mleapDataset = mleapTransformer.transform(leapFrame).get
-
-    equalityTest(sparkDataset, mleapDataset)
-  }
-
-  it("produces the same results for a dense dataset") {
-    doTest(sparkTransformerForDenseDataset, denseDataset, bundleCacheDense)
-  }
-
-  it("produces the same result for a sparse dataset") {
-    doTest(sparkTransformerForSparseDataset, sparseDataset, bundleCacheSparse)
   }
 }

--- a/mleap-xgboost-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelParitySpec.scala
+++ b/mleap-xgboost-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelParitySpec.scala
@@ -22,8 +22,11 @@ class XGBoostRegressionModelParitySpec extends SparkParityBase {
     "treeMethod" -> "approx",
     "earlyStoppingRounds" -> 2,
     "numRound" -> 15,
-    "allowNonZeroFor_Missing" -> true
+    "allowNonZeroForMissing" -> true
   )
+
+  // These params are not needed for making predictions, so we don't serialize them
+  override val unserializedParams = Set("labelCol", "evalMetric", "objective")
 
   val dataset: DataFrame = {
     import spark.sqlContext.implicits._

--- a/mleap-xgboost-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelParitySpec.scala
+++ b/mleap-xgboost-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelParitySpec.scala
@@ -1,46 +1,28 @@
 package ml.dmlc.xgboost4j.scala.spark.mleap
 
-import java.io.File
-import java.nio.file.{Files, Path}
-
-import ml.combust.bundle.BundleFile
-import ml.combust.bundle.serializer.SerializationFormat
-import ml.combust.mleap.core.types.{ScalarType, StructField, StructType}
-import ml.combust.mleap.runtime.frame
-import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.dmlc.xgboost4j.scala.spark.XGBoostRegressor
-import org.apache.spark.ml.bundle.SparkBundleContext
-import org.apache.spark.ml.linalg.Vector
-import org.apache.spark.ml.{Pipeline, Transformer}
+import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.feature.VectorAssembler
 import org.apache.spark.ml.mleap.SparkUtil
-import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.scalatest.{BeforeAndAfterAll, FunSpec}
-import resource.managed
+import org.apache.spark.ml.parity.SparkParityBase
+import org.apache.spark.sql.DataFrame
 
 /**
   * Created by hollinwilkins on 9/16/17.
   */
 case class PowerPlantTable(AT: Double, V : Double, AP : Double, RH : Double, PE : Double)
 
-class XGBoostRegressionModelParitySpec extends FunSpec
-  with BeforeAndAfterAll {
-  val spark = SparkSession.builder().
-    master("local[2]").
-    appName("XGBoostRegressionModelParitySpec").
-    getOrCreate()
-
-  override protected def afterAll(): Unit = {
-    spark.stop()
-  }
+class XGBoostRegressionModelParitySpec extends SparkParityBase {
 
   private val xgboostParams: Map[String, Any] = Map(
     "eta" -> 0.3,
-    "max_depth" -> 2,
+    "maxDepth" -> 2,
     "missing" -> 0.0f,
-    "objective" -> "reg:squarederror",
-    "early_stopping_rounds" ->2,
-    "num_round" -> 15
+    "objective" -> "reg:squaredlogerror",
+    "treeMethod" -> "approx",
+    "earlyStoppingRounds" -> 2,
+    "numRound" -> 15,
+    "allowNonZeroFor_Missing" -> true
   )
 
   val dataset: DataFrame = {
@@ -66,78 +48,5 @@ class XGBoostRegressionModelParitySpec extends FunSpec
       setTreeLimit(2)
 
     SparkUtil.createPipelineModel(Array(featureAssembler, regressor))
-  }
-
-  def equalityTest(sparkDataset: DataFrame,
-                   mleapDataset: DefaultLeapFrame): Unit = {
-    val sparkPredictionCol = sparkDataset.schema.fieldIndex("prediction")
-    val mleapPredictionCol = mleapDataset.schema.indexOf("prediction").get
-
-    val sparkFeaturesCol = sparkDataset.schema.fieldIndex("features")
-    val mleapFeaturesCol = mleapDataset.schema.indexOf("features").get
-
-    val sparkCollected = sparkDataset.collect()
-    val collected = mleapDataset.collect()
-
-    sparkCollected.zip(collected).foreach {
-      case (sp, ml) =>
-        val v1 = sp.getDouble(sparkPredictionCol)
-        val v2 = ml.getDouble(mleapPredictionCol)
-
-        assert(sp.getAs[Vector](sparkFeaturesCol).toDense.values sameElements ml.getTensor[Double](mleapFeaturesCol).toDense.rawValues)
-        assert(Math.abs(v2 - v1) < 0.0001)
-    }
-  }
-
-  var bundleCache: Option[File] = None
-
-  def serializedModel(transformer: Transformer): File = {
-    import ml.combust.mleap.spark.SparkSupport._
-
-    implicit val sbc = SparkBundleContext.defaultContext.withDataset(transformer.transform(dataset))
-
-    bundleCache.getOrElse {
-
-      val tempDirPath = {
-        val temp: Path = Files.createTempDirectory("mleap-spark-parity")
-        temp.toFile.deleteOnExit()
-        temp.toAbsolutePath
-      }
-
-      val file = new File(s"${tempDirPath}/${classOf[XGBoostRegressionModelParitySpec].getName}.zip")
-
-      for(bf <- managed(BundleFile(file))) {
-        transformer.writeBundle.format(SerializationFormat.Json).save(bf).get
-      }
-
-      bundleCache = Some(file)
-      file
-    }
-  }
-
-  def mleapTransformer(transformer: Transformer)
-                      (implicit context: SparkBundleContext): frame.Transformer = {
-    import ml.combust.mleap.runtime.MleapSupport._
-
-    (for(bf <- managed(BundleFile(serializedModel(transformer)))) yield {
-      bf.loadMleapBundle().get.root
-    }).tried.get
-  }
-
-  private val mleapSchema = StructType(StructField("AT", ScalarType.Double),
-    StructField("V", ScalarType.Double),
-    StructField("AP", ScalarType.Double),
-    StructField("RH", ScalarType.Double)).get
-
-  it("produces the same results") {
-    val data = dataset.collect().map {
-      r => Row(r.getDouble(0), r.getDouble(1), r.getDouble(2), r.getDouble(3))
-    }
-    val frame = DefaultLeapFrame(mleapSchema, data)
-    val mleapT = mleapTransformer(sparkTransformer)
-    val sparkDataset = sparkTransformer.transform(dataset)
-    val mleapDataset = mleapT.transform(frame).get
-
-    equalityTest(sparkDataset, mleapDataset)
   }
 }

--- a/scripts/scala_classpath_for_python.sh
+++ b/scripts/scala_classpath_for_python.sh
@@ -1,11 +1,13 @@
 #! /bin/bash
-
+if [ -z ${SBT} ]; then
+  export SBT=sbt
+fi
 # Source this file to load SCALA_CLASS_PATH in the environment
 
 # Compile classes used in python tests
-sbt mleap-spark-extension/compile
-sbt mleap-spark/compile
+${SBT} mleap-spark-extension/compile
+${SBT} mleap-spark/compile
 
 # Export the complete dependencyClasspath into an env. variable
 export SCALA_CLASS_PATH=\
-"$(sbt --error 'export mleap-spark-extension/runtime:fullClasspath' 2> /dev/null)"
+"$( ${SBT} --error 'export mleap-spark-extension/runtime:fullClasspath' 2> /dev/null)"


### PR DESCRIPTION
`mleap-xgboost-spark` only serialized the params needed for the `mleap-xgboost-runtime`, but this prohibited reloading the xgboost model back into Spark.  So this PR does the following:

- Serialize and deserialize additional parameters for the xgboost spark ops.

   - For deserialization I tried to be backwards compatible.  So any serialized models from prior mleap versions would still be deserializable, just wouldn't have all the parameters.
   - There are other params we might also want to serialize (in principle all the `Params` are viable), but I think this is the list needed to deserialize to spark and then call transform in spark.

- Change the mleap-xgboost-spark test cases to be `SparkParityBase` subclasses to better test all the cases.
- `SparkParityBase` seemingly had a bug where it was reordering columns in the output schemas using the node shape?  The test was comparing the udf output to the model output, so shouldn't do reordering I think?  Reordering/renaming should only be at the mleap transformer level.
   
   - While debugging this, I added some additional debugging output to the `SparkParityBase` so you know which column is messing up.  Figured it was generally useful so left it in.
   - After fixing `SparkParityBase`, the `OneVsRestParity` spec was broken because it deliberately has the udf and model have different output schemas depending on the conditions.  So overwrote that test case.

- fixed up the `Makefile` which hadn't been touched in a while.  And added sbt as an environment variable rather than requiring sbt be a system executable.  Should be backwards compatible.