### PR TITLE
remove unneccessary headers for GET requests without payloads

### DIFF
--- a/mleap-spring-boot/src/main/scala/ml/combust/mleap/springboot/JsonScoringController.scala
+++ b/mleap-spring-boot/src/main/scala/ml/combust/mleap/springboot/JsonScoringController.scala
@@ -54,7 +54,6 @@ class JsonScoringController(@Autowired val actorSystem : ActorSystem,
       .map(model => JsonMethods.compact(jsonPrinter.toJson(model)))(executor).toJava
 
   @GetMapping(path = Array("/models/{model_name}"),
-              consumes = Array("application/json; charset=UTF-8"),
               produces = Array("application/json; charset=UTF-8"))
   def getModel(@PathVariable("model_name") modelName: String,
                @RequestHeader(value = "timeout", defaultValue = "60000") timeout: Int): CompletionStage[String] =
@@ -64,7 +63,6 @@ class JsonScoringController(@Autowired val actorSystem : ActorSystem,
       .map(model => JsonMethods.compact(jsonPrinter.toJson(model)))(executor).toJava
 
   @GetMapping(path = Array("/models/{model_name}/meta"),
-              consumes = Array("application/json; charset=UTF-8"),
               produces = Array("application/json; charset=UTF-8"))
   def getMeta(@PathVariable("model_name") modelName: String,
               @RequestHeader(value = "timeout", defaultValue = "60000") timeout: Int) : CompletionStage[String] =

--- a/mleap-spring-boot/src/main/scala/ml/combust/mleap/springboot/ProtobufScoringController.scala
+++ b/mleap-spring-boot/src/main/scala/ml/combust/mleap/springboot/ProtobufScoringController.scala
@@ -47,7 +47,6 @@ class ProtobufScoringController(@Autowired val actorSystem : ActorSystem,
       .map(model => Model.toJavaProto(model))(executor).toJava
 
   @GetMapping(path = Array("/models/{model_name}"),
-    consumes = Array("application/x-protobuf; charset=UTF-8"),
     produces = Array("application/x-protobuf; charset=UTF-8"))
   def getModel(@PathVariable("model_name") modelName: String,
                @RequestHeader(value = "timeout", defaultValue = "60000") timeout: Int): CompletionStage[Mleap.Model] =
@@ -56,7 +55,6 @@ class ProtobufScoringController(@Autowired val actorSystem : ActorSystem,
       .map(model => Model.toJavaProto(model))(executor).toJava
 
   @GetMapping(path = Array("/models/{model_name}/meta"),
-    consumes = Array("application/x-protobuf; charset=UTF-8"),
     produces = Array("application/x-protobuf; charset=UTF-8"))
   def getMeta(@PathVariable("model_name") modelName: String,
               @RequestHeader(value = "timeout", defaultValue = "60000") timeout: Int) : CompletionStage[Mleap.BundleMeta] =


### PR DESCRIPTION
Remove the requirement to have Content type headers on GET requests with empty payloads. 
