### PR TITLE
Fix Legacy Model Deserialization

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@
 
 ### Bug Fixes
 - Fix (List <-> Tensor) casting when base types match
+- Fix deserialization of legacy Spark 2 models
 
 # Release 0.18.0
 

--- a/mleap-spark-base/src/main/scala/org/apache/spark/ml/bundle/MultiInOutFormatSparkOp.scala
+++ b/mleap-spark-base/src/main/scala/org/apache/spark/ml/bundle/MultiInOutFormatSparkOp.scala
@@ -30,13 +30,13 @@ trait MultiInOutFormatSparkOp[
     val outputCol = model.getValue("output_col").map(_.getString)
     val outputCols = model.getValue("output_cols").map(_.getStringList)
     val result: N = (inputCol, inputCols) match {
-      case (None, None) => throw new UnsupportedOperationException("No inputs found.")
+      case (None, None) => obj
       case (Some(col), None) => obj.set(obj.inputCol, col)
       case (None, Some(cols)) => obj.set(obj.inputCols, cols.toArray)
       case (_, _) => throw new UnsupportedOperationException("Cannot use both inputCol and inputCols")
     }
     (outputCol, outputCols) match {
-      case (None, None) => throw new UnsupportedOperationException("No outputs found.")
+      case (None, None) => obj
       case (Some(col), None) => result.set(result.outputCol, col)
       case (None, Some(cols)) => result.set(result.outputCols, cols.toArray)
       case (_, _) => throw new UnsupportedOperationException("Cannot use both outputCol and outputCols")
@@ -44,7 +44,6 @@ trait MultiInOutFormatSparkOp[
   }
 
   def sparkInputs(obj: N): Seq[ParamSpec] = {
-    ParamValidators.checkSingleVsMultiColumnParams(obj, Seq(obj.inputCol), Seq(obj.inputCols))
     if (obj.isSet(obj.inputCols)) {
       Seq(ParamSpec("input", obj.inputCols))
     } else{
@@ -53,7 +52,6 @@ trait MultiInOutFormatSparkOp[
   }
 
   def sparkOutputs(obj: N): Seq[ParamSpec] = {
-    ParamValidators.checkSingleVsMultiColumnParams(obj, Seq(obj.outputCol), Seq(obj.outputCols))
     if (obj.isSet(obj.outputCols)) {
       Seq(ParamSpec("output", obj.outputCols))
     } else{


### PR DESCRIPTION
Legacy models do not have input/output param information saved in their `model.json` file,
so we cannot raise an exception when this information is missing

This new change lets `Model` deserialization go through without needing to set either `inputCol` or `outputCol`, and leaves it up to `NodeShape` deserialization in the case of legacy models

This change has been tested locally with a legacy model, and everything seems to work now in our e2etests