### PR TITLE
Fix (List <-> Tensor) Casting When Base Types Match

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,11 @@
 
 ### Other Changes
 
+# Release 0.18.1
+
+### Bug Fixes
+- Fix (List <-> Tensor) casting for identical base type
+
 # Release 0.18.0
 
 ### Breaking Changes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,7 +13,7 @@
 # Release 0.18.1
 
 ### Bug Fixes
-- Fix (List <-> Tensor) casting for identical base type
+- Fix (List <-> Tensor) casting when base types match
 
 # Release 0.18.0
 

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/types/Casting.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/types/Casting.scala
@@ -214,9 +214,11 @@ object Casting {
         }
       case (_: TensorType, _: ListType) =>
         baseCast(from.base, to.base).map {
-          _.map {
-            c => (v: Any) => v.asInstanceOf[Tensor[_]].rawValues.toList.map(c)
+          _.flatMap {
+            c => Try((v: Any) => v.asInstanceOf[Tensor[_]].rawValues.toList.map(c))
           }
+        }.orElse {
+          Some(Try((v: Any) => v.asInstanceOf[Tensor[_]].rawValues.toList))
         }
       case (_: TensorType, _: TensorType) =>
         baseCast(from.base, to.base).map {

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/types/Casting.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/types/Casting.scala
@@ -153,8 +153,8 @@ object Casting {
         }
       case (_: ListType, _: TensorType) =>
         baseCast(from.base, to.base).map {
-          _.map {
-            c =>
+          _.flatMap {
+            c => Try {
               to.base match {
                 case BasicType.Boolean =>
                   val cc = c.asInstanceOf[(Any) => Boolean]
@@ -184,6 +184,32 @@ object Casting {
                   val cc = c.asInstanceOf[(Any) => ByteString]
                   (v: Any) => Tensor.denseVector(v.asInstanceOf[Seq[_]].map(cc).toArray)
               }
+            }
+          }
+        }.orElse {
+          Some {
+            Try {
+              from.base match {
+                case BasicType.Boolean =>
+                  (v: Any) => Tensor.denseVector(v.asInstanceOf[Seq[_]].map(_.asInstanceOf[Boolean]).toArray)
+                case BasicType.Byte =>
+                  (v: Any) => Tensor.denseVector(v.asInstanceOf[Seq[_]].map(_.asInstanceOf[Byte]).toArray)
+                case BasicType.Short =>
+                  (v: Any) => Tensor.denseVector(v.asInstanceOf[Seq[_]].map(_.asInstanceOf[Short]).toArray)
+                case BasicType.Int =>
+                  (v: Any) => Tensor.denseVector(v.asInstanceOf[Seq[_]].map(_.asInstanceOf[Int]).toArray)
+                case BasicType.Long =>
+                  (v: Any) => Tensor.denseVector(v.asInstanceOf[Seq[_]].map(_.asInstanceOf[Long]).toArray)
+                case BasicType.Float =>
+                  (v: Any) => Tensor.denseVector(v.asInstanceOf[Seq[_]].map(_.asInstanceOf[Float]).toArray)
+                case BasicType.Double =>
+                  (v: Any) => Tensor.denseVector(v.asInstanceOf[Seq[_]].map(_.asInstanceOf[Double]).toArray)
+                case BasicType.String =>
+                  (v: Any) => Tensor.denseVector(v.asInstanceOf[Seq[_]].map(_.asInstanceOf[String]).toArray)
+                case BasicType.ByteString =>
+                  (v: Any) => Tensor.denseVector(v.asInstanceOf[Seq[_]].map(_.asInstanceOf[ByteString]).toArray)
+              }
+            }
           }
         }
       case (_: TensorType, _: ListType) =>

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/types/CastingSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/types/CastingSpec.scala
@@ -30,6 +30,7 @@ class CastingSpec extends FunSpec {
     (BasicType.Boolean, BasicType.Double, true, 1.0),
     (BasicType.Boolean, BasicType.String, true, "1"),
 
+    (BasicType.Byte, BasicType.Byte, 7.toByte, 7.toByte),
     (BasicType.Byte, BasicType.Boolean, 7.toByte, true),
     (BasicType.Byte, BasicType.Boolean, 0.toByte, false),
     (BasicType.Byte, BasicType.Short, 13.toByte, 13.toShort),
@@ -39,6 +40,7 @@ class CastingSpec extends FunSpec {
     (BasicType.Byte, BasicType.Double, 13.toByte, 13.toDouble),
     (BasicType.Byte, BasicType.String, 13.toByte, 13.toString),
 
+    (BasicType.Short, BasicType.Short, 7.toShort, 7.toShort),
     (BasicType.Short, BasicType.Boolean, 7.toShort, true),
     (BasicType.Short, BasicType.Boolean, 0.toShort, false),
     (BasicType.Short, BasicType.Byte, 13.toShort, 13.toByte),
@@ -48,6 +50,7 @@ class CastingSpec extends FunSpec {
     (BasicType.Short, BasicType.Double, 13.toShort, 13.toDouble),
     (BasicType.Short, BasicType.String, 13.toShort, 13.toString),
 
+    (BasicType.Int, BasicType.Int, 7, 7),
     (BasicType.Int, BasicType.Boolean, 7, true),
     (BasicType.Int, BasicType.Boolean, 0, false),
     (BasicType.Int, BasicType.Byte, 13, 13.toByte),
@@ -57,6 +60,7 @@ class CastingSpec extends FunSpec {
     (BasicType.Int, BasicType.Double, 13, 13.toDouble),
     (BasicType.Int, BasicType.String, 13, 13.toString),
 
+    (BasicType.Long, BasicType.Long, 7.toLong, 7.toLong),
     (BasicType.Long, BasicType.Boolean, 7.toLong, true),
     (BasicType.Long, BasicType.Boolean, 0.toLong, false),
     (BasicType.Long, BasicType.Byte, 13.toLong, 13.toByte),
@@ -66,6 +70,7 @@ class CastingSpec extends FunSpec {
     (BasicType.Long, BasicType.Double, 13.toLong, 13.toDouble),
     (BasicType.Long, BasicType.String, 13.toLong, 13.toString),
 
+    (BasicType.Float, BasicType.Float, 7.0.toFloat, 7.0.toFloat),
     (BasicType.Float, BasicType.Boolean, 7.0.toFloat, true),
     (BasicType.Float, BasicType.Boolean, 0.0.toFloat, false),
     (BasicType.Float, BasicType.Byte, 13.0.toFloat, 13.0.toFloat.toByte),
@@ -75,6 +80,7 @@ class CastingSpec extends FunSpec {
     (BasicType.Float, BasicType.Double, 13.0.toFloat, 13.0),
     (BasicType.Float, BasicType.String, 13.toFloat, 13.0.toFloat.toString),
 
+    (BasicType.Double, BasicType.Double, 7.0, 7.0),
     (BasicType.Double, BasicType.Boolean, 7.0, true),
     (BasicType.Double, BasicType.Boolean, 0.0, false),
     (BasicType.Double, BasicType.Byte, 13.0, 13.0.toByte),
@@ -84,6 +90,7 @@ class CastingSpec extends FunSpec {
     (BasicType.Double, BasicType.Float, 13.0, 13.0.toFloat),
     (BasicType.Double, BasicType.String, 13.0, 13.0.toString),
 
+    (BasicType.String, BasicType.String, "hello", "hello"),
     (BasicType.String, BasicType.Boolean, "true", true),
     (BasicType.String, BasicType.Boolean, "false", false),
     (BasicType.String, BasicType.Boolean, "", false),
@@ -173,13 +180,13 @@ class CastingSpec extends FunSpec {
         val fromListTensor = createTensor(from, Seq(fromValue, fromValue, fromValue))
         val expectedList = Seq(expectedValue, expectedValue, expectedValue)
 
-        val c = Casting.cast(TensorType(from), TensorType(to)).get.get
-        val oc = Casting.cast(TensorType(from), TensorType(to).nonNullable).get.get
-        val co = Casting.cast(TensorType(from).nonNullable, TensorType(to)).get.get
-        val oco = Casting.cast(TensorType(from), TensorType(to)).get.get
-        val tc = Casting.cast(ScalarType(from), TensorType(to, Some(Seq()))).get.get
-        val ct = Casting.cast(TensorType(from, Some(Seq())), ScalarType(to)).get.get
-        val lct = Casting.cast(TensorType(from, Some(Seq(expectedList.length))), ListType(to)).get.get
+        val c = Casting.cast(TensorType(from), TensorType(to)).getOrElse(Success((v: Any) => v)).get
+        val oc = Casting.cast(TensorType(from), TensorType(to).nonNullable).getOrElse(Success((v: Any) => v)).get
+        val co = Casting.cast(TensorType(from).nonNullable, TensorType(to)).getOrElse(Success((v: Any) => v)).get
+        val oco = Casting.cast(TensorType(from), TensorType(to)).getOrElse(Success((v: Any) => v)).get
+        val tc = Casting.cast(ScalarType(from), TensorType(to, Some(Seq()))).getOrElse(Success((v: Any) => v)).get
+        val ct = Casting.cast(TensorType(from, Some(Seq())), ScalarType(to)).getOrElse(Success((v: Any) => v)).get
+        val lct = Casting.cast(TensorType(from, Some(Seq(expectedList.length))), ListType(to)).getOrElse(Success((v: Any) => v)).get
 
         assert(c(fromTensor) == expectedTensor)
         assertThrows[NullPointerException](oc(null))

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/types/CastingSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/types/CastingSpec.scala
@@ -2,6 +2,7 @@ package ml.combust.mleap.core.types
 
 import ml.combust.mleap.tensor.{ByteString, Tensor}
 import org.scalatest.FunSpec
+import scala.util.Success
 
 /**
   * Created by hollinwilkins on 9/18/17.
@@ -20,6 +21,7 @@ class CastingSpec extends FunSpec {
   }
 
   val castTests = Seq(
+    (BasicType.Boolean, BasicType.Boolean, true, true),
     (BasicType.Boolean, BasicType.Byte, true, 1.toByte),
     (BasicType.Boolean, BasicType.Short, true, 1.toShort),
     (BasicType.Boolean, BasicType.Int, true, 1),
@@ -132,10 +134,10 @@ class CastingSpec extends FunSpec {
   for(((from, to, fromValue, expectedValue), i) <- castTests.zipWithIndex) {
     describe(s"cast from $from to $to - $i") {
       it("casts the scalar") {
-        val c = Casting.cast(ScalarType(from), ScalarType(to)).get.get
-        val oc = Casting.cast(ScalarType(from), ScalarType(to).nonNullable).get.get
-        val co = Casting.cast(ScalarType(from).nonNullable, ScalarType(to)).get.get
-        val oco = Casting.cast(ScalarType(from), ScalarType(to)).get.get
+        val c = Casting.cast(ScalarType(from), ScalarType(to)).getOrElse(Success((v: Any) => v)).get
+        val oc = Casting.cast(ScalarType(from), ScalarType(to).nonNullable).getOrElse(Success((v: Any) => v)).get
+        val co = Casting.cast(ScalarType(from).nonNullable, ScalarType(to)).getOrElse(Success((v: Any) => v)).get
+        val oco = Casting.cast(ScalarType(from), ScalarType(to)).getOrElse(Success((v: Any) => v)).get
 
         assert(c(fromValue) == expectedValue)
         assertThrows[NullPointerException](oc(null))
@@ -148,11 +150,11 @@ class CastingSpec extends FunSpec {
         val expectedList = Seq(expectedValue, expectedValue, expectedValue)
         val expectedTensor = createTensor(to, expectedList)
 
-        val c = Casting.cast(ListType(from), ListType(to)).get.get
-        val oc = Casting.cast(ListType(from), ListType(to).nonNullable).get.get
-        val co = Casting.cast(ListType(from).nonNullable, ListType(to)).get.get
-        val oco = Casting.cast(ListType(from), ListType(to)).get.get
-        val tcl = Casting.cast(ListType(from), TensorType(to, Some(Seq(expectedList.length)))).get.get
+        val c = Casting.cast(ListType(from), ListType(to)).getOrElse(Success((v: Any) => v)).get
+        val oc = Casting.cast(ListType(from), ListType(to).nonNullable).getOrElse(Success((v: Any) => v)).get
+        val co = Casting.cast(ListType(from).nonNullable, ListType(to)).getOrElse(Success((v: Any) => v)).get
+        val oco = Casting.cast(ListType(from), ListType(to)).getOrElse(Success((v: Any) => v)).get
+        val tcl = Casting.cast(ListType(from), TensorType(to, Some(Seq(expectedList.length)))).getOrElse(Success((v: Any) => v)).get
 
         assert(c(fromList) == expectedList)
         assertThrows[NullPointerException](oc(null))

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/types/CastingSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/types/CastingSpec.scala
@@ -199,4 +199,17 @@ class CastingSpec extends FunSpec {
 
     }
   }
+
+  it("SparseTensor cannot be cast to List") {
+    val tensor = Tensor.create[Double](Array(42.0), Seq(2), Some(Seq(Seq(0))))
+    val cast1 = Casting.cast(TensorType(BasicType.Double), ListType(BasicType.Double)).get.get
+    val cast2 = Casting.cast(TensorType(BasicType.Double), ListType(BasicType.Float)).get.get
+    assertThrows[IllegalArgumentException] {
+      cast1(tensor)
+    }
+    assertThrows[IllegalArgumentException] {
+      cast2(tensor)
+    }
+  }
+
 }


### PR DESCRIPTION
I tried to use my previous casting PR and realized that:

```
Casting.cast(ListType(BasicType.Double), TensorType(BasicType.Double, Some(Seq())))
```

returns `None`. I also noticed that our casting tests lacked coverage for cases when `from.base == to.base`, so I added that in as well