### PR TITLE
Mleap Runtime serialization using wrong file name for DecisionTree models

### DIFF
--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/DecisionTreeClassifierOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/classification/DecisionTreeClassifierOp.scala
@@ -24,7 +24,7 @@ class DecisionTreeClassifierOp extends MleapOp[DecisionTreeClassifier, DecisionT
 
     override def store(model: Model, obj: DecisionTreeClassifierModel)
                       (implicit context: BundleContext[MleapContext]): Model = {
-      TreeSerializer[tree.Node](context.file("nodes"), withImpurities = true).write(obj.rootNode)
+      TreeSerializer[tree.Node](context.file("tree"), withImpurities = true).write(obj.rootNode)
       model.withValue("num_features", Value.long(obj.numFeatures)).
         withValue("num_classes", Value.long(obj.numClasses)).
         withValue("thresholds", obj.thresholds.map(Value.doubleList(_)))

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/DecisionTreeRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/regression/DecisionTreeRegressionOp.scala
@@ -24,7 +24,7 @@ class DecisionTreeRegressionOp extends MleapOp[DecisionTreeRegression, DecisionT
 
     override def store(model: Model, obj: DecisionTreeRegressionModel)
                       (implicit context: BundleContext[MleapContext]): Model = {
-      TreeSerializer[tree.Node](context.file("nodes"), withImpurities = false).write(obj.rootNode)
+      TreeSerializer[tree.Node](context.file("tree"), withImpurities = false).write(obj.rootNode)
       model.withValue("num_features", Value.long(obj.numFeatures))
     }
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/DecisionTreeClassifierSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/DecisionTreeClassifierSpec.scala
@@ -1,8 +1,17 @@
 package ml.combust.mleap.runtime.transformer.classification
 
+import ml.combust.bundle.BundleFile
+import ml.combust.bundle.serializer.SerializationFormat
 import ml.combust.mleap.core.classification.DecisionTreeClassifierModel
+import ml.combust.mleap.core.tree.{ContinuousSplit, InternalNode, LeafNode}
 import ml.combust.mleap.core.types._
+import ml.combust.mleap.runtime.MleapSupport._
+import ml.combust.mleap.runtime.test.TestUtil
 import org.scalatest.FunSpec
+import resource.managed
+
+import java.io.File
+import java.net.URI
 
 class DecisionTreeClassifierSpec extends FunSpec {
 
@@ -43,6 +52,34 @@ class DecisionTreeClassifierSpec extends FunSpec {
           StructField("rp", TensorType(BasicType.Double, Seq(2))),
           StructField("probability", TensorType(BasicType.Double, Seq(2))),
           StructField("prediction", ScalarType.Double.nonNullable)))
+    }
+  }
+
+  describe("save/load model") {
+    it("correctly reproduces the model when saved and loaded") {
+      val node = InternalNode(LeafNode(Seq(0.78)), LeafNode(Seq(0.34)), ContinuousSplit(0, 0.5))
+      val transformer = DecisionTreeClassifier(shape = NodeShape.probabilisticClassifier(rawPredictionCol = Some("rp"),
+        probabilityCol = Some("probability")),
+        model = new DecisionTreeClassifierModel(node, 3, 2))
+
+      // serialization
+      val fileName = s"${TestUtil.baseDir}/decision_tree_classifier_saved_model.json.zip"
+      val uri = new URI(s"jar:file:$fileName")
+      for (file <- managed(BundleFile(uri))) {
+        transformer.writeBundle.name("bundle")
+          .format(SerializationFormat.Json)
+          .save(file)
+      }
+
+      // de-serialization
+      val file = new File(fileName)
+      val loadedTransformer = (for (bf <- managed(BundleFile(file))) yield {
+        bf.loadMleapBundle().get.root
+      }).tried.get.asInstanceOf[DecisionTreeClassifier]
+
+      // checks
+      assert(transformer.inputSchema.fields equals (loadedTransformer.inputSchema.fields))
+      assert(transformer.outputSchema.fields equals (loadedTransformer.outputSchema.fields))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/DecisionTreeRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/DecisionTreeRegressionSpec.scala
@@ -1,9 +1,17 @@
 package ml.combust.mleap.runtime.transformer.regression
 
+import ml.combust.bundle.BundleFile
+import ml.combust.bundle.serializer.SerializationFormat
 import ml.combust.mleap.core.regression.DecisionTreeRegressionModel
 import ml.combust.mleap.core.tree.{ContinuousSplit, InternalNode, LeafNode}
 import ml.combust.mleap.core.types._
+import ml.combust.mleap.runtime.MleapSupport._
+import ml.combust.mleap.runtime.test.TestUtil
 import org.scalatest.FunSpec
+import resource.managed
+
+import java.io.File
+import java.net.URI
 
 class DecisionTreeRegressionSpec extends FunSpec {
 
@@ -18,6 +26,35 @@ class DecisionTreeRegressionSpec extends FunSpec {
       assert(transformer.schema.fields ==
         Seq(StructField("features", TensorType.Double(3)),
           StructField("prediction", ScalarType.Double.nonNullable)))
+    }
+  }
+
+  describe("save/load model") {
+    it("correctly reproduces the model when saved and loaded") {
+      val node = InternalNode(LeafNode(Seq(0.78)), LeafNode(Seq(0.34)), ContinuousSplit(0, 0.5))
+      val regression = DecisionTreeRegressionModel(node, 3)
+
+      val transformer = DecisionTreeRegression(shape = NodeShape.regression(),
+        model = regression)
+
+      // serialization
+      val fileName = s"${TestUtil.baseDir}/decision_tree_regression_saved_model.json.zip"
+      val uri = new URI(s"jar:file:$fileName")
+      for (file <- managed(BundleFile(uri))) {
+        transformer.writeBundle.name("bundle")
+          .format(SerializationFormat.Json)
+          .save(file)
+      }
+
+      // de-serialization
+      val file = new File(fileName)
+      val loadedTransformer = (for (bf <- managed(BundleFile(file))) yield {
+        bf.loadMleapBundle().get.root
+      }).tried.get.asInstanceOf[DecisionTreeRegression]
+
+      // checks
+      assert(transformer.inputSchema.fields equals (loadedTransformer.inputSchema.fields))
+      assert(transformer.outputSchema.fields equals (loadedTransformer.outputSchema.fields))
     }
   }
 }


### PR DESCRIPTION
[This PR](https://github.com/combust/mleap/pull/54) introduced a bug in the Mleap Runtime serialization for DecisionTree-type models (DecisionTreeClassifier and DecisionTreeRegression).  That PR intended to update how the trees in the DecisionTree are serialized, including switching the file name from "nodes" to "tree".  However, two instances were missed, one in the runtime DecisionTreeClassifierOp and one in the runtime DecisionTreeRegressionOp.  This bug means that any DecisionTreeClassifier or DecisionTreeRegression models that are serialized using Mleap Runtime will use the "nodes" file name and thus are unable to be deserialized because both Mleap Runtime and Mleap Spark expect the "tree" file name during deserialization (because they were correctly updated in that PR).

In this PR, I am fixing the two missed instances from the original PR and adding a test case for each of these instances.  I have verified that the test case failed before the change and succeeds after the change.

Demonstrating that the two new tests failed before fixing the file name:
```
$ sbt "project mleap-runtime” test
…
[info] DecisionTreeRegressionSpec:
…
[info] save/load model
[info] - correctly reproduces the model when saved and loaded *** FAILED ***
[info]   java.nio.file.NoSuchFileException: /root/tree.json
[info]   at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem.newInputStream(ZipFileSystem.java:572)
[info]   at jdk.zipfs/jdk.nio.zipfs.ZipPath.newInputStream(ZipPath.java:708)
[info]   at jdk.zipfs/jdk.nio.zipfs.ZipFileSystemProvider.newInputStream(ZipFileSystemProvider.java:273)
[info]   at java.base/java.nio.file.Files.newInputStream(Files.java:158)
[info]   at ml.combust.bundle.tree.decision.TreeSerializer.$anonfun$read$1(TreeSerializer.scala:107)
[info]   at resource.DefaultManagedResource.open(AbstractManagedResource.scala:110)
[info]   at resource.AbstractManagedResource.acquireFor(AbstractManagedResource.scala:87)
[info]   at resource.ManagedResourceOperations.apply(ManagedResourceOperations.scala:26)
[info]   at resource.ManagedResourceOperations.apply$(ManagedResourceOperations.scala:26)
[info]   at resource.AbstractManagedResource.apply(AbstractManagedResource.scala:50)
…
[info] DecisionTreeClassifierSpec:
…
[info] save/load model
[info] - correctly reproduces the model when saved and loaded *** FAILED ***
[info]   java.nio.file.NoSuchFileException: /root/tree.json
[info]   at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem.newInputStream(ZipFileSystem.java:572)
[info]   at jdk.zipfs/jdk.nio.zipfs.ZipPath.newInputStream(ZipPath.java:708)
[info]   at jdk.zipfs/jdk.nio.zipfs.ZipFileSystemProvider.newInputStream(ZipFileSystemProvider.java:273)
[info]   at java.base/java.nio.file.Files.newInputStream(Files.java:158)
[info]   at ml.combust.bundle.tree.decision.TreeSerializer.$anonfun$read$1(TreeSerializer.scala:107)
[info]   at resource.DefaultManagedResource.open(AbstractManagedResource.scala:110)
[info]   at resource.AbstractManagedResource.acquireFor(AbstractManagedResource.scala:87)
[info]   at resource.ManagedResourceOperations.apply(ManagedResourceOperations.scala:26)
[info]   at resource.ManagedResourceOperations.apply$(ManagedResourceOperations.scala:26)
[info]   at resource.AbstractManagedResource.apply(AbstractManagedResource.scala:50)
…
[info] Run completed in 3 seconds, 652 milliseconds.
[info] Total number of tests run: 274
[info] Suites: completed 72, aborted 0
[info] Tests: succeeded 272, failed 2, canceled 0, ignored 0, pending 0
[info] *** 2 TESTS FAILED ***
[error] Failed tests:
[error] 	ml.combust.mleap.runtime.transformer.regression.DecisionTreeRegressionSpec
[error] 	ml.combust.mleap.runtime.transformer.classification.DecisionTreeClassifierSpec
[error] (Test / test) sbt.TestsFailedException: Tests unsuccessful
```

Demonstrating that the two new tests succeed after fixing the file name:
```
$ sbt "project mleap-runtime” test
…
[info] DecisionTreeRegressionSpec:
…
[info] save/load model
[info] - correctly reproduces the model when saved and loaded
…
[info] DecisionTreeClassifierSpec:
…
[info] save/load model
[info] - correctly reproduces the model when saved and loaded
…
[info] Run completed in 4 seconds, 104 milliseconds.
[info] Total number of tests run: 274
[info] Suites: completed 72, aborted 0
[info] Tests: succeeded 274, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```