### PR TITLE
fix test failure with gensim 4.x

### DIFF
--- a/python/mleap/gensim/word2vec.py
+++ b/python/mleap/gensim/word2vec.py
@@ -59,10 +59,10 @@ class SimpleSparkSerializer(MLeapSerializer):
 
         # compile tuples of model attributes to serialize
         attributes = list()
-        attributes.append(('words', transformer.wv.index2word))
+        attributes.append(('words', transformer.wv.index_to_key))
 
-        # indices = [np.float64(x) for x in list(range(len(transformer.wv.index2word)))]
-        word_vectors = np.array([float(y) for x in [transformer.wv.word_vec(w) for w in transformer.wv.index2word] for y in x])
+        # indices = [np.float64(x) for x in list(range(len(transformer.wv.index_to_key)))]
+        word_vectors = np.array([float(y) for x in [transformer.wv.word_vec(w) for w in transformer.wv.index_to_key] for y in x])
 
         # attributes.append(('indices', indices))
         # Excluding indices because they are 0 - N

--- a/python/tests/gensim_test.py
+++ b/python/tests/gensim_test.py
@@ -54,7 +54,7 @@ class TransformerTests(unittest.TestCase):
         size_ = 5
         window_ = 2
 
-        model_ = Word2Vec(sentences4word2vec_, min_count=2, size=size_, window=window_)
+        model_ = Word2Vec(sentences4word2vec_, min_count=2, vector_size=size_, window=window_)
         model_.mlinit(input_features=['input'], prediction_column = 'sentence_vector')
 
         model_.serialize_to_bundle(self.tmp_dir, model_.name)


### PR DESCRIPTION
The latest release gensim 4.x has API breaks, see [Migrating from Gensim 3.x to 4](https://github.com/RaRe-Technologies/gensim/wiki/Migrating-from-Gensim-3.x-to-4)