### PR TITLE
bump sbt-assembly to fix fat jar not working issue

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
 


### PR DESCRIPTION
in an empty project with `mleap-databricks-runtime` dependency, the following code will fail:
```scala
val bytes = Array.emptyByteArray
val shape: DataShape = ml.bundle.DataShape.parseFrom(bytes)
```

with error message:
```
Symbol 'type scalapb.GeneratedMessageCompanion' is missing from the classpath.
This symbol is required by 'object ml.bundle.DataShape'.
Make sure that type GeneratedMessageCompanion is in your classpath and check for conflicting dependencies with `-Ylog-classpath`.
A full rebuild may help if 'DataShape.class' was compiled against an incompatible version of scalapb.
    val shape: DataShape = ml.bundle.DataShape.parseFrom(bytes)

value parseFrom is not a member of object ml.bundle.DataShape
    val shape: DataShape = ml.bundle.DataShape.parseFrom(bytes)
```

After some digging, I found this is due to shading of scalapb (which is a scala lib) was not supported by the previous sbt-assembly plugin. It has been fixed in an recently version of the plugin, see https://github.com/sbt/sbt-assembly/pull/393.