### PR TITLE
attempt at fixing build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: "Python 3.7 tests"
       language: python
-      python: 3.7
+      python: 3.7.9
       env:
         # By default, "python" projects use the default jdk version, which is openjdk11 on xenial
         # But we need jdk8 for spark, so we need to change it back


### PR DESCRIPTION
Attempt at fixing the error below, which happens when running the 3.7 python tests on travis.

```
Traceback (most recent call last):
  File "setup.py", line 22, in <module>
    from setuptools import setup, find_packages
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/setuptools/__init__.py", line 18, in <module>
    from setuptools.dist import Distribution
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/setuptools/dist.py", line 34, in <module>
    from ._importlib import metadata
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/setuptools/_importlib.py", line 28, in <module>
    disable_importlib_metadata_finder(metadata)
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/setuptools/_importlib.py", line 12, in disable_importlib_metadata_finder
    import importlib_metadata
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/importlib_metadata/__init__.py", line 471, in <module>
    __version__ = version(__name__)
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/importlib_metadata/__init__.py", line 438, in version
    return distribution(package).version
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/importlib_metadata/__init__.py", line 411, in distribution
    return Distribution.from_name(package)
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/importlib_metadata/__init__.py", line 179, in from_name
    dists = resolver(name)
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/setuptools/_vendor/importlib_metadata/__init__.py", line 886, in find_distributions
    found = self._search_paths(context.name, context.path)
AttributeError: 'str' object has no attribute 'name'
```
