### PR TITLE
annotate SerializationFormat as Serializable

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/serializer/SerializationFormat.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/serializer/SerializationFormat.scala
@@ -11,7 +11,7 @@ import ml.bundle.Format
   *   <li>protobuf - use protobuf for all attributes, models and nodes</li>
   * </ol>
   */
-sealed trait SerializationFormat {
+sealed trait SerializationFormat extends Serializable {
   def asBundle: Format
 }
 


### PR DESCRIPTION
If there's no introduced complications from doing this, this would help simplify the resolution to spark task serialization issues we're facing when trying to broadcast mleap models in our inference pattern.