### PR TITLE
Prepare for 0.19.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Choose the right version of the `mleap-spark` module to export your pipeline. Th
 
 | MLeap Version | Spark Version |
 |---------------|---------------|
+| 0.19.0        | 3.0.2         |
 | 0.18.1        | 3.0.2         |
 | 0.18.0        | 3.0.2         |
 | 0.17.0        | 2.4.5         |
@@ -73,7 +74,7 @@ Please see the [release notes](RELEASE_NOTES.md) for changes (especially breakin
 #### SBT
 
 ```sbt
-libraryDependencies += "ml.combust.mleap" %% "mleap-runtime" % "0.18.1"
+libraryDependencies += "ml.combust.mleap" %% "mleap-runtime" % "0.19.0"
 ```
 
 #### Maven
@@ -82,7 +83,7 @@ libraryDependencies += "ml.combust.mleap" %% "mleap-runtime" % "0.18.1"
 <dependency>
     <groupId>ml.combust.mleap</groupId>
     <artifactId>mleap-runtime_2.12</artifactId>
-    <version>0.18.1</version>
+    <version>0.19.0</version>
 </dependency>
 ```
 
@@ -91,7 +92,7 @@ libraryDependencies += "ml.combust.mleap" %% "mleap-runtime" % "0.18.1"
 #### SBT
 
 ```sbt
-libraryDependencies += "ml.combust.mleap" %% "mleap-spark" % "0.18.1"
+libraryDependencies += "ml.combust.mleap" %% "mleap-spark" % "0.19.0"
 ```
 
 #### Maven
@@ -100,14 +101,14 @@ libraryDependencies += "ml.combust.mleap" %% "mleap-spark" % "0.18.1"
 <dependency>
     <groupId>ml.combust.mleap</groupId>
     <artifactId>mleap-spark_2.12</artifactId>
-    <version>0.18.1</version>
+    <version>0.19.0</version>
 </dependency>
 ```
 
 ### Spark Packages
 
 ```bash
-$ bin/spark-shell --packages ml.combust.mleap:mleap-spark_2.12:0.18.1
+$ bin/spark-shell --packages ml.combust.mleap:mleap-spark_2.12:0.19.0
 ```
 
 ### PySpark Integration

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# Release 0.19.0-SNAPSHOT (NOT RELEASED YET)
+# Release 0.20.0-SNAPSHOT (NOT RELEASED YET)
 
 ### Breaking Changes
 
@@ -9,6 +9,22 @@
 ### Improvements
 
 ### Other Changes
+
+# Release 0.19.0
+
+### New Features
+- `MapType` is now supported as a core data type (#789)
+- `MapEntrySelector` is a new Transformer that can be used to select keys from maps (#789)
+- Spark Vectors can now be cast into MLeap Tensors (#791)
+
+### Bug Fixes
+- Fixes uid parity for certain Spark 3 transformers (#788)
+- MLeap Tensor -> Spark vector casting logic is fixed for non-increasing indices (#794)
+
+### Improvements
+- Upgrades to xgboost v1.3.1 (#778)
+- Updates shading rules for databricks runtime assembly (#780)
+- StringIndexerModel now performs faster lookups by caching the index size (#793)
 
 # Release 0.18.1
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,12 +14,12 @@
 
 ### New Features
 - `MapType` is now supported as a core data type (#789)
-- `MapEntrySelector` is a new Transformer that can be used to select keys from maps (#789)
+- `MapEntrySelector` is a new Transformer that can be used to select values from maps (#789)
 - Spark Vectors can now be cast into MLeap Tensors (#791)
 
 ### Bug Fixes
-- Fixes uid parity for certain Spark 3 transformers (#788)
-- MLeap Tensor -> Spark vector casting logic is fixed for non-increasing indices (#794)
+- Fixes uid parity issues for certain Spark 3 transformers (#788)
+- MLeap Tensor -> Spark Vector casting logic is fixed for non-increasing indices (#794)
 
 ### Improvements
 - Upgrades to xgboost v1.3.1 (#778)

--- a/mleap-databricks-runtime-testkit/README.md
+++ b/mleap-databricks-runtime-testkit/README.md
@@ -3,7 +3,7 @@
 ```
 sbt mleap-databricks-runtime-fat/assembly mleap-databricks-runtime-testkit/assembly
 
-spark-submit --jars $PWD/mleap-databricks-runtime-fat/target/scala-2.12/mleap-databricks-runtime-fat-assembly-0.18.1.jar \
+spark-submit --jars $PWD/mleap-databricks-runtime-fat/target/scala-2.12/mleap-databricks-runtime-fat-assembly-0.19.0.jar \
   --packages org.tensorflow:tensorflow:1.11.0,org.tensorflow:libtensorflow_jni:1.11.0,ml.dmlc:xgboost4j-spark:1.0.0 \
-  mleap-databricks-runtime-testkit/target/scala-2.12/mleap-databricks-runtime-testkit-assembly-0.18.1.jar
+  mleap-databricks-runtime-testkit/target/scala-2.12/mleap-databricks-runtime-testkit-assembly-0.19.0.jar
 ```

--- a/python/mleap/version.py
+++ b/python/mleap/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = "0.19.0-SNAPSHOT"
+version = "0.19.0"


### PR DESCRIPTION
@ancasarb I'm a little confused on how to handle versions during the release process.

It seems like `sbt release` can automatically handle bumping the version in `version.sbt`?

But do I have to manually set `python/mleap/version.py` before attempting a release?