### PR TITLE
Add uid assertion to SparkParity tests and fix broken transformers.

### DIFF
--- a/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
+++ b/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
@@ -208,6 +208,7 @@ abstract class SparkParityBase extends FunSpec with BeforeAndAfterAll {
 
   def checkEquality(original: Transformer, deserialized: Transformer, additionalIgnoreParams: Set[String]): Unit = {
     assert(original.getClass == deserialized.getClass)
+    assert(original.uid == deserialized.uid)
     checkParamsEquality(original, deserialized, additionalIgnoreParams)
     original match {
       case original: PipelineModel =>

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/OpsUtils.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/OpsUtils.scala
@@ -1,0 +1,24 @@
+package org.apache.spark.ml.bundle.ops
+
+import org.apache.spark.ml.PipelineStage
+
+object OpsUtils {
+
+  def copySparkStageParams(fromStage: PipelineStage, toStage: PipelineStage): Unit = {
+    /**
+      * This method copy params from one spark stage to another spark stage.
+      * The "from" stage type must be the same with the "to" stage.
+      * Allow "to" stage have different uid with "from" stage".
+      *
+      * This helper function is a suppliment of spark API `PipelineStage.copy()`
+      * which only support copy param between stages with the same uid.
+      */
+    for (param <- fromStage.params) {
+      val paramValueOpt = fromStage.get(param)
+      if (paramValueOpt.isDefined) {
+        toStage.set(toStage.getParam(param.name), paramValueOpt.get)
+      }
+    }
+  }
+
+}

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BinarizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BinarizerOp.scala
@@ -4,9 +4,9 @@ import ml.bundle.DataShape
 import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.OpModel
-import ml.combust.mleap.core.types.ListShape
 import org.apache.spark.ml.bundle._
 import org.apache.spark.ml.feature.Binarizer
+import org.apache.spark.ml.bundle.ops.OpsUtils
 import org.apache.spark.sql.mleap.TypeConverters._
 import ml.combust.mleap.runtime.types.BundleTypeConverters._
 import org.apache.spark.ml.param.ParamValidators
@@ -56,6 +56,8 @@ class BinarizerOp extends SimpleSparkOp[Binarizer] with MultiInOutFormatSparkOp[
   }
 
   override def sparkLoad(uid: String, shape: NodeShape, model: Binarizer): Binarizer = {
-    model
+    val m = new Binarizer(uid)
+    OpsUtils.copySparkStageParams(model, m)
+    m
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StopWordsRemoverOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StopWordsRemoverOp.scala
@@ -2,7 +2,8 @@ package org.apache.spark.ml.bundle.ops.feature
 
 import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
-import ml.combust.bundle.op.{OpModel}
+import ml.combust.bundle.op.OpModel
+import org.apache.spark.ml.bundle.ops.OpsUtils
 import org.apache.spark.ml.bundle.{MultiInOutFormatSparkOp, SimpleSparkOp, SparkBundleContext}
 import org.apache.spark.ml.feature.StopWordsRemover
 
@@ -31,6 +32,8 @@ class StopWordsRemoverOp extends SimpleSparkOp[StopWordsRemover] with MultiInOut
   }
 
   override def sparkLoad(uid: String, shape: NodeShape, model: StopWordsRemover): StopWordsRemover = {
-    model
+    val m = new StopWordsRemover(uid)
+    OpsUtils.copySparkStageParams(model, m)
+    m
   }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOp.scala
@@ -4,6 +4,7 @@ import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.OpModel
 import org.apache.spark.ml.bundle._
+import org.apache.spark.ml.bundle.ops.OpsUtils
 import org.apache.spark.ml.feature.StringIndexerModel
 
 /**
@@ -48,6 +49,8 @@ class StringIndexerOp extends SimpleSparkOp[StringIndexerModel] with MultiInOutF
   }
 
   override def sparkLoad(uid: String, shape: NodeShape, model: StringIndexerModel): StringIndexerModel = {
-    model
+    val m = new StringIndexerModel(uid,  model.labelsArray)
+    OpsUtils.copySparkStageParams(model, m)
+    m
   }
 }


### PR DESCRIPTION
Fixes #787

Bug was introduced in the spark 3 upgrade.  Code taken from #777 

After altering the SparkParityBase saw many test failures.  Tests pass again after changing the transformer ops.