### PR TITLE
Upgrade to Spark 3.4.0.

### DIFF
--- a/mleap-core/src/main/scala/ml/combust/mleap/core/ann/BreezeUtil.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/ann/BreezeUtil.scala
@@ -18,7 +18,7 @@ package ml.combust.mleap.core.ann
  */
 
 import breeze.linalg.{DenseMatrix => BDM, DenseVector => BDV}
-import com.github.fommil.netlib.BLAS.{getInstance => NativeBLAS}
+import dev.ludovic.netlib.blas.BLAS.{getInstance => NativeBLAS}
 import ml.combust.mleap.core.annotation.SparkCode
 
 /**

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/clustering/optimization/LDAOptimizer.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/clustering/optimization/LDAOptimizer.scala
@@ -2,7 +2,7 @@ package ml.combust.mleap.core.clustering.optimization
 
 import breeze.linalg.{Vector, sum, DenseMatrix => BDM, DenseVector => BDV, SparseVector => BSV}
 import breeze.numerics.{abs, exp}
-import breeze.stats.distributions.Gamma
+import breeze.stats.distributions.{Gamma, RandBasis}
 import ml.combust.mleap.core.annotation.SparkCode
 import ml.combust.mleap.core.clustering.LDAUtils
 
@@ -35,7 +35,7 @@ private[clustering] object OnlineLDAOptimizer {
     }
     // Initialize the variational distribution q(theta|gamma) for the mini-batch
     val gammad: BDV[Double] =
-      new Gamma(gammaShape, 1.0 / gammaShape).samplesVector(k)                   // K
+      new Gamma(gammaShape, 1.0 / gammaShape)(RandBasis.mt0).samplesVector(k)                   // K
     val expElogthetad: BDV[Double] = exp(LDAUtils.dirichletExpectation(gammad))  // K
     val expElogbetad = expElogbeta(ids, ::).toDenseMatrix                        // ids * K
 

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/linalg/CholeskyDecomposition.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/linalg/CholeskyDecomposition.scala
@@ -17,7 +17,7 @@
 
 package ml.combust.mleap.core.linalg
 
-import com.github.fommil.netlib.LAPACK.{getInstance => lapack}
+import dev.ludovic.netlib.lapack.LAPACK.{getInstance => lapack}
 import ml.combust.mleap.core.annotation.SparkCode
 import org.netlib.util.intW
 

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/recommendation/ALSModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/recommendation/ALSModel.scala
@@ -3,7 +3,7 @@ package ml.combust.mleap.core.recommendation
 import ml.combust.mleap.core.Model
 import ml.combust.mleap.core.annotation.SparkCode
 import ml.combust.mleap.core.types.{ScalarType, StructType}
-import com.github.fommil.netlib.BLAS.{getInstance => blas}
+import dev.ludovic.netlib.blas.BLAS.{getInstance => blas}
 
 @SparkCode(uri = "https://github.com/apache/spark/blob/v2.2.0/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala")
 case class ALSModel(rank: Integer, userFactors: Map[Int, Array[Float]], itemFactors: Map[Int, Array[Float]]) extends Model {

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/regression/GeneralizedLinearRegressionModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/regression/GeneralizedLinearRegressionModel.scala
@@ -2,6 +2,7 @@ package ml.combust.mleap.core.regression
 
 import breeze.numerics.erfinv
 import breeze.stats.{distributions => dist}
+import breeze.stats.distributions.RandBasis
 import ml.combust.mleap.core.Model
 import ml.combust.mleap.core.annotation.SparkCode
 import ml.combust.mleap.core.regression.GeneralizedLinearRegressionModel.FamilyAndLink
@@ -275,16 +276,17 @@ object GeneralizedLinearRegressionModel {
   }
 
   object Probit extends Link("probit") {
+    private val rand = RandBasis.mt0
     //TODO: use Gaussian#inverseCdf() from breeze 0.13 after updating to spark 2.2
     private def icdf(mu:Double, sigma:Double, p:Double) = mu + sigma * math.sqrt(2.0) * erfinv(2 * p - 1)
 
     override def link(mu: Double): Double = icdf(0.0, 1.0, mu)
 
     override def deriv(mu: Double): Double = {
-      1.0 / dist.Gaussian(0.0, 1.0).pdf(icdf(0.0, 1.0, mu))
+      1.0 / dist.Gaussian(0.0, 1.0)(rand).pdf(icdf(0.0, 1.0, mu))
     }
 
-    override def unlink(eta: Double): Double = dist.Gaussian(0.0, 1.0).cdf(eta)
+    override def unlink(eta: Double): Double = dist.Gaussian(0.0, 1.0)(rand).cdf(eta)
   }
 
   object CLogLog extends Link("cloglog") {

--- a/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
+++ b/mleap-spark-testkit/src/main/scala/org/apache/spark/ml/parity/SparkParityBase.scala
@@ -182,7 +182,7 @@ abstract class SparkParityBase extends FunSpec with BeforeAndAfterAll {
     }
   }
 
-  var relTolEps: Double = 1E-7
+  var relTolEps: Double = 1E-6
   def equalityTest(sparkDataset: DataFrame, mleapDataset: DataFrame): Unit = {
     val sparkCols = sparkDataset.columns.toSeq
     assert(mleapDataset.columns.toSet === sparkCols.toSet)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ import Keys._
 object Dependencies {
   import DependencyHelpers._
 
-  val sparkVersion = "3.3.0"
+  val sparkVersion = "3.4.0"
   val scalaTestVersion = "3.0.8"
   val junitVersion = "5.8.2"
   val akkaVersion = "2.6.14" // Stay below akka v2.7.0 since they swapped to a BSL license
@@ -14,12 +14,12 @@ object Dependencies {
   val springBootVersion = "2.6.2"
   lazy val logbackVersion = "1.2.3"
   lazy val loggingVersion = "3.9.0"
-  lazy val slf4jVersion = "1.7.36"
+  lazy val slf4jVersion = "2.0.6"
   lazy val awsSdkVersion = "1.11.1033"
   val tensorflowJavaVersion = "0.5.0" // Match Tensorflow 2.10.1 https://github.com/tensorflow/java/#tensorflow-version-support
   val xgboostVersion = "1.7.3"
-  val breezeVersion = "1.2"
-  val hadoopVersion = "2.7.4" // matches spark version
+  val breezeVersion = "2.1.0"
+  val hadoopVersion = "3.3.4" // matches spark version
   val platforms = "windows-x86_64,linux-x86_64,macosx-x86_64"
   val tensorflowPlatforms : Array[String] =  sys.env.getOrElse("TENSORFLOW_PLATFORMS", platforms).split(",")
 
@@ -32,7 +32,7 @@ object Dependencies {
       "org.apache.spark" %% "spark-catalyst" % sparkVersion,
       "org.apache.spark" %% "spark-avro" % sparkVersion
     )
-    val avroDep = "org.apache.avro" % "avro" % "1.8.1"
+    val avroDep = "org.apache.avro" % "avro" % "1.11.1"
     val sprayJson = "io.spray" %% "spray-json" % "1.3.2"
     val arm = "com.jsuereth" %% "scala-arm" % "2.0"
     val config = "com.typesafe" % "config" % "1.3.0"


### PR DESCRIPTION
- Upgrade to Spark 3.4.0
- Upgrade Breeze to match Spark's version.  This required a few other small changes since they had changed their underlying netlib dependency and made some incompatible changes from v1.x to v2.x
- Upgrade slf4j to match Spark's version.
- Upgrade avro to match Spark's version.
- Upgrade hadoop to match Spark's version.