### PR TITLE
Upgrade to xgboost v1.3.1

### DIFF
--- a/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/XgbConverters.scala
+++ b/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/XgbConverters.scala
@@ -13,10 +13,10 @@ trait XgbConverters {
     def asXGB: DMatrix = {
       vector match {
         case SparseVector(_, indices, values) =>
-          new DMatrix(Iterator(new LabeledPoint(0.0f, indices, values.map(_.toFloat))))
+          new DMatrix(Iterator(new LabeledPoint(0.0f, vector.size, indices, values.map(_.toFloat))))
 
         case DenseVector(values) =>
-          new DMatrix(Iterator(new LabeledPoint(0.0f, null, values.map(_.toFloat))))
+          new DMatrix(Iterator(new LabeledPoint(0.0f, vector.size, null, values.map(_.toFloat))))
       }
     }
 
@@ -34,10 +34,10 @@ trait XgbConverters {
     def asXGB: DMatrix = {
       tensor match {
         case SparseTensor(indices, values, _) =>
-          new DMatrix(Iterator(new LabeledPoint(0.0f, indices.map(_.head).toArray, values.map(_.toFloat))))
+          new DMatrix(Iterator(new LabeledPoint(0.0f, tensor.size, indices.map(_.head).toArray, values.map(_.toFloat))))
 
-        case DenseTensor(_, _) =>
-          new DMatrix(Iterator(new LabeledPoint(0.0f, null, tensor.toDense.rawValues.map(_.toFloat))))
+        case DenseTensor(values, _) =>
+          new DMatrix(Iterator(new LabeledPoint(0.0f, tensor.size, null, tensor.toDense.rawValues.map(_.toFloat))))
       }
     }
 

--- a/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/testing/FloatingPointApproximations.scala
+++ b/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/testing/FloatingPointApproximations.scala
@@ -3,7 +3,7 @@ package ml.combust.mleap.xgboost.runtime.testing
 
 trait FloatingPointApproximations {
 
-  val DefaultMinimumPrecision = 1e-7
+  val DefaultMinimumPrecision = 1e-6
 
   def almostEqual(x: Double, y: Double, precision: Double = DefaultMinimumPrecision): Boolean = {
     if ((x - y).abs < precision) true else false

--- a/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
+++ b/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
@@ -54,7 +54,7 @@ class XGBoostClassificationModelOp extends SimpleSparkOp[XGBoostClassificationMo
 
       model.getValue("thresholds").map(o => xgb.setThresholds(o.getDoubleList.toArray))
       model.getValue("missing").map(o => xgb.setMissing(o.getFloat))
-      model.getValue("allow_non_zero_for_missing").map(o => xgb.setAllowZeroForMissingValue(o.getBoolean))
+      model.getValue("allow_non_zero_for_missing").map(o => xgb.setAllowNonZeroForMissing(o.getBoolean))
       model.getValue("infer_batch_size").map(o => xgb.setInferBatchSize(o.getInt))
       model.getValue("use_external_memory").map(o => xgb.set(xgb.useExternalMemory, o.getBoolean))
       xgb
@@ -67,7 +67,7 @@ class XGBoostClassificationModelOp extends SimpleSparkOp[XGBoostClassificationMo
     val xgb = new XGBoostClassificationModel(uid, model.numClasses, model._booster)
     if(model.isSet(model.thresholds)) xgb.setThresholds(model.getOrDefault(model.thresholds))
     if(model.isSet(model.missing)) xgb.setMissing(model.getOrDefault(model.missing))
-    if(model.isSet(model.allowNonZeroForMissing)) xgb.setAllowZeroForMissingValue(model.getOrDefault(model.allowNonZeroForMissing))
+    if(model.isSet(model.allowNonZeroForMissing)) xgb.setAllowNonZeroForMissing(model.getOrDefault(model.allowNonZeroForMissing))
     if(model.isSet(model.inferBatchSize)) xgb.setInferBatchSize(model.getOrDefault(model.inferBatchSize))
     if(model.isSet(model.treeLimit)) xgb.setTreeLimit(model.getOrDefault(model.treeLimit))
     if(model.isSet(model.useExternalMemory)) xgb.set(xgb.useExternalMemory, model.getOrDefault(model.useExternalMemory))

--- a/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelOp.scala
+++ b/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelOp.scala
@@ -47,7 +47,7 @@ class XGBoostRegressionModelOp extends SimpleSparkOp[XGBoostRegressionModel] {
         setTreeLimit(model.value("tree_limit").getInt)
 
       model.getValue("missing").map(o => xgb.setMissing(o.getFloat))
-      model.getValue("allow_non_zero_for_missing").map(o => xgb.setAllowZeroForMissingValue(o.getBoolean))
+      model.getValue("allow_non_zero_for_missing").map(o => xgb.setAllowNonZeroForMissing(o.getBoolean))
       model.getValue("infer_batch_size").map(o => xgb.setInferBatchSize(o.getInt))
       model.getValue("use_external_memory").map(o => xgb.set(xgb.useExternalMemory, o.getBoolean))
       xgb
@@ -59,7 +59,7 @@ class XGBoostRegressionModelOp extends SimpleSparkOp[XGBoostRegressionModel] {
                          model: XGBoostRegressionModel): XGBoostRegressionModel = {
     val xgb = new XGBoostRegressionModel(uid, model._booster)
     if(model.isSet(model.missing)) xgb.setMissing(model.getOrDefault(model.missing))
-    if(model.isSet(model.allowNonZeroForMissing)) xgb.setAllowZeroForMissingValue(model.getOrDefault(model.allowNonZeroForMissing))
+    if(model.isSet(model.allowNonZeroForMissing)) xgb.setAllowNonZeroForMissing(model.getOrDefault(model.allowNonZeroForMissing))
     if(model.isSet(model.inferBatchSize)) xgb.setInferBatchSize(model.getOrDefault(model.inferBatchSize))
     if(model.isSet(model.treeLimit)) xgb.setTreeLimit(model.getOrDefault(model.treeLimit))
     if(model.isSet(model.useExternalMemory)) xgb.set(xgb.useExternalMemory, model.getOrDefault(model.useExternalMemory))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,10 +16,9 @@ object Dependencies {
   lazy val slf4jVersion = "1.7.25"
   lazy val awsSdkVersion = "1.11.1033"
   val tensorflowJavaVersion = "0.3.1" // Match Tensorflow 2.4.1 https://github.com/tensorflow/java/#tensorflow-version-support
-  val xgboostVersion = "1.0.0"
+  val xgboostVersion = "1.3.1"
   val breezeVersion = "1.0"
   val hadoopVersion = "2.7.4" // matches spark version
-  val kryoVersion = "4.0.2" // Remove upon upgrading to xgboost 1.1.1
   val platforms = "windows-x86_64,linux-x86_64,macosx-x86_64"
   val tensorflowPlatforms : Array[String] =  sys.env.getOrElse("TENSORFLOW_PLATFORMS", platforms).split(",")
 
@@ -72,11 +71,10 @@ object Dependencies {
 
     val breeze = "org.scalanlp" %% "breeze" % breezeVersion
 
-    val kryo = "com.esotericsoftware" % "kryo" % kryoVersion
-    val xgboostDep = "ml.dmlc" %% "xgboost4j" % xgboostVersion exclude("com.esotericsoftware.kryo", "kryo")
-    val xgboostPredictorDep = "ai.h2o" % "xgboost-predictor" % "0.3.17" exclude("com.esotericsoftware.kryo", "kryo")
+    val xgboostDep = "ml.dmlc" %% "xgboost4j" % xgboostVersion
+    val xgboostSparkDep = "ml.dmlc" %% "xgboost4j-spark" % xgboostVersion
+    val xgboostPredictorDep = "ai.h2o" % "xgboost-predictor" % "0.3.18" exclude("com.esotericsoftware.kryo", "kryo")
 
-    val xgboostSparkDep = "ml.dmlc" %% "xgboost4j-spark" % xgboostVersion exclude("com.esotericsoftware.kryo", "kryo")
     val hadoop = "org.apache.hadoop" % "hadoop-client" % hadoopVersion
   }
 
@@ -125,9 +123,9 @@ object Dependencies {
 
   val tensorflow = l ++= tensorflowDeps ++ Seq(Test.scalaTest)
 
-  val xgboostRuntime = l ++= Seq(xgboostDep) ++ Seq(xgboostPredictorDep) ++ Seq(kryo) ++ Test.spark ++ Test.sparkTest ++ Seq(Test.scalaTest)
+  val xgboostRuntime = l ++= Seq(xgboostDep) ++ Seq(xgboostPredictorDep) ++ Test.spark ++ Test.sparkTest ++ Seq(Test.scalaTest)
 
-  val xgboostSpark = l ++= Seq(xgboostSparkDep) ++ Seq(kryo) ++ Provided.spark ++ Test.spark ++ Test.sparkTest
+  val xgboostSpark = l ++= Seq(xgboostSparkDep) ++ Provided.spark ++ Test.spark ++ Test.sparkTest
 
   val serving = l ++= Seq(akkaHttp, akkaHttpSprayJson, config, Test.scalaTest, Test.akkaHttpTestkit)
 


### PR DESCRIPTION
Interesting things:

- v1.4.x didn't work for me and I couldn't figure out why.  I think it had issues somewhere in the JNI layer.  Thus this upgade only goes to the v1.3.x series.
- xgboost v1.3.3 is identical to v1.3.1 for jvm packages -- so this is the latest version of 1.3.x series for jvm packages.
- I had to reduce the floating point precision comparison in the tests.  I think 1e-6 is all we should normally expect though?