### PR TITLE
Implement Vector -> Tensor Casting

### DIFF
--- a/mleap-core/src/main/scala/ml/combust/mleap/core/types/Casting.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/types/Casting.scala
@@ -1,6 +1,7 @@
 package ml.combust.mleap.core.types
 
 import ml.combust.mleap.tensor.{ByteString, Tensor, DenseTensor, SparseTensor}
+import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector => SparkVector}
 
 import scala.util.{Failure, Success, Try}
 
@@ -81,6 +82,13 @@ object Casting {
     (BasicType.String, BasicType.Double) -> { (v: String) => if (v == "null" || v == "") null else v.toDouble }
   ).map {
     case (k, v) => (k, v.asInstanceOf[(Any) => Any])
+  }
+
+  def sparkVectorToMLeapTensor(sparkVector: SparkVector): Tensor[Double] = {
+    sparkVector match {
+      case v: DenseVector => DenseTensor[Double](v.values, Seq(v.size))
+      case v: SparseVector => SparseTensor[Double](v.indices.map(i => Seq(i)), v.values, Seq(v.size))
+    }
   }
 
   def baseCast(from: BasicType, to: BasicType): Option[Try[(Any) => Any]] = {
@@ -245,32 +253,88 @@ object Casting {
               to.base match {
                 case BasicType.Boolean =>
                   val cc = c.asInstanceOf[(Any) => Boolean]
-                  (v: Any) => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                  (v: Any) => {
+                    v match {
+                      case _: SparkVector => sparkVectorToMLeapTensor(v.asInstanceOf[SparkVector]).mapValues(cc)
+                      case _ => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                    }
+                  }
                 case BasicType.Byte =>
                   val cc = c.asInstanceOf[(Any) => Byte]
-                  (v: Any) => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                  (v: Any) => {
+                    v match {
+                      case _: SparkVector => sparkVectorToMLeapTensor(v.asInstanceOf[SparkVector]).mapValues(cc)
+                      case _ => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                    }
+                  }
                 case BasicType.Short =>
                   val cc = c.asInstanceOf[(Any) => Short]
-                  (v: Any) => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                  (v: Any) => {
+                    v match {
+                      case _: SparkVector => sparkVectorToMLeapTensor(v.asInstanceOf[SparkVector]).mapValues(cc)
+                      case _ => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                    }
+                  }
                 case BasicType.Int =>
                   val cc = c.asInstanceOf[(Any) => Int]
-                  (v: Any) => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                  (v: Any) => {
+                    v match {
+                      case _: SparkVector => sparkVectorToMLeapTensor(v.asInstanceOf[SparkVector]).mapValues(cc)
+                      case _ => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                    }
+                  }
                 case BasicType.Long =>
                   val cc = c.asInstanceOf[(Any) => Long]
-                  (v: Any) => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                  (v: Any) => {
+                    v match {
+                      case _: SparkVector => sparkVectorToMLeapTensor(v.asInstanceOf[SparkVector]).mapValues(cc)
+                      case _ => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                    }
+                  }
                 case BasicType.Float =>
                   val cc = c.asInstanceOf[(Any) => Float]
-                  (v: Any) => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                  (v: Any) => {
+                    v match {
+                      case _: SparkVector => sparkVectorToMLeapTensor(v.asInstanceOf[SparkVector]).mapValues(cc)
+                      case _ => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                    }
+                  }
                 case BasicType.Double =>
                   val cc = c.asInstanceOf[(Any) => Double]
-                  (v: Any) => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                  (v: Any) => {
+                    v match {
+                      case _: SparkVector => sparkVectorToMLeapTensor(v.asInstanceOf[SparkVector]).mapValues(cc)
+                      case _ => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                    }
+                  }
                 case BasicType.String =>
                   val cc = c.asInstanceOf[(Any) => String]
-                  (v: Any) => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                  (v: Any) => {
+                    v match {
+                      case _: SparkVector => sparkVectorToMLeapTensor(v.asInstanceOf[SparkVector]).mapValues(cc)
+                      case _ => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                    }
+                  }
                 case BasicType.ByteString =>
                   val cc = c.asInstanceOf[(Any) => ByteString]
-                  (v: Any) => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                  (v: Any) => {
+                    v match {
+                      case _: SparkVector => sparkVectorToMLeapTensor(v.asInstanceOf[SparkVector]).mapValues(cc)
+                      case _ => v.asInstanceOf[Tensor[_]].mapValues(cc)
+                    }
+                  }
               }
+          }
+        }.orElse {
+          Some {
+            Try {
+              (v: Any) => {
+                v match {
+                  case _: SparkVector => sparkVectorToMLeapTensor(v.asInstanceOf[SparkVector])
+                  case _ => v
+                }
+              }
+            }
           }
         }
       case _ => Some(Failure(new IllegalArgumentException(s"Cannot cast $from to $to")))

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/types/CastingSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/types/CastingSpec.scala
@@ -1,6 +1,7 @@
 package ml.combust.mleap.core.types
 
