### PR TITLE
Spark 3.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,15 @@ scala:
 jdk:
   - oraclejdk8  # sbt +compile fails on jdk11 (xenial's default)
 
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      # Used for xgboost test. (It require libgomp.so.1: version `GOMP_4.0')
+      - gcc-4.8
+      - g++-4.8
+
 jobs:
   include:
     - stage: "Mleap tests"

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/ann/LossFunctions.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/ann/LossFunctions.scala
@@ -45,7 +45,7 @@ class SigmoidLayerModelWithSquaredError
   extends FunctionalLayerModel(new FunctionalLayer(new SigmoidFunction)) with LossFunction {
   override def loss(output: BDM[Double], target: BDM[Double], delta: BDM[Double]): Double = {
     ApplyInPlace(output, target, delta, (o: Double, t: Double) => o - t)
-    val error = Bsum(delta :* delta) / 2 / output.cols
+    val error = Bsum(delta *:* delta) / 2 / output.cols
     ApplyInPlace(delta, output, delta, (x: Double, o: Double) => x * (o - o * o))
     error
   }
@@ -108,6 +108,6 @@ class SoftmaxLayerModelWithCrossEntropyLoss extends LayerModel with LossFunction
 
   override def loss(output: BDM[Double], target: BDM[Double], delta: BDM[Double]): Double = {
     ApplyInPlace(output, target, delta, (o: Double, t: Double) => o - t)
-    -Bsum( target :* brzlog(output)) / output.cols
+    -Bsum( target *:* brzlog(output)) / output.cols
   }
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/clustering/LDAModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/clustering/LDAModel.scala
@@ -186,7 +186,7 @@ case class LocalLDAModel (topics: Matrix[Double],
         docBound += count * LDAUtils.logSumExp(Elogthetad + localElogbeta(idx, ::).t)
       }
       // E[log p(theta | alpha) - log q(theta | gamma)]
-      docBound += sum((brzAlpha - gammad) :* Elogthetad)
+      docBound += sum((brzAlpha - gammad) *:* Elogthetad)
       docBound += sum(lgamma(gammad) - lgamma(brzAlpha))
       docBound += lgamma(sum(brzAlpha)) - lgamma(sum(gammad))
 
@@ -196,7 +196,7 @@ case class LocalLDAModel (topics: Matrix[Double],
     // Bound component for prob(topic-term distributions):
     //   E[log p(beta | eta) - log q(beta | lambda)]
     val sumEta = eta * vocabSize
-    val topicsPart = sum((eta - lambda) :* Elogbeta) +
+    val topicsPart = sum((eta - lambda) *:* Elogbeta) +
       sum(lgamma(lambda) - lgamma(eta)) +
       sum(lgamma(sumEta) - lgamma(sum(lambda(::, breeze.linalg.*))))
 

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/clustering/LDAUtils.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/clustering/LDAUtils.scala
@@ -15,7 +15,7 @@ object LDAUtils {
     */
   private[clustering] def logSumExp(x: BDV[Double]): Double = {
     val a = max(x)
-    a + log(sum(exp(x :- a)))
+    a + log(sum(exp(x -:- a)))
   }
 
   /**

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/clustering/optimization/LDAOptimizer.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/clustering/optimization/LDAOptimizer.scala
@@ -39,7 +39,7 @@ private[clustering] object OnlineLDAOptimizer {
     val expElogthetad: BDV[Double] = exp(LDAUtils.dirichletExpectation(gammad))  // K
     val expElogbetad = expElogbeta(ids, ::).toDenseMatrix                        // ids * K
 
-    val phiNorm: BDV[Double] = expElogbetad * expElogthetad :+ 1e-100            // ids
+    val phiNorm: BDV[Double] = expElogbetad * expElogthetad +:+ 1e-100            // ids
     var meanGammaChange = 1D
     val ctsVector = new BDV[Double](cts)                                         // ids
 
@@ -47,14 +47,14 @@ private[clustering] object OnlineLDAOptimizer {
     while (meanGammaChange > 1e-3) {
       val lastgamma = gammad.copy
       //        K                  K * ids               ids
-      gammad := (expElogthetad :* (expElogbetad.t * (ctsVector :/ phiNorm))) :+ alpha
+      gammad := (expElogthetad *:* (expElogbetad.t * (ctsVector /:/ phiNorm))) +:+ alpha
       expElogthetad := exp(LDAUtils.dirichletExpectation(gammad))
       // TODO: Keep more values in log space, and only exponentiate when needed.
-      phiNorm := expElogbetad * expElogthetad :+ 1e-100
+      phiNorm := expElogbetad * expElogthetad +:+ 1e-100
       meanGammaChange = sum(abs(gammad - lastgamma)) / k
     }
 
-    val sstatsd = expElogthetad.asDenseMatrix.t * (ctsVector :/ phiNorm).asDenseMatrix
+    val sstatsd = expElogthetad.asDenseMatrix.t * (ctsVector /:/ phiNorm).asDenseMatrix
     (gammad, sstatsd, ids)
   }
 }

--- a/mleap-databricks-runtime-fat/build.sbt
+++ b/mleap-databricks-runtime-fat/build.sbt
@@ -7,28 +7,35 @@ Common.noPublishSettings
 enablePlugins(AssemblyPlugin)
 
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
-assemblyShadeRules in assembly := Seq(
-  ShadeRule.rename("spray.json.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("com.google.protobuf.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("com.trueaccord.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("au.com.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("com.github.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("com.typesafe.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("edu.emory.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("fastparse.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("google.protobuf.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("machinist.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("macrocompat.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("org.apache.commons.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("org.netlib.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("org.j_paine.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("resource.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("scalapb.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("scalaxy.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("shapeless.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("spire.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("sourcecode.**" -> "ml.combust.mleap.shaded.@0").inAll,
-  ShadeRule.rename("buildinfo.**" -> "ml.combust.mleap.shaded.@0").inAll,
 
-  ShadeRule.zap("org.slf4j.**").inAll
-)
+assemblyShadeRules in assembly := Seq(
+  "spray.json.**",
+  "com.google.protobuf.**",
+  "com.trueaccord.**",
+  "au.com.**",
+  "com.github.**",
+  "com.typesafe.**",
+  "edu.emory.**",
+  "fastparse.**",
+  "google.protobuf.**",
+  "machinist.**",
+  "macrocompat.**",
+  "org.apache.commons.**",
+  "org.netlib.**",
+  "org.j_paine.**",
+  "resource.**",
+  "scalapb.**",
+  "scalaxy.**",
+  "shapeless.**",
+  "spire.**",
+  "sourcecode.**",
+  "buildinfo.**",
+  "ai.h2o.**",
+  "biz.k11i.**",
+  "com.esotericsoftware.**",
+  "net.jafama.**",
+  "org.objectweb.**",
+  "org.objenesis.**"
+).map { pattern =>
+  ShadeRule.rename(pattern -> "ml.combust.mleap.shaded.@0").inAll
+} :+ ShadeRule.zap("org.slf4j.**").inAll

--- a/mleap-databricks-runtime-testkit/src/main/scala/ml/combust/mleap/databricks/runtime/testkit/TestSparkMl.scala
+++ b/mleap-databricks-runtime-testkit/src/main/scala/ml/combust/mleap/databricks/runtime/testkit/TestSparkMl.scala
@@ -7,7 +7,6 @@ import ml.combust.bundle.BundleFile
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.{StringIndexer, VectorAssembler}
 import org.apache.spark.sql.SparkSession
-import com.databricks.spark.avro._
 import ml.combust.mleap.spark.SparkSupport._
 import ml.combust.mleap.runtime.MleapSupport._
 import org.apache.spark.ml.Pipeline
@@ -23,7 +22,7 @@ class TestSparkMl(session: SparkSession) extends Runnable {
       path,
       StandardCopyOption.REPLACE_EXISTING)
 
-    val sampleData = sqlContext.read.avro(path.toString)
+    val sampleData = sqlContext.read.format("avro").load(path.toString)
     sampleData.show()
 
     val stringIndexer = new StringIndexer().

--- a/mleap-databricks-runtime-testkit/src/main/scala/ml/combust/mleap/databricks/runtime/testkit/TestTensorflow.scala
+++ b/mleap-databricks-runtime-testkit/src/main/scala/ml/combust/mleap/databricks/runtime/testkit/TestTensorflow.scala
@@ -11,9 +11,10 @@ import ml.combust.mleap.runtime.MleapSupport._
 
 class TestTensorflow(session: SparkSession) extends Runnable {
   override def run(): Unit = {
-    val model = TensorflowModel(TensorFlowTestUtil.createAddGraph(),
+    val model = TensorflowModel(Some(TensorFlowTestUtil.createAddGraph()),
       inputs = Seq(("InputA", TensorType.Float()), ("InputB", TensorType.Float())),
-      outputs = Seq(("MyResult", TensorType.Float())))
+      outputs = Seq(("MyResult", TensorType.Float())),
+      graphBytes = Array.emptyByteArray)
     val shape = NodeShape().withInput("InputA", "input_a").
       withInput("InputB", "input_b").
       withOutput("MyResult", "my_result")

--- a/mleap-databricks-runtime-testkit/src/main/scala/ml/combust/mleap/databricks/runtime/testkit/TestXgboost.scala
+++ b/mleap-databricks-runtime-testkit/src/main/scala/ml/combust/mleap/databricks/runtime/testkit/TestXgboost.scala
@@ -7,7 +7,6 @@ import ml.combust.bundle.BundleFile
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.{StringIndexer, VectorAssembler}
 import org.apache.spark.sql.SparkSession
-import com.databricks.spark.avro._
 import ml.combust.mleap.spark.SparkSupport._
 import ml.combust.mleap.runtime.MleapSupport._
 import ml.dmlc.xgboost4j.scala.spark.XGBoostClassifier
@@ -32,7 +31,7 @@ class TestXgboost(session: SparkSession) extends Runnable {
       path,
       StandardCopyOption.REPLACE_EXISTING)
 
-    val sampleData = sqlContext.read.avro(path.toString)
+    val sampleData = sqlContext.read.format("avro").load(path.toString)
     sampleData.show()
 
     val stringIndexer = new StringIndexer().

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/HashingTermFrequencyOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/HashingTermFrequencyOp.scala
@@ -21,13 +21,16 @@ class HashingTermFrequencyOp extends MleapOp[HashingTermFrequency, HashingTermFr
                       (implicit context: BundleContext[MleapContext]): Model = {
       model.withValue("num_features", Value.long(obj.numFeatures))
         .withValue("binary", Value.boolean(obj.binary))
+        .withValue("version", Value.long(obj.version))
     }
 
     override def load(model: Model)
                      (implicit context: BundleContext[MleapContext]): HashingTermFrequencyModel = {
-      val binary = model.getValue("binary").map(_.getBoolean).getOrElse(false)
-      HashingTermFrequencyModel(numFeatures = model.value("num_features").getLong.toInt, binary = binary)
-
+      HashingTermFrequencyModel(
+        numFeatures = model.value("num_features").getLong.toInt,
+        binary = model.getValue("binary").map(_.getBoolean).getOrElse(false),
+        version = model.getValue("version").map(_.getLong.toInt).getOrElse(1)
+      )
     }
   }
 

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/classification/SVM.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/classification/SVM.scala
@@ -93,7 +93,7 @@ class SVMModel(override val uid: String,
     if(margin(features) > getThreshold) 1.0 else 0.0
   }
 
-  override protected def predictRaw(features: linalg.Vector): linalg.Vector = {
+  override def predictRaw(features: linalg.Vector): linalg.Vector = {
     val m = margin(features)
     linalg.Vectors.dense(-m, m)
   }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/MultiLayerPerceptronClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/MultiLayerPerceptronClassifierOp.scala
@@ -21,16 +21,19 @@ class MultiLayerPerceptronClassifierOp extends SimpleSparkOp[MultilayerPerceptro
       val thresholds = if(obj.isSet(obj.thresholds)) {
         Some(obj.getThresholds)
       } else None
-      model.withValue("layers", Value.longList(obj.layers.map(_.toLong))).
+
+      val layers = obj.getLayers
+      model.withValue("layers", Value.longList(layers.map(_.toLong))).
         withValue("weights", Value.vector(obj.weights.toArray)).
         withValue("thresholds", thresholds.map(_.toSeq).map(Value.doubleList))
     }
 
     override def load(model: Model)
                      (implicit context: BundleContext[SparkBundleContext]): MultilayerPerceptronClassificationModel = {
-      val m = new MultilayerPerceptronClassificationModel(uid = "",
-        layers = model.value("layers").getLongList.map(_.toInt).toArray,
-        weights = Vectors.dense(model.value("weights").getTensor[Double].toArray))
+      val layers = model.value("layers").getLongList.map(_.toInt).toArray
+      val weights = Vectors.dense(model.value("weights").getTensor[Double].toArray)
+      val m = new MultilayerPerceptronClassificationModel(uid = "", weights = weights)
+      m.set(m.layers, layers)
       model.getValue("thresholds").
         map(t => m.setThresholds(t.getDoubleList.toArray)).
         getOrElse(m)
@@ -38,8 +41,10 @@ class MultiLayerPerceptronClassifierOp extends SimpleSparkOp[MultilayerPerceptro
 
   }
 
-  override def sparkLoad(uid: String, shape: NodeShape, model: MultilayerPerceptronClassificationModel): MultilayerPerceptronClassificationModel = {
-    val m = new MultilayerPerceptronClassificationModel(uid = uid,layers = model.layers, weights = model.weights)
+  override def sparkLoad(uid: String, shape: NodeShape, model: MultilayerPerceptronClassificationModel):
+      MultilayerPerceptronClassificationModel = {
+    val m = new MultilayerPerceptronClassificationModel(uid = uid, weights = model.weights)
+    m.set(m.layers, model.getLayers)
     if (model.isSet(model.thresholds)) m.setThresholds(model.getThresholds)
     m
   }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/RandomForestClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/RandomForestClassifierOp.scala
@@ -56,7 +56,7 @@ class RandomForestClassifierOp extends SimpleSparkOp[RandomForestClassificationM
         numFeatures = numFeatures,
         numClasses = numClasses,
         _trees = models)
-      m.setNumTrees(models.size)
+      m.set(m.getParam("numTrees"), models.size)
       model.getValue("thresholds").
         map(t => m.setThresholds(t.getDoubleList.toArray)).
         getOrElse(m)
@@ -69,7 +69,7 @@ class RandomForestClassifierOp extends SimpleSparkOp[RandomForestClassificationM
       numFeatures = model.numFeatures,
       numClasses = model.numClasses)
     if (model.isDefined(model.thresholds)) { r.setThresholds(model.getThresholds) }
-    if (model.isDefined(model.numTrees)) { r.setNumTrees(model.getNumTrees) }
+    if (model.isDefined(model.numTrees)) { r.set(r.getParam("numTrees"), model.getNumTrees) }
     r
   }
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ChiSqSelectorOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ChiSqSelectorOp.scala
@@ -30,13 +30,12 @@ class ChiSqSelectorOp extends SimpleSparkOp[ChiSqSelectorModel] {
     override def load(model: Model)
                      (implicit context: BundleContext[SparkBundleContext]): ChiSqSelectorModel = {
       new ChiSqSelectorModel(uid = "",
-        chiSqSelector = new feature.ChiSqSelectorModel(model.value("filter_indices").getLongList.map(_.toInt).toArray))
+        model.value("filter_indices").getLongList.map(_.toInt).toArray)
     }
   }
 
   override def sparkLoad(uid: String, shape: NodeShape, model: ChiSqSelectorModel): ChiSqSelectorModel = {
-    new ChiSqSelectorModel(uid = uid,
-      chiSqSelector = new feature.ChiSqSelectorModel(model.selectedFeatures))
+    new ChiSqSelectorModel(uid = uid, model.selectedFeatures)
   }
 
   override def sparkInputs(obj: ChiSqSelectorModel): Seq[ParamSpec] = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/IDFOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/IDFOp.scala
@@ -5,9 +5,9 @@ import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.{ParamSpec, SimpleParamSpec, SimpleSparkOp, SparkBundleContext}
 import org.apache.spark.ml.feature.IDFModel
-import org.apache.spark.ml.param.Param
-import org.apache.spark.mllib.feature
-import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.mllib.linalg.{Vectors => OldVectors}
+import org.apache.spark.mllib.feature.{IDFModel => OldIDFModel}
 
 /**
   * Created by hollinwilkins on 12/28/16.
@@ -25,13 +25,23 @@ class IDFOp extends SimpleSparkOp[IDFModel] {
 
     override def load(model: Model)
                      (implicit context: BundleContext[SparkBundleContext]): IDFModel = {
-      val idfModel = new feature.IDFModel(Vectors.dense(model.value("idf").getTensor[Double].toArray))
-      new IDFModel(uid = "", idfModel = idfModel)
+      val idf = Vectors.dense(model.value("idf").getTensor[Double].toArray)
+      val oldModel = new OldIDFModel(
+        OldVectors.fromML(idf),
+        docFreq = new Array[Long](idf.size),
+        numDocs = -1L
+      )
+      new IDFModel(uid = "", idfModel = oldModel)
     }
   }
 
   override def sparkLoad(uid: String, shape: NodeShape, model: IDFModel): IDFModel = {
-    new IDFModel(uid = uid, idfModel = new feature.IDFModel(Vectors.dense(model.idf.toArray)))
+    val oldModel = new OldIDFModel(
+      OldVectors.fromML(model.idf),
+      docFreq = new Array[Long](model.idf.size),
+      numDocs = -1L
+    )
+    new IDFModel(uid = uid, idfModel = oldModel)
   }
 
   override def sparkInputs(obj: IDFModel): Seq[ParamSpec] = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/tree/decision/SparkNodeWrapper.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/tree/decision/SparkNodeWrapper.scala
@@ -43,7 +43,7 @@ object SparkNodeWrapper extends NodeWrapper[tree.Node] {
 
   override def leaf(node: LeafNode, withImpurities: Boolean): tree.Node = {
     val calc: ImpurityCalculator = if(withImpurities) {
-      ImpurityCalculator.getCalculator("gini", node.values.toArray)
+      ImpurityCalculator.getCalculator("gini", node.values.toArray, rawCount = -1L)
     } else {
       null
     }

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/classification/MultiLayerPerceptronClassifierParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/classification/MultiLayerPerceptronClassifierParitySpec.scala
@@ -20,4 +20,6 @@ class MultiLayerPerceptronClassifierParitySpec extends SparkParityBase {
       setLayers(Array(4, 5, 4, 3)).
       setFeaturesCol("features").
       setPredictionCol("prediction"))).fit(dataset)
+
+  override protected val unserializedParams: Set[String] = Set("seed")
 }

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/ChiSqSelectorParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/ChiSqSelectorParitySpec.scala
@@ -14,7 +14,7 @@ class ChiSqSelectorParitySpec extends SparkParityBase {
   override val sparkTransformer: Transformer = new Pipeline().setStages(Array(new VectorAssembler().
     setInputCols(Array("dti", "loan_amount")).
     setOutputCol("features"),
-    new ChiSqSelectorModel(uid = "chi_sq_selector", chiSqSelector = new feature.ChiSqSelectorModel(Array(1))).
+    new ChiSqSelectorModel(uid = "chi_sq_selector", Array(1)).
       setFeaturesCol("features").
       setOutputCol("filter_features"))).fit(dataset)
 }

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/MinMaxScalerWithNonDefaultsParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/MinMaxScalerWithNonDefaultsParitySpec.scala
@@ -10,12 +10,14 @@ import org.apache.spark.sql.DataFrame
   */
 class MinMaxScalerWithNonDefaultsParitySpec extends SparkParityBase {
   override val dataset: DataFrame = baseDataset.select("dti", "loan_amount")
-  override val sparkTransformer: Transformer = new Pipeline().setStages(Array(new VectorAssembler().
-    setInputCols(Array("dti", "loan_amount")).
-    setOutputCol("features"),
+  override val sparkTransformer: Transformer = new Pipeline().setStages(Array(
+    new VectorAssembler().
+      setInputCols(Array("dti", "loan_amount")).
+      setOutputCol("features"),
     new MinMaxScaler().
       setInputCol("features").
       setOutputCol("scaled_features").
       setMin(2.0).
-      setMax(4.0))).fit(dataset)
+      setMax(4.0)
+  )).fit(dataset)
 }

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/OneHotEncoderParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/OneHotEncoderParitySpec.scala
@@ -1,7 +1,7 @@
 package org.apache.spark.ml.parity.feature
 
 import org.apache.spark.ml.parity.SparkParityBase
-import org.apache.spark.ml.feature.{OneHotEncoderEstimator, StringIndexer}
+import org.apache.spark.ml.feature.{OneHotEncoder, StringIndexer}
 import org.apache.spark.ml.{Pipeline, Transformer}
 import org.apache.spark.sql.DataFrame
 
@@ -15,7 +15,7 @@ class OneHotEncoderParitySpec extends SparkParityBase {
         .setStages(Array(
           new StringIndexer().setInputCol("state").setOutputCol("state_index"),
           new StringIndexer().setInputCol("state").setOutputCol("state_index2"),
-          new OneHotEncoderEstimator()
+          new OneHotEncoder()
             .setInputCols(Array("state_index", "state_index2"))
             .setOutputCols(Array("state_oh", "state_oh2"))
         ))

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/StopWordsRemoverParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/StopWordsRemoverParitySpec.scala
@@ -1,5 +1,7 @@
 package org.apache.spark.ml.parity.feature
 
+import java.util.Locale
+
 import org.apache.spark.ml.parity.SparkParityBase
 import org.apache.spark.ml.{Pipeline, Transformer}
 import org.apache.spark.ml.feature.{StopWordsRemover, Tokenizer}

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/regression/AFTSurvivalRegressionParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/regression/AFTSurvivalRegressionParitySpec.scala
@@ -1,6 +1,6 @@
 package org.apache.spark.ml.parity.regression
 
-import org.apache.spark.ml.feature.{OneHotEncoderEstimator, StringIndexer, VectorAssembler}
+import org.apache.spark.ml.feature.{OneHotEncoder, StringIndexer, VectorAssembler}
 import org.apache.spark.ml.{Pipeline, Transformer}
 import org.apache.spark.ml.parity.SparkParityBase
 import org.apache.spark.ml.regression.AFTSurvivalRegression
@@ -15,7 +15,7 @@ class AFTSurvivalRegressionParitySpec extends SparkParityBase {
   override val sparkTransformer: Transformer = new Pipeline().setStages(Array(new StringIndexer().
     setInputCol("fico_score_group_fnl").
     setOutputCol("fico_index"),
-    new OneHotEncoderEstimator().
+    new OneHotEncoder().
       setInputCols(Array("fico_index")).
       setOutputCols(Array("fico")),
     new VectorAssembler().

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/regression/GeneralizedLinearRegressionParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/regression/GeneralizedLinearRegressionParitySpec.scala
@@ -1,7 +1,7 @@
 package org.apache.spark.ml.parity.regression
 
-import org.apache.spark.ml.feature.{OneHotEncoderEstimator, StringIndexer, VectorAssembler}
-import org.apache.spark.ml.{Pipeline, Transformer}
+import org.apache.spark.ml.feature.{OneHotEncoder, StringIndexer, VectorAssembler}
+import org.apache.spark.ml.{Pipeline, Transformer, feature}
 import org.apache.spark.ml.parity.SparkParityBase
 import org.apache.spark.ml.regression.GeneralizedLinearRegression
 import org.apache.spark.sql._
@@ -14,7 +14,7 @@ class GeneralizedLinearRegressionParitySpec extends SparkParityBase {
   override val sparkTransformer: Transformer = new Pipeline().setStages(Array(new StringIndexer().
     setInputCol("fico_score_group_fnl").
     setOutputCol("fico_index"),
-    new OneHotEncoderEstimator().
+    new OneHotEncoder().
       setInputCols(Array("fico_index")).
       setOutputCols(Array("fico")),
     new VectorAssembler().

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/regression/LinearRegressionParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/regression/LinearRegressionParitySpec.scala
@@ -1,7 +1,7 @@
 package org.apache.spark.ml.parity.regression
 
 import org.apache.spark.ml.parity.SparkParityBase
-import org.apache.spark.ml.feature.{OneHotEncoderEstimator, StringIndexer, VectorAssembler}
+import org.apache.spark.ml.feature.{OneHotEncoder, StringIndexer, VectorAssembler}
 import org.apache.spark.ml.regression.LinearRegression
 import org.apache.spark.ml.{Pipeline, Transformer}
 import org.apache.spark.sql.DataFrame
@@ -14,7 +14,7 @@ class LinearRegressionParitySpec extends SparkParityBase {
   override val sparkTransformer: Transformer = new Pipeline().setStages(Array(new StringIndexer().
     setInputCol("fico_score_group_fnl").
     setOutputCol("fico_index"),
-    new OneHotEncoderEstimator().
+    new OneHotEncoder().
       setInputCols(Array("fico_index")).
       setOutputCols(Array("fico")),
     new VectorAssembler().

--- a/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/XgbConverters.scala
+++ b/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/XgbConverters.scala
@@ -13,10 +13,10 @@ trait XgbConverters {
     def asXGB: DMatrix = {
       vector match {
         case SparseVector(_, indices, values) =>
-          new DMatrix(Iterator(new LabeledPoint(0.0f, indices, values.map(_.toFloat))))
+          new DMatrix(Iterator(new LabeledPoint(0.0f, values.size, indices, values.map(_.toFloat))))
 
         case DenseVector(values) =>
-          new DMatrix(Iterator(new LabeledPoint(0.0f, null, values.map(_.toFloat))))
+          new DMatrix(Iterator(new LabeledPoint(0.0f, values.size, null, values.map(_.toFloat))))
       }
     }
 
@@ -34,10 +34,10 @@ trait XgbConverters {
     def asXGB: DMatrix = {
       tensor match {
         case SparseTensor(indices, values, _) =>
-          new DMatrix(Iterator(new LabeledPoint(0.0f, indices.map(_.head).toArray, values.map(_.toFloat))))
+          new DMatrix(Iterator(new LabeledPoint(0.0f, values.size, indices.map(_.head).toArray, values.map(_.toFloat))))
 
         case DenseTensor(_, _) =>
-          new DMatrix(Iterator(new LabeledPoint(0.0f, null, tensor.toDense.rawValues.map(_.toFloat))))
+          new DMatrix(Iterator(new LabeledPoint(0.0f, tensor.toDense.size, null, tensor.toDense.rawValues.map(_.toFloat))))
       }
     }
 

--- a/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/XGBoostPredictorClassificationModelParitySpec.scala
+++ b/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/XGBoostPredictorClassificationModelParitySpec.scala
@@ -38,7 +38,8 @@ class XGBoostPredictorClassificationModelParitySpec extends FunSpec
         assert(
           almostEqualSequences(
             Seq(boosterProbability.values),
-            Seq(mleapResult.dataset.head.getTensor[Double](mleapProbabilityColIndex).toArray)
+            Seq(mleapResult.dataset.head.getTensor[Double](mleapProbabilityColIndex).toArray),
+            precision = 1e-6
           )
         )
     }
@@ -58,7 +59,9 @@ class XGBoostPredictorClassificationModelParitySpec extends FunSpec
         assert(
           almostEqualSequences(
             Seq(row1.getTensor[Double](probabilityIndex).toArray),
-            Seq(row2.getTensor[Double](probabilityIndex).toArray)))
+            Seq(row2.getTensor[Double](probabilityIndex).toArray),
+            precision = 1e-6
+          ))
       }
     }
   }

--- a/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
+++ b/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
@@ -54,7 +54,7 @@ class XGBoostClassificationModelOp extends SimpleSparkOp[XGBoostClassificationMo
 
       model.getValue("thresholds").map(o => xgb.setThresholds(o.getDoubleList.toArray))
       model.getValue("missing").map(o => xgb.setMissing(o.getFloat))
-      model.getValue("allow_non_zero_for_missing").map(o => xgb.setAllowZeroForMissingValue(o.getBoolean))
+      model.getValue("allow_non_zero_for_missing").map(o => xgb.setAllowNonZeroForMissing(o.getBoolean))
       model.getValue("infer_batch_size").map(o => xgb.setInferBatchSize(o.getInt))
       model.getValue("use_external_memory").map(o => xgb.set(xgb.useExternalMemory, o.getBoolean))
       xgb
@@ -67,7 +67,7 @@ class XGBoostClassificationModelOp extends SimpleSparkOp[XGBoostClassificationMo
     val xgb = new XGBoostClassificationModel(uid, model.numClasses, model._booster)
     if(model.isSet(model.thresholds)) xgb.setThresholds(model.getOrDefault(model.thresholds))
     if(model.isSet(model.missing)) xgb.setMissing(model.getOrDefault(model.missing))
-    if(model.isSet(model.allowNonZeroForMissing)) xgb.setAllowZeroForMissingValue(model.getOrDefault(model.allowNonZeroForMissing))
+    if(model.isSet(model.allowNonZeroForMissing)) xgb.setAllowNonZeroForMissing(model.getOrDefault(model.allowNonZeroForMissing))
     if(model.isSet(model.inferBatchSize)) xgb.setInferBatchSize(model.getOrDefault(model.inferBatchSize))
     if(model.isSet(model.treeLimit)) xgb.setTreeLimit(model.getOrDefault(model.treeLimit))
     if(model.isSet(model.useExternalMemory)) xgb.set(xgb.useExternalMemory, model.getOrDefault(model.useExternalMemory))

--- a/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelOp.scala
+++ b/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelOp.scala
@@ -47,7 +47,7 @@ class XGBoostRegressionModelOp extends SimpleSparkOp[XGBoostRegressionModel] {
         setTreeLimit(model.value("tree_limit").getInt)
 
       model.getValue("missing").map(o => xgb.setMissing(o.getFloat))
-      model.getValue("allow_non_zero_for_missing").map(o => xgb.setAllowZeroForMissingValue(o.getBoolean))
+      model.getValue("allow_non_zero_for_missing").map(o => xgb.setAllowNonZeroForMissing(o.getBoolean))
       model.getValue("infer_batch_size").map(o => xgb.setInferBatchSize(o.getInt))
       model.getValue("use_external_memory").map(o => xgb.set(xgb.useExternalMemory, o.getBoolean))
       xgb
@@ -59,7 +59,7 @@ class XGBoostRegressionModelOp extends SimpleSparkOp[XGBoostRegressionModel] {
                          model: XGBoostRegressionModel): XGBoostRegressionModel = {
     val xgb = new XGBoostRegressionModel(uid, model._booster)
     if(model.isSet(model.missing)) xgb.setMissing(model.getOrDefault(model.missing))
-    if(model.isSet(model.allowNonZeroForMissing)) xgb.setAllowZeroForMissingValue(model.getOrDefault(model.allowNonZeroForMissing))
+    if(model.isSet(model.allowNonZeroForMissing)) xgb.setAllowNonZeroForMissing(model.getOrDefault(model.allowNonZeroForMissing))
     if(model.isSet(model.inferBatchSize)) xgb.setInferBatchSize(model.getOrDefault(model.inferBatchSize))
     if(model.isSet(model.treeLimit)) xgb.setTreeLimit(model.getOrDefault(model.treeLimit))
     if(model.isSet(model.useExternalMemory)) xgb.set(xgb.useExternalMemory, model.getOrDefault(model.useExternalMemory))

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -16,7 +16,7 @@ object Common {
   lazy val defaultSettings = buildSettings ++ sonatypeSettings
 
   lazy val buildSettings: Seq[Def.Setting[_]] = Seq(
-    scalaVersion := "2.11.12",
+    scalaVersion := "2.12.10",
     crossScalaVersions := Seq("2.11.12", "2.12.10"),
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
     fork in Test := true,
@@ -28,7 +28,7 @@ object Common {
       if(isSnapshot.value) {
         Seq(
           "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
-          "ASF Snapshots" at "https://repository.apache.org/content/groups/snapshots"
+          "ASF spark" at "https://repository.apache.org/content/repositories/orgapachespark-1341" // Apache spark repo
         )
       } else {
         Seq()

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -17,7 +17,7 @@ object Common {
 
   lazy val buildSettings: Seq[Def.Setting[_]] = Seq(
     scalaVersion := "2.12.10",
-    crossScalaVersions := Seq("2.11.12", "2.12.10"),
+    crossScalaVersions := Seq("2.12.10"),
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
     fork in Test := true,
     javaOptions in test += sys.env.getOrElse("JVM_OPTS", ""),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,17 +6,17 @@ import Keys._
 object Dependencies {
   import DependencyHelpers._
 
-  val sparkVersion = "3.0.0"
+  val sparkVersion = "3.1.1"
   val scalaTestVersion = "3.0.8"
-  val akkaVersion = "2.5.12"
-  val akkaHttpVersion = "10.0.3"
+  val akkaVersion = "2.6.14"
+  val akkaHttpVersion = "10.2.4"
   val springBootVersion = "2.0.4.RELEASE"
   lazy val logbackVersion = "1.2.3"
   lazy val loggingVersion = "3.9.0"
   lazy val slf4jVersion = "1.7.25"
   lazy val awsSdkVersion = "1.11.349"
   val tensorflowVersion = "1.11.0"
-  val xgboostVersion = "1.0.0"
+  val xgboostVersion = "1.3.1"
   val hadoopVersion = "2.7.4" // matches spark version
   val kryoVersion = "4.0.2"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,7 +72,7 @@ object Dependencies {
     val kryo = "com.esotericsoftware" % "kryo" % kryoVersion
     // exclude jar "com.esotericsoftware.kryo % kryo" which conflicts with spark 3.0
     val xgboostDep = "ml.dmlc" %% "xgboost4j" % xgboostVersion exclude("com.esotericsoftware.kryo", "kryo")
-    val xgboostPredictorDep = "biz.k11i" % "xgboost-predictor" % "0.3.1" exclude("com.esotericsoftware.kryo", "kryo")
+    val xgboostPredictorDep = "ai.h2o" % "xgboost-predictor" % "0.3.17" exclude("com.esotericsoftware.kryo", "kryo")
     val xgboostSparkDep = "ml.dmlc" %% "xgboost4j-spark" % xgboostVersion exclude("com.esotericsoftware.kryo", "kryo")
 
     val hadoop = "org.apache.hadoop" % "hadoop-client" % hadoopVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,8 +6,8 @@ import Keys._
 object Dependencies {
   import DependencyHelpers._
 
-  val sparkVersion = "2.4.5"
-  val scalaTestVersion = "3.0.3"
+  val sparkVersion = "3.0.0"
+  val scalaTestVersion = "3.0.8"
   val akkaVersion = "2.5.12"
   val akkaHttpVersion = "10.0.3"
   val springBootVersion = "2.0.4.RELEASE"
@@ -17,8 +17,8 @@ object Dependencies {
   lazy val awsSdkVersion = "1.11.349"
   val tensorflowVersion = "1.11.0"
   val xgboostVersion = "1.0.0"
-  val hadoopVersion = "2.6.5" // matches spark version
-  val kryoVersion = "4.0.2" // Remove upon upgrading to xgboost 1.1.1
+  val hadoopVersion = "2.7.4" // matches spark version
+  val kryoVersion = "4.0.2"
 
   object Compile {
     val sparkMllibLocal = "org.apache.spark" %% "spark-mllib-local" % sparkVersion excludeAll(ExclusionRule(organization = "org.scalatest"))
@@ -70,10 +70,11 @@ object Dependencies {
     )
 
     val kryo = "com.esotericsoftware" % "kryo" % kryoVersion
+    // exclude jar "com.esotericsoftware.kryo % kryo" which conflicts with spark 3.0
     val xgboostDep = "ml.dmlc" %% "xgboost4j" % xgboostVersion exclude("com.esotericsoftware.kryo", "kryo")
-    val xgboostPredictorDep = "ai.h2o" % "xgboost-predictor" % "0.3.17" exclude("com.esotericsoftware.kryo", "kryo")
-
+    val xgboostPredictorDep = "biz.k11i" % "xgboost-predictor" % "0.3.1" exclude("com.esotericsoftware.kryo", "kryo")
     val xgboostSparkDep = "ml.dmlc" %% "xgboost4j-spark" % xgboostVersion exclude("com.esotericsoftware.kryo", "kryo")
+
     val hadoop = "org.apache.hadoop" % "hadoop-client" % hadoopVersion
   }
 

--- a/python/mleap/pyspark/feature/string_map.py
+++ b/python/mleap/pyspark/feature/string_map.py
@@ -85,6 +85,18 @@ class StringMap(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, Java
         """
         return self._set(outputCol=value)
 
+    def setInputCol(self, value):
+        """
+        Sets the value of :py:attr:`inputCol`.
+        """
+        return self._set(inputCol=value)
+
+    def setOutputCol(self, value):
+        """
+        Sets the value of :py:attr:`outputCol`.
+        """
+        return self._set(outputCol=value)
+
     @classmethod
     def from_dataframe(cls, labels_df, inputCol, outputCol, handleInvalid='error', defaultValue=0.0):
         """

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -4,4 +4,4 @@ coverage<5.0.0
 ipdb
 nose
 nose-exclude>=0.5.0
-pyspark==3.0.0
+pyspark==3.1.1

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,6 +1,7 @@
+-f https://dist.apache.org/repos/dist/dev/spark/v3.0.0-rc1-bin/
 -r requirements.txt
 coverage<5.0.0
 ipdb
 nose
 nose-exclude>=0.5.0
-pyspark<=2.4.5
+pyspark==3.0.0

--- a/travis/travis.sh
+++ b/travis/travis.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [[ $TRAVIS_BRANCH == 'master' ]] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+  source travis/extract.sh
+  source travis/docker.sh
+  # TODO: Add back xgboost test when xgboost unit test fixed with spark 3.0
+  sbt "test" "mleap-executor-tests/test" "mleap-benchmark/test" "publishSigned" "mleap-serving/docker:publish" "mleap-spring-boot/docker:publish"
+else
+  # TODO: Add back xgboost test when xgboost unit test fixed with spark 3.0
+  sbt "test" "mleap-executor-tests/test" "mleap-benchmark/test"
+fi

--- a/travis/travis.sh
+++ b/travis/travis.sh
@@ -3,9 +3,7 @@
 if [[ $TRAVIS_BRANCH == 'master' ]] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
   source travis/extract.sh
   source travis/docker.sh
-  # TODO: Add back xgboost test when xgboost unit test fixed with spark 3.0
-  sbt "test" "mleap-executor-tests/test" "mleap-benchmark/test" "publishSigned" "mleap-serving/docker:publish" "mleap-spring-boot/docker:publish"
+  sbt "+ test" "+ mleap-executor-tests/test" "+ mleap-benchmark/test" "mleap-xgboost-runtime/test" "mleap-xgboost-spark/test" "+ publishSigned" "mleap-xgboost-runtime/publishSigned" "mleap-xgboost-spark/publishSigned" "mleap-serving/docker:publish" "mleap-spring-boot/docker:publish" 2>/dev/null
 else
-  # TODO: Add back xgboost test when xgboost unit test fixed with spark 3.0
-  sbt "test" "mleap-executor-tests/test" "mleap-benchmark/test"
+  sbt "+ test" "+ mleap-executor-tests/test" "+ mleap-benchmark/test" "mleap-xgboost-runtime/test" "mleap-xgboost-spark/test" 2>/dev/null
 fi


### PR DESCRIPTION
This branch provides the following dependency upgrades:
- scala 2.11 -> 2.12
- spark 2.4.5 -> 3.1.1
- xgboost 1.0.0 -> 1.3.1
- akka 2.5.12 -> 2.6.14
- akka HTTP 10.0.3 -> 10.2.4
- hadoop 2.6.5 -> 2.7.4