### PR TITLE
Allow casting a tensor of size 1 to scalar

### DIFF
--- a/mleap-core/src/main/scala/ml/combust/mleap/core/types/Casting.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/types/Casting.scala
@@ -143,7 +143,7 @@ object Casting {
             }
           }
         }
-      case (tt: TensorType, _: ScalarType) if tt.dimensions.exists(_.isEmpty) =>
+      case (tt: TensorType, _: ScalarType) if tt.dimensions.exists(dimensions => dimensions.isEmpty || dimensions.product == 1) =>
         baseCast(from.base, to.base).map {
           _.map {
             c => (v: Any) => c(v.asInstanceOf[Tensor[_]](0))

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/types/CastingSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/types/CastingSpec.scala
@@ -197,6 +197,7 @@ class CastingSpec extends FunSpec {
         val tc = Casting.cast(ScalarType(from), TensorType(to, Some(Seq()))).getOrElse(Success((v: Any) => v)).get
         val ct = Casting.cast(TensorType(from, Some(Seq())), ScalarType(to)).getOrElse(Success((v: Any) => v)).get
         val lct = Casting.cast(TensorType(from, Some(Seq(expectedList.length))), ListType(to)).getOrElse(Success((v: Any) => v)).get
+        val ct1 = Casting.cast(TensorType(from, Some(Seq(1))), ScalarType(to)).getOrElse(Success((v: Any) => v)).get
 
         assert(c(fromTensor) == expectedTensor)
         assertThrows[NullPointerException](oc(null))
@@ -205,6 +206,7 @@ class CastingSpec extends FunSpec {
         assert(tc(fromValue) == expectedScalarTensor)
         assert(ct(fromScalarTensor) == expectedValue)
         assert(lct(fromListTensor) == expectedList)
+        assert(ct1(fromTensor) == expectedValue)
       }
 
     }


### PR DESCRIPTION
- Allow casting a tensor of size 1 to scalar
- Since, we already allow casting a tensor with empty dimensions to scalar, this should be pretty similar as it can be done safely