### PR TITLE
Added backward compatibility fix for XGBoost models

### DIFF
--- a/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/bundle/ops/XGBoostClassificationOp.scala
+++ b/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/bundle/ops/XGBoostClassificationOp.scala
@@ -37,7 +37,8 @@ class XGBoostClassificationOp extends MleapOp[XGBoostClassification, XGBoostClas
 
       val numClasses = model.value("num_classes").getInt
       val numFeatures = model.value("num_features").getInt
-      val treeLimit = model.value("tree_limit").getInt
+      val treeLimit = model.getValue("tree_limit")
+        .map(_.getInt).getOrElse(0)
 
       val impl = if(numClasses == 2) {
         XGBoostBinaryClassificationModel(booster, numFeatures, treeLimit)

--- a/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/bundle/ops/XGBoostPredictorClassificationOp.scala
+++ b/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/bundle/ops/XGBoostPredictorClassificationOp.scala
@@ -33,7 +33,8 @@ class XGBoostPredictorClassificationOp extends MleapOp[XGBoostPredictorClassific
 
     val numClasses = model.value("num_classes").getInt
     val numFeatures = model.value("num_features").getInt
-    val treeLimit = model.value("tree_limit").getInt
+    val treeLimit = model.getValue("tree_limit")
+      .map(_.getInt).getOrElse(0)
 
     val impl = if(numClasses == 2) {
       XGBoostPredictorBinaryClassificationModel(predictor, numFeatures, treeLimit)

--- a/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/bundle/ops/XGBoostPredictorRegressionOp.scala
+++ b/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/bundle/ops/XGBoostPredictorRegressionOp.scala
@@ -27,7 +27,8 @@ class XGBoostPredictorRegressionOp extends MleapOp[XGBoostPredictorRegression, X
       val predictor = new Predictor(Files.newInputStream(context.file("xgboost.model")))
 
       val numFeatures = model.value("num_features").getInt
-      val treeLimit = model.value("tree_limit").getInt
+      val treeLimit = model.getValue("tree_limit")
+        .map(_.getInt).getOrElse(0)
 
       XGBoostPredictorRegressionModel(
         predictor,

--- a/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/bundle/ops/XGBoostRegressionOp.scala
+++ b/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/bundle/ops/XGBoostRegressionOp.scala
@@ -35,7 +35,8 @@ class XGBoostRegressionOp extends MleapOp[XGBoostRegression, XGBoostRegressionMo
                      (implicit context: BundleContext[MleapContext]): XGBoostRegressionModel = {
       val bytes = Files.readAllBytes(context.file("xgboost.model"))
       val booster = XGBoost.loadModel(new ByteArrayInputStream(bytes))
-      val treeLimit = model.value("tree_limit").getInt
+      val treeLimit = model.getValue("tree_limit")
+        .map(_.getInt).getOrElse(0)
 
       XGBoostRegressionModel(booster,
         numFeatures = model.value("num_features").getInt,

--- a/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
+++ b/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
@@ -49,9 +49,9 @@ class XGBoostClassificationModelOp extends SimpleSparkOp[XGBoostClassificationMo
         SXGBoost.loadModel(in)
       }).tried.get
 
-      val xgb = new XGBoostClassificationModel("", model.value("num_classes").getInt, booster).
-          setTreeLimit(model.value("tree_limit").getInt)
+      val xgb = new XGBoostClassificationModel("", model.value("num_classes").getInt, booster)
 
+      model.getValue("tree_limit").map(o => xgb.setTreeLimit(o.getInt))
       model.getValue("thresholds").map(o => xgb.setThresholds(o.getDoubleList.toArray))
       model.getValue("missing").map(o => xgb.setMissing(o.getFloat))
       model.getValue("allow_non_zero_for_missing").map(o => xgb.setAllowNonZeroForMissing(o.getBoolean))

--- a/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelOp.scala
+++ b/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelOp.scala
@@ -43,9 +43,9 @@ class XGBoostRegressionModelOp extends SimpleSparkOp[XGBoostRegressionModel] {
         SXGBoost.loadModel(in)
       }).tried.get
 
-      val xgb = new XGBoostRegressionModel("", booster).
-        setTreeLimit(model.value("tree_limit").getInt)
+      val xgb = new XGBoostRegressionModel("", booster)
 
+      model.getValue("tree_limit").map(o => xgb.setTreeLimit(o.getInt))
       model.getValue("missing").map(o => xgb.setMissing(o.getFloat))
       model.getValue("allow_non_zero_for_missing").map(o => xgb.setAllowNonZeroForMissing(o.getBoolean))
       model.getValue("infer_batch_size").map(o => xgb.setInferBatchSize(o.getInt))


### PR DESCRIPTION
Hi,

We have noticed a few issues while trying to load XGBoost models on latest mleap version, these models were trained using a mleap version built on scala 2.11.
The issue is due to **tree_limit** variable which wasn't getting stored during model serialisation in older mleap version but is a variable that is expected to be present in bundle file in the latest version. So, in order to fix this behaviour have updated the code to either read from bundle file or fallback to default value in case of its absence instead of failure during deserialisation.