### PR TITLE
Alter jvm_scala_object to better handle nested scala classes.

### DIFF
--- a/python/mleap/pyspark/feature/math_binary.py
+++ b/python/mleap/pyspark/feature/math_binary.py
@@ -90,8 +90,8 @@ class MathBinary(JavaTransformer, HasOutputCol, JavaMLReadable, JavaMLWritable):
         # if operation is not None, we can proceed to instantiate the scala classes
         if operation:
             scalaBinaryOperation = jvm_scala_object(
-                _jvm().ml.combust.mleap.core.feature.BinaryOperation,
-                operation.name
+                _jvm().ml.combust.mleap.core.feature,
+                f"BinaryOperation${operation.name}$"
             )
 
             scalaMathBinaryModel = _jvm().ml.combust.mleap.core.feature.MathBinaryModel(

--- a/python/mleap/pyspark/feature/math_unary.py
+++ b/python/mleap/pyspark/feature/math_unary.py
@@ -46,8 +46,8 @@ class MathUnary(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, Java
         # if operation is not None, we can proceed to instantiate the scala classes
         if operation:
             scalaUnaryOperation = jvm_scala_object(
-                _jvm().ml.combust.mleap.core.feature.UnaryOperation,
-                operation.name
+                _jvm().ml.combust.mleap.core.feature,
+                f"UnaryOperation${operation.name}$",
             )
 
             scalaMathUnaryModel = _jvm().ml.combust.mleap.core.feature.MathUnaryModel(scalaUnaryOperation)

--- a/python/mleap/pyspark/feature/string_map.py
+++ b/python/mleap/pyspark/feature/string_map.py
@@ -45,8 +45,8 @@ class StringMap(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, Java
             .toMap(_jvm().scala.Predef.conforms())
 
         handle_invalid_jvm = jvm_scala_object(
-            _jvm().ml.combust.mleap.core.feature.HandleInvalid,
-            handleInvalid.capitalize(),
+            _jvm().ml.combust.mleap.core.feature,
+            f"HandleInvalid${handleInvalid.capitalize()}$",
         )
 
         string_map_model = _jvm().ml.combust.mleap.core.feature.StringMapModel(

--- a/python/mleap/pyspark/py2scala.py
+++ b/python/mleap/pyspark/py2scala.py
@@ -13,7 +13,7 @@ def jvm_scala_object(jpkg, obj):
         (for reference see file ml.combust.mleap.core.feature.MathUnaryModel)
     """
     return getattr(
-        getattr(jpkg, obj + "$"),  # JavaClass
+        getattr(jpkg, obj),  # JavaClass
         "MODULE$",  # JavaObject
     )
 
@@ -25,4 +25,4 @@ def Some(value):
     return _jvm().scala.Some(value)
 
 def ScalaNone():
-    return jvm_scala_object(_jvm().scala, "None")
+    return jvm_scala_object(_jvm().scala, "None$")


### PR DESCRIPTION
The enums for binary operation (and others) are implemented as nested case objects, which means they have class paths like the following:
```
$ ls mleap-core/target/scala-2.12/classes/ml/combust/mleap/core/feature/ | grep BinaryOperation
BinaryOperation$.class
BinaryOperation$Add$.class
BinaryOperation$Divide$.class
BinaryOperation$LogN$.class
BinaryOperation$Max$.class
BinaryOperation$Min$.class
BinaryOperation$Multiply$.class
BinaryOperation$Pow$.class
BinaryOperation$Remainder$.class
BinaryOperation$Subtract$.class
BinaryOperation.class
```

This PR makes it so that we'll search in the jvm for `ml.combust.mleap.core.feature.BinaryOperation$Add$` instead of the current `ml.combust.mleap.core.feature.BinaryOperation.Add$`.  To be honest I'm not sure why the current code doesn't break the existing tests.

## Release Note
I have this PR based off of the v0.21.0 tag and intend to release this as v0.21.1.  I'll also make a PR to apply this commit to master branch (which will later be released as v0.22.0)