### PR TITLE
Improved CountVectorizer Serialization Error

### DIFF
--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/CountVectorizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/CountVectorizerOp.scala
@@ -18,6 +18,9 @@ class CountVectorizerOp extends SimpleSparkOp[CountVectorizerModel] {
 
     override def store(model: Model, obj: CountVectorizerModel)
                       (implicit context: BundleContext[SparkBundleContext]): Model = {
+      if (obj.vocabulary contains null) {
+        throw new RuntimeException("MLeap cannot serialize CountVectorizerModel vocabularies containing `null`")
+      }
       model.withValue("vocabulary", Value.stringList(obj.vocabulary)).
         withValue("binary", Value.boolean(obj.getBinary)).
         withValue("min_tf", Value.double(obj.getMinTF))

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSerializationSpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSerializationSpec.scala
@@ -1,0 +1,51 @@
+package org.apache.spark.ml.feature
+
+import java.io.File
+import java.nio.file.{Files, Path}
+import ml.combust.bundle.BundleFile
+import ml.combust.bundle.serializer.SerializationFormat
+import ml.combust.mleap.spark.SparkSupport._
+import org.apache.spark.ml.bundle.SparkBundleContext
+import org.apache.spark.ml.{Transformer, Pipeline}
+import org.apache.spark.sql._
+import org.apache.spark.sql.types._
+import org.scalatest.FunSpec
+import resource._
+
+class CountVectorizerSerializationSpec extends FunSpec {
+  val spark = SparkSession.builder().appName("CountVectorizerSerializationSpec").master("local[2]").getOrCreate()
+  val df = spark.createDataFrame(
+    rows = java.util.Arrays.asList(
+      Row(Array("a", "b", "a", "a", "b", null)),
+      Row(Array("b", null, null))
+    ),
+    schema = StructType(Seq(
+      StructField("feature", ArrayType(StringType, true), false)
+    ))
+  )
+
+  it("raises an informative error given null vocabulary") {
+    val sparkTransformer: Transformer = new Pipeline().setStages(Array(
+      new CountVectorizer()
+        .setInputCol("feature")
+        .setOutputCol("feature_counts")
+    )).fit(df)
+    val transformedDF = sparkTransformer.transform(df)
+
+    implicit val context = SparkBundleContext().withDataset(transformedDF)
+    val tempDirPath = {
+      val temp: Path = Files.createTempDirectory("CountVectorizerSerializationSpec")
+      temp.toFile.deleteOnExit()
+      temp.toAbsolutePath
+    }
+    val file = new File(s"${tempDirPath}/${getClass.getName}.zip")
+
+    val caughtException = intercept[RuntimeException] {
+      for (bf <- managed(BundleFile(file))) {
+        sparkTransformer.writeBundle.format(SerializationFormat.Json).save(bf).get
+      }
+    }
+    assert(caughtException.getMessage == "MLeap cannot serialize CountVectorizerModel vocabularies containing `null`")
+  }
+
+}

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/CountVectorizerParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/CountVectorizerParitySpec.scala
@@ -10,6 +10,7 @@ import org.apache.spark.sql._
   */
 class CountVectorizerParitySpec extends SparkParityBase {
   override val dataset: DataFrame = baseDataset.select("loan_title")
+  throw new RuntimeException(dataset.schema)
   override val sparkTransformer: Transformer = new Pipeline().setStages(Array(new Tokenizer().
     setInputCol("loan_title").
     setOutputCol("loan_title_tokens"),

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/CountVectorizerParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/feature/CountVectorizerParitySpec.scala
@@ -10,7 +10,6 @@ import org.apache.spark.sql._
   */
 class CountVectorizerParitySpec extends SparkParityBase {
   override val dataset: DataFrame = baseDataset.select("loan_title")
-  throw new RuntimeException(dataset.schema)
   override val sparkTransformer: Transformer = new Pipeline().setStages(Array(new Tokenizer().
     setInputCol("loan_title").
     setOutputCol("loan_title_tokens"),


### PR DESCRIPTION
When serializing a `CountVectorizerModel` that has been fit on a `null` vocabulary, I currently get the following error:

https://pastebin.com/Y2Hc1kud

It's cryptic to figure out that `java.lang.IllegalArgumentException: requirement failed` in `Predef.scala` means that you cannot serialize a `StringList` containing `null`, so I improved the error messaging surrounding that