### PR TITLE
Fixing conversion for Mleap vectors with non-increasing indices

### DIFF
--- a/mleap-core/src/main/scala/ml/combust/mleap/core/util/VectorConverters.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/util/VectorConverters.scala
@@ -20,10 +20,10 @@ trait VectorConverters {
   implicit def mleapTensorToSparkVector(tensor: Tensor[Double]): Vector = tensor match {
     case tensor: DenseTensor[_] =>
       Vectors.dense(tensor.rawValues.asInstanceOf[Array[Double]])
-    case tensor: SparseTensor[_] =>
-      Vectors.sparse(tensor.dimensions.product,
-        tensor.indices.map(_.head).toArray,
-        tensor.values.asInstanceOf[Array[Double]])
+    case tensor: SparseTensor[_] => {
+      val elements = tensor.indices.map(_.head).toArray zip tensor.values.asInstanceOf[Array[Double]]
+      Vectors.sparse(tensor.dimensions.product, elements)
+    }
   }
 
   implicit def sparkMatrixToMleapTensor(matrix: Matrix): Tensor[Double] = matrix match {

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/util/VectorConvertersSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/util/VectorConvertersSpec.scala
@@ -1,0 +1,31 @@
+package ml.combust.mleap.core.util
+
+import ml.combust.mleap.tensor.{DenseTensor, SparseTensor}
+import org.scalatest.FunSpec
+
+class VectorConvertersSpec extends FunSpec {
+  describe("mleapTensorToSparkVector works when") {
+
+    it("using a Sparse Tensor") {
+      val vec = Seq(1.0, 0, 3.0)
+      val indices = Seq(0, 2).map(Seq(_))
+      val values = indices.map((i: Seq[Int]) => vec(i.head)).toArray
+      val tensor = SparseTensor(indices, values, Seq(vec.length))
+      assert(VectorConverters.mleapTensorToSparkVector(tensor).toArray sameElements vec)
+    }
+
+    it("using a Sparse Tensor with non-increasing indices") {
+      val vec = Seq(1.0, 0, 3.0)
+      val indices = Seq(2, 0).map(Seq(_))
+      val values = indices.map((i: Seq[Int]) => vec(i.head)).toArray
+      val tensor = SparseTensor(indices, values, Seq(vec.length))
+      assert(VectorConverters.mleapTensorToSparkVector(tensor).toArray sameElements vec)
+    }
+
+    it("using a Dense Tensor") {
+      val vec = Seq(1.0, 2.0, 3.0).toArray
+      val tensor = DenseTensor(vec, Seq(vec.length))
+      assert(VectorConverters.mleapTensorToSparkVector(tensor).toArray sameElements vec)
+    }
+  }
+}


### PR DESCRIPTION
### Description
Mleap allows Sparse Tensors to be created with sequences of non-increasing indices; not so in Spark. `mleapTensorToSparkVector` fails if the mleap Tensor was created with such a sequence of indices. The following change fixes this: the new construction used here does not require the indices to be increasing. 