-import ml.combust.mleap.tensor.{ByteString, Tensor}
+import ml.combust.mleap.tensor.{ByteString, Tensor, SparseTensor}
+import org.apache.spark.ml.linalg.{Vector => SparkVector, Vectors}
 import org.scalatest.FunSpec
 import scala.util.Success
 
@@ -209,6 +210,46 @@ class CastingSpec extends FunSpec {
     }
     assertThrows[IllegalArgumentException] {
       cast2(tensor)
+    }
+  }
+
+  describe(s"DenseVector[Double] can be cast to") {
+    for((from, to, fromValue, expectedValue) <- castTests.filter(t => t._1 == BasicType.Double & t._4 != false)) {
+      it(s"Tensor[$to]") {
+        val fromDouble = fromValue.asInstanceOf[Double]
+        val inputVector = Vectors.dense(fromDouble, fromDouble, fromDouble)
+
+        val castingFn = Casting.cast(
+          TensorType.Double(inputVector.size),
+          TensorType(to, Some(Seq(inputVector.size)))
+        ).get.get
+
+        val actualTensor = castingFn(inputVector)
+        val expectedTensor = createTensor(to, Seq(expectedValue, expectedValue, expectedValue))
+        assert(expectedTensor == actualTensor)
+      }
+    }
+  }
+
+  describe(s"SparseVector[Double] can be cast to") {
+    for((from, to, fromValue, expectedValue) <- castTests.filter(t => t._1 == BasicType.Double & t._4 != false)) {
+      it(s"Tensor[$to]") {
+        val fromDouble = fromValue.asInstanceOf[Double]
+        val inputVector = Vectors.sparse(3, Array(0, 1), Array(fromDouble, fromDouble))
+
+        val castingFn = Casting.cast(
+          TensorType.Double(inputVector.size),
+          TensorType(to, Some(Seq(inputVector.size)))
+        ).get.get
+
+        val actualTensor = castingFn(inputVector).asInstanceOf[SparseTensor[_]]
+        val expectedTensor = SparseTensor(Seq(Seq(0), Seq(1)), Array(expectedValue, expectedValue), Seq(3))
+
+        assert(expectedTensor.values.sameElements(actualTensor.values))
+        assert(expectedTensor.indices == actualTensor.indices)
+        assert(expectedTensor.dimensions == actualTensor.dimensions)
+
+      }
     }
   }
 


### PR DESCRIPTION
You can see [here](https://github.com/combust/mleap/blob/68cbf375968d9f55acb1d673a4c2390602c0274a/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala#L72) that MLeap's DataFrame -> LeapFrame conversion code defines `TensorType` as the MLeap equivalent of Spark's `VectorUDT`

You can see [here](https://github.com/combust/mleap/blob/68cbf375968d9f55acb1d673a4c2390602c0274a/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala#L31) though, that the `Vector` value for this field never actually gets coerced into a `Tensor[Double]`, and is just declared as such

This results in the following error getting thrown in the casting module:
```
java.lang.ClassCastException: org.apache.spark.ml.linalg.DenseVector cannot be cast to ml.combust.mleap.tensor.Tensor
```

I considered changing the `DataFrame -> LeapFrame` conversion logic at first, but decided against it because there are models like [VectorAssemblerModel](https://github.com/combust/mleap/blob/4175f631168118fab87d87f7a0e5a01cef6c6e5b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/VectorAssemblerModel.scala#L90) that produce Vectors and assign a TensorType schema to them.

Therefore, I made the necessary changes in the Casting module itself, and you have to do a TensorType -> TensorType cast any time you want to convert a Vector into a Tensor
