### PR TITLE
Fixes 'cannot assign instance of java.lang.invoke.SerializedLambda' for Tensorflow transformer when using sparkTransform() method

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,7 +16,7 @@
 ### New Features
 - `MapType` is now supported as a core data type (#789)
 - `MapEntrySelector` is a new Transformer that can be used to select values from maps (#789)
-- Spark Vectors can now be cast into\ MLeap Tensors (#791)
+- Spark Vectors can now be cast into MLeap Tensors (#791)
 
 ### Bug Fixes
 - Fixes uid parity issues for certain Spark 3 transformers (#788)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 ### New Features
 
 ### Bug Fixes
+- Fixes 'cannot assign instance of java.lang.invoke.SerializedLambda' for Tensorflow transformer when using sparkTransform() method
 
 ### Improvements
 
@@ -15,7 +16,7 @@
 ### New Features
 - `MapType` is now supported as a core data type (#789)
 - `MapEntrySelector` is a new Transformer that can be used to select values from maps (#789)
-- Spark Vectors can now be cast into MLeap Tensors (#791)
+- Spark Vectors can now be cast into\ MLeap Tensors (#791)
 
 ### Bug Fixes
 - Fixes uid parity issues for certain Spark 3 transformers (#788)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,7 @@
 ### New Features
 
 ### Bug Fixes
-- Fixes 'cannot assign instance of java.lang.invoke.SerializedLambda' for Tensorflow transformer when using sparkTransform() method
+- Fixes 'cannot assign instance of java.lang.invoke.SerializedLambda' for Tensorflow transformer when using sparkTransform() method 
 
 ### Improvements
 

--- a/mleap-tensorflow/src/main/scala/ml/combust/mleap/tensorflow/TensorflowTransformer.scala
+++ b/mleap-tensorflow/src/main/scala/ml/combust/mleap/tensorflow/TensorflowTransformer.scala
@@ -13,12 +13,16 @@ import scala.util.Try
 case class TensorflowTransformer(override val uid: String = Transformer.uniqueName("tensorflow"),
                                  override val shape: NodeShape,
                                  override val model: TensorflowModel) extends Transformer {
-  private val f = (tensors: Row) => {
-    Row(model(tensors.toSeq.map(_.asInstanceOf[Tensor[_]]): _*): _*)
+
+  val exec: UserDefinedFunction = {
+    val f = (tensors: Row) => {
+      Row(model(tensors.toSeq.map(_.asInstanceOf[Tensor[_]]): _*): _*)
+    }
+
+    UserDefinedFunction(f,
+      outputSchema,
+      Seq(SchemaSpec(inputSchema)))
   }
-  val exec: UserDefinedFunction = UserDefinedFunction(f,
-    outputSchema,
-    Seq(SchemaSpec(inputSchema)))
 
   val outputCols: Seq[String] = outputSchema.fields.map(_.name)
   val inputCols: Seq[String] = inputSchema.fields.map(_.name)


### PR DESCRIPTION
Exception encountered:

```
Caused by: java.lang.ClassCastException: cannot assign instance of java.lang.invoke.SerializedLambda to field ml.combust.mleap.tensorflow.TensorflowTransformer.f of type scala.Function1 in instance of ml.combust.mleap.tensorflow.TensorflowTransformer
```

Note: for reference adding a couple more links to Spark issues, this is a wider issue and not specific to the TF transformer or TF itself.

https://issues.apache.org/jira/browse/SPARK-29497
https://issues.apache.org/jira/browse/SPARK-25047

The workaround is quite simple and doesn't seem to cause any issue. 