### PR TITLE
BugFix: StringIndexerModel Cache labels.length to avoid travel it everytime

### DIFF
--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringIndexerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringIndexerModel.scala
@@ -16,7 +16,7 @@ case class StringIndexerModel(labels: Seq[String],
                               handleInvalid: HandleInvalid = HandleInvalid.Error) extends Model {
   val stringToIndex: Map[String, Int] = labels.zipWithIndex.toMap
   private val keepInvalid = handleInvalid == HandleInvalid.Keep
-
+  private val invalidValue = labels.length
   /** Convert a string into its integer representation.
     *
     * @param value label to index
@@ -24,17 +24,18 @@ case class StringIndexerModel(labels: Seq[String],
     */
   def apply(value: Any): Int = if (value == null) {
     if (keepInvalid) {
-      labels.length
+      invalidValue
     } else {
       throw new NullPointerException("StringIndexer encountered NULL value. " +
         s"To handle NULLS, set handleInvalid to ${HandleInvalid.Keep.asParamString}")
     }
   } else {
     val label = value.toString
-    if (stringToIndex.contains(label)) {
-      stringToIndex(label)
+    val index = stringToIndex.get(label)
+    if (index.isDefined) {
+      index.get
     } else if (keepInvalid) {
-      labels.length
+      invalidValue
     } else {
       throw new NoSuchElementException(s"Unseen label: $label. To handle unseen labels, " +
         s"set handleInvalid to ${HandleInvalid.Keep.asParamString}")

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringIndexerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringIndexerModel.scala
@@ -31,14 +31,14 @@ case class StringIndexerModel(labels: Seq[String],
     }
   } else {
     val label = value.toString
-    val index = stringToIndex.get(label)
-    if (index.isDefined) {
-      index.get
-    } else if (keepInvalid) {
-      invalidValue
-    } else {
-      throw new NoSuchElementException(s"Unseen label: $label. To handle unseen labels, " +
-        s"set handleInvalid to ${HandleInvalid.Keep.asParamString}")
+    stringToIndex.get(label) match {
+      case Some(v) => v
+      case None => if (keepInvalid) {
+        invalidValue
+      } else {
+        throw new NoSuchElementException(s"Unseen label: $label. To handle unseen labels, " +
+          s"set handleInvalid to ${HandleInvalid.Keep.asParamString}")
+      }
     }
   }
 


### PR DESCRIPTION
[StringIndexerModel](https://github.com/combust/mleap/blob/4175f631168118fab87d87f7a0e5a01cef6c6e5b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringIndexerModel.scala)
line 27 and 37 both call labels.length and labels is Seq[String] and implemented with List
So when input contains missing label, the complexity is O(N) very time.
We should change to use cache the val invalidValue = labels.length.

And also StringIndexer call stringToIndex.contains and stringToIndex.apply every time.
This will performance two lookup. It's totally unnecessary, because 99% percent contains return true
We can call stringToIndex.get then do a match on it's a Some or None.