### PR TITLE
Serialize objective for XGBoostClassificationModel

### DIFF
--- a/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
+++ b/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
@@ -41,6 +41,7 @@ class XGBoostClassificationModelOp extends SimpleSparkOp[XGBoostClassificationMo
         withValue("infer_batch_size", Value.int(obj.getOrDefault(obj.inferBatchSize))).
         withValue("use_external_memory", Value.boolean(obj.getOrDefault(obj.useExternalMemory))).
         withValue("allow_non_zero_for_missing", Value.boolean(obj.getOrDefault(obj.allowNonZeroForMissing)))
+        withValue("objective", Value.string(obj.getOrDefault(obj.objective)))
     }
 
     override def load(model: Model)
@@ -57,6 +58,7 @@ class XGBoostClassificationModelOp extends SimpleSparkOp[XGBoostClassificationMo
       model.getValue("allow_non_zero_for_missing").map(o => xgb.setAllowNonZeroForMissing(o.getBoolean))
       model.getValue("infer_batch_size").map(o => xgb.setInferBatchSize(o.getInt))
       model.getValue("use_external_memory").map(o => xgb.set(xgb.useExternalMemory, o.getBoolean))
+      model.getValue("objective").map(o => xgb.set(xgb.objective, o.getString))
       xgb
     }
   }

--- a/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
+++ b/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
@@ -73,6 +73,7 @@ class XGBoostClassificationModelOp extends SimpleSparkOp[XGBoostClassificationMo
     if(model.isSet(model.inferBatchSize)) xgb.setInferBatchSize(model.getOrDefault(model.inferBatchSize))
     if(model.isSet(model.treeLimit)) xgb.setTreeLimit(model.getOrDefault(model.treeLimit))
     if(model.isSet(model.useExternalMemory)) xgb.set(xgb.useExternalMemory, model.getOrDefault(model.useExternalMemory))
+    if(model.isSet(model.objective)) xgb.set(xgb.objective, model.getOrDefault(model.objective))
     xgb
   }
 

--- a/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
+++ b/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
@@ -40,7 +40,7 @@ class XGBoostClassificationModelOp extends SimpleSparkOp[XGBoostClassificationMo
         withValue("missing", Value.float(obj.getOrDefault(obj.missing))).
         withValue("infer_batch_size", Value.int(obj.getOrDefault(obj.inferBatchSize))).
         withValue("use_external_memory", Value.boolean(obj.getOrDefault(obj.useExternalMemory))).
-        withValue("allow_non_zero_for_missing", Value.boolean(obj.getOrDefault(obj.allowNonZeroForMissing)))
+        withValue("allow_non_zero_for_missing", Value.boolean(obj.getOrDefault(obj.allowNonZeroForMissing))).
         withValue("objective", Value.string(obj.getOrDefault(obj.objective)))
     }
 

--- a/mleap-xgboost-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelParitySpec.scala
+++ b/mleap-xgboost-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelParitySpec.scala
@@ -31,7 +31,7 @@ class XGBoostClassificationModelParitySpec extends SparkParityBase {
   )
 
   // These params are not needed for making predictions, so we don't serialize them
-  override val unserializedParams = Set("labelCol", "evalMetric", "objective")
+  override val unserializedParams = Set("labelCol", "evalMetric")
 
   override val excludedColsForComparison = Array[String]("prediction")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   lazy val slf4jVersion = "1.7.36"
   lazy val awsSdkVersion = "1.11.1033"
   val tensorflowJavaVersion = "0.4.0" // Match Tensorflow 2.7.0 https://github.com/tensorflow/java/#tensorflow-version-support
-  val xgboostVersion = "1.6.1"
+  val xgboostVersion = "1.7.3"
   val breezeVersion = "1.2"
   val hadoopVersion = "2.7.4" // matches spark version
   val platforms = "windows-x86_64,linux-x86_64,macosx-x86_64"


### PR DESCRIPTION
Preserve `objective` when serializing `XGBoostClassificationModel`. `objective` is used in `transform`:

https://github.com/dmlc/xgboost/blob/a65ad0bd9c26ff0ce4cb842d3312064cd1e9eadc/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala#L396

```
    if (getObjective.equals("multi:softmax")) {
```