### PR TITLE
Add setClassLoader method to MleapReflection

### DIFF
--- a/mleap-core/src/main/scala/ml/combust/mleap/core/reflection/MleapReflection.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/reflection/MleapReflection.scala
@@ -152,7 +152,17 @@ trait MleapReflection {
 
 object MleapReflection extends MleapReflection {
   override val universe: scala.reflect.runtime.universe.type = scala.reflect.runtime.universe
+  private var classLoader: Option[ClassLoader] = None
+
+  def setClassLoader(cl: ClassLoader) = MleapReflectionLock.synchronized {
+    classLoader = Some(cl)
+  }
+
+  def getClassLoader(): ClassLoader = MleapReflectionLock.synchronized {
+    classLoader.getOrElse(Thread.currentThread().getContextClassLoader)
+  }
+
   override def mirror: universe.Mirror = MleapReflectionLock.synchronized {
-    universe.runtimeMirror(Thread.currentThread().getContextClassLoader)
+    universe.runtimeMirror(getClassLoader())
   }
 }


### PR DESCRIPTION
MleapReflection use `Thread.currentThread().getContextClassLoader` as classLoader for `mirror`.
In some case we need to specified classLoader without changing the current thread's classLoader.

Providing a set method here will make this hack easier.