### PR TITLE
Ground work for making mleap scala 2.13 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # Use container-based infrastructure
 os: linux
-dist: focal
+dist: jammy
 
 # Set default python env
 # because the xgboost-spark library when running training code, it will
@@ -22,7 +22,7 @@ services:
 
 language: scala
 scala:
-  - 2.12.13
+  - 2.12.18
 jdk:
   - openjdk11
 
@@ -43,27 +43,27 @@ jobs:
 
     - name: "Python 3.7 tests"
       language: python
-      python: 3.7.9
+      python: 3.7.15
       install:
         - pip install tox
       before_script:
         - >
           curl
-          --create-dirs -L -o /home/travis/.sbt/launchers/1.4.9/sbt-launch.jar
-          https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.9/sbt-launch-1.4.9.jar
+          --create-dirs -L -o /home/travis/.sbt/launchers/1.9.4/sbt-launch.jar
+          https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.9.4/sbt-launch-1.9.4.jar
       script:
         - make test_python37
 
     - name: "Python 3.8 tests"
       language: python
-      python: 3.8.15
+      python: 3.8.16
       install:
         - pip install tox
       before_script:
         - >
           curl
-          --create-dirs -L -o /home/travis/.sbt/launchers/1.4.9/sbt-launch.jar
-          https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.9/sbt-launch-1.4.9.jar
+          --create-dirs -L -o /home/travis/.sbt/launchers/1.9.4/sbt-launch.jar
+          https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.9.4/sbt-launch-1.9.4.jar
       script:
         - make test_python38
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.feature.{Binarizer, StringIndexer}
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
-import resource._
+import scala.util.Using
 
   val datasetName = "./examples/spark-demo.csv"
 
@@ -143,7 +143,7 @@ import resource._
 
   // then serialize pipeline
   val sbc = SparkBundleContext().withDataset(pipeline.transform(dataframe))
-  for(bf <- managed(BundleFile("jar:file:/tmp/simple-spark-pipeline.zip"))) {
+  Using(BundleFile("jar:file:/tmp/simple-spark-pipeline.zip")) { bf =>
     pipeline.writeBundle.save(bf)(sbc).get
   }
 ```
@@ -215,9 +215,9 @@ Because we export Spark and Scikit-learn pipelines to a standard format, we can 
 ```scala
 import ml.combust.bundle.BundleFile
 import ml.combust.mleap.runtime.MleapSupport._
-import resource._
+import scala.util.Using
 // load the Spark pipeline we saved in the previous section
-val bundle = (for(bundleFile <- managed(BundleFile("jar:file:/tmp/simple-spark-pipeline.zip"))) yield {
+val bundle = Using(BundleFile("jar:file:/tmp/simple-spark-pipeline.zip"))) { bundleFile =>
   bundleFile.loadMleapBundle().get
 }).opt.get
 
@@ -271,7 +271,7 @@ For more documentation, please see our [documentation](https://combust.github.io
 
 ## Building
 
-Please ensure you have sbt 1.4.9, java 11, scala 2.12.13
+Please ensure you have sbt 1.9.3, java 11, scala 2.12.13
 
 1. Initialize the git submodules `git submodule update --init --recursive`
 2. Run `sbt compile`

--- a/bundle-hdfs/src/test/scala/ml/bundle/hdfs/HadoopBundleFileSystemSpec.scala
+++ b/bundle-hdfs/src/test/scala/ml/bundle/hdfs/HadoopBundleFileSystemSpec.scala
@@ -5,9 +5,9 @@ import java.nio.file.{Files, Paths}
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class HadoopBundleFileSystemSpec extends FunSpec {
+class HadoopBundleFileSystemSpec extends org.scalatest.funspec.AnyFunSpec {
   private val fs = FileSystem.get(new Configuration())
   private val bundleFs = new HadoopBundleFileSystem(fs)
 

--- a/bundle-ml/src/main/scala/ml/combust/bundle/BundleRegistry.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/BundleRegistry.scala
@@ -7,7 +7,7 @@ import ml.combust.bundle.fs.BundleFileSystem
 import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.mleap.ClassLoaderUtil
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /** Trait for classes that contain a bundle registry.
   *
@@ -39,7 +39,7 @@ object BundleRegistry {
 
     val br = ops.foldLeft(Map[String, OpNode[_, _, _]]()) {
       (m, opClass) =>
-        val opNode = cl.loadClass(opClass).newInstance().asInstanceOf[OpNode[_, _, _]]
+        val opNode = cl.loadClass(opClass).getDeclaredConstructor().newInstance().asInstanceOf[OpNode[_, _, _]]
         m + (opNode.Model.opName -> opNode)
     }.values.foldLeft(BundleRegistry(cl)) {
       (br, opNode) => br.register(opNode)

--- a/bundle-ml/src/main/scala/ml/combust/bundle/serializer/FileUtil.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/serializer/FileUtil.scala
@@ -1,76 +1,40 @@
 package ml.combust.bundle.serializer
 
-import java.io.{File, FileInputStream, FileOutputStream}
-import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
-
-import resource._
+import java.io.File
+import java.util.zip.{ZipInputStream, ZipOutputStream}
 
 /**
   * Created by hollinwilkins on 9/11/16.
   */
+@deprecated("Prefer ml.combust.bundle.util.FileUtil object.")
 case class FileUtil() {
+  import ml.combust.bundle.util.{FileUtil => FileUtils}
+  @deprecated("use FileUtil.rmRF(Path).")
   def rmRF(path: File): Array[(String, Boolean)] = {
-    Option(path.listFiles).map(_.flatMap(f => rmRF(f))).getOrElse(Array()) :+ (path.getPath -> path.delete)
+    FileUtils.rmRF(path.toPath)
   }
 
+  @deprecated("use extract(Path, Path).")
   def extract(source: File, dest: File): Unit = {
-    dest.mkdirs()
-    for(in <- managed(new ZipInputStream(new FileInputStream(source)))) {
-      extract(in, dest)
-    }
+    FileUtils.extract(source.toPath, dest.toPath)
   }
 
+  @deprecated("use extract(ZipInputStream, Path).")
   def extract(in: ZipInputStream, dest: File): Unit = {
-    dest.mkdirs()
-    val buffer = new Array[Byte](1024 * 1024)
-
-    var entry = in.getNextEntry
-    while(entry != null) {
-      if(entry.isDirectory) {
-        new File(dest, entry.getName).mkdirs()
-      } else {
-        val filePath = new File(dest, entry.getName)
-        for(out <- managed(new FileOutputStream(filePath))) {
-          var len = in.read(buffer)
-          while(len > 0) {
-            out.write(buffer, 0, len)
-            len = in.read(buffer)
-          }
-        }
-      }
-      entry = in.getNextEntry
-    }
+    FileUtils.extract(in, dest.toPath)
   }
 
+  @deprecated("use FileUtil.extract(Path, Path).")
   def zip(source: File, dest: File): Unit = {
-    for(out <- managed(new ZipOutputStream(new FileOutputStream(dest)))) {
-      zip(source, out)
-    }
+    FileUtils.zip(source.toPath, dest.toPath)
   }
 
-  def zip(source: File, dest: ZipOutputStream): Unit = zip(source, source, dest)
+  @deprecated("use FileUtil.extract(Path, ZipOutputStream).")
+  def zip(source: File, dest: ZipOutputStream): Unit = FileUtils.zip(source.toPath, source.toPath, dest)
 
+  @deprecated("use FileUtil.extract(Path, Path, ZipOutputStream).")
   def zip(base: File, source: File, dest: ZipOutputStream): Unit = {
-    val buffer = new Array[Byte](1024 * 1024)
-
-    for(files <- Option(source.listFiles);
-        file <- files) {
-      val name = file.toString.substring(base.toString.length + 1)
-
-      if(file.isDirectory) {
-        dest.putNextEntry(new ZipEntry(s"$name/"))
-        zip(base, file, dest)
-      } else {
-        dest.putNextEntry(new ZipEntry(name))
-
-        for (in <- managed(new FileInputStream(file))) {
-          var read = in.read(buffer)
-          while (read > 0) {
-            dest.write(buffer, 0, read)
-            read = in.read(buffer)
-          }
-        }
-      }
-    }
+    FileUtils.zip(base.toPath, source.toPath, dest)
   }
+
 }

--- a/bundle-ml/src/main/scala/ml/combust/bundle/serializer/NodeSerializer.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/serializer/NodeSerializer.scala
@@ -88,7 +88,7 @@ case class NodeSerializer[Context](bundleContext: BundleContext[Context]) {
         val shape = op.shape(obj)(bundleContext)
         Node(name = name, shape = shape)
     }
-  }.flatMap(identity).flatMap {
+  }.flatten.flatMap {
     node => Try(FormatNodeSerializer.serializer.write(bundleContext.file(Bundle.nodeFile), node))
   }
 

--- a/bundle-ml/src/main/scala/ml/combust/bundle/tensor/ArraySerializer.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/tensor/ArraySerializer.scala
@@ -2,12 +2,10 @@ package ml.combust.bundle.tensor
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, DataOutputStream}
 import java.nio.ByteBuffer
-
 import ml.combust.mleap.tensor.ByteString
-import resource._
 
 import scala.collection.mutable
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success, Try, Using}
 
 /**
   * Created by hollinwilkins on 1/15/17.
@@ -140,7 +138,7 @@ object DoubleArraySerializer extends ArraySerializer[Double] {
 
 object StringArraySerializer extends ArraySerializer[String] {
   override def write(arr: Array[String]): Array[Byte] = {
-    (for(out <- managed(new ByteArrayOutputStream())) yield {
+    Using(new ByteArrayOutputStream()) { out =>
       val dout = new DataOutputStream(out)
       arr.foreach {
         str =>
@@ -150,11 +148,11 @@ object StringArraySerializer extends ArraySerializer[String] {
 
       dout.flush()
       out.toByteArray
-    }).opt.get
+    }.toOption.get
   }
 
   override def read(arr: Array[Byte]): Array[String] = {
-    (for(in <- managed(new ByteArrayInputStream(arr))) yield {
+    Using(new ByteArrayInputStream(arr)) { in =>
       val din = new DataInputStream(in)
       val arr = mutable.ArrayBuilder.make[String]
 
@@ -172,13 +170,13 @@ object StringArraySerializer extends ArraySerializer[String] {
       }
 
       arr.result()
-    }).opt.get
+    }.toOption.get
   }
 }
 
 object ByteStringArraySerializer extends ArraySerializer[ByteString] {
   override def write(arr: Array[ByteString]): Array[Byte] = {
-    (for(out <- managed(new ByteArrayOutputStream())) yield {
+    Using(new ByteArrayOutputStream()) { out =>
       val dout = new DataOutputStream(out)
       arr.foreach {
         bs =>
@@ -188,11 +186,11 @@ object ByteStringArraySerializer extends ArraySerializer[ByteString] {
 
       dout.flush()
       out.toByteArray
-    }).opt.get
+    }.toOption.get
   }
 
   override def read(arr: Array[Byte]): Array[ByteString] = {
-    (for(in <- managed(new ByteArrayInputStream(arr))) yield {
+    Using(new ByteArrayInputStream(arr)) { in =>
       val din = new DataInputStream(in)
       val arr = mutable.ArrayBuilder.make[ByteString]
 
@@ -210,6 +208,6 @@ object ByteStringArraySerializer extends ArraySerializer[ByteString] {
       }
 
       arr.result()
-    }).opt.get
+    }.toOption.get
   }
 }

--- a/bundle-ml/src/main/scala/ml/combust/bundle/util/FileUtil.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/util/FileUtil.scala
@@ -1,13 +1,19 @@
 package ml.combust.bundle.util
 
-import java.io.IOException
+import java.io.{IOException, InputStream, OutputStream}
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
-
+import java.util.Comparator
+import java.util.stream.Collectors
+import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
+import scala.jdk.CollectionConverters.iterableAsScalaIterableConverter
+import scala.util.{Failure, Success, Try, Using}
 /**
   * Created by hollinwilkins on 12/24/16.
   */
 object FileUtil {
+  private val bufferSize = 1024 * 1024
+
   def rmRf(path: Path): Unit = {
     Files.walkFileTree(path, new SimpleFileVisitor[Path]() {
       override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
@@ -20,5 +26,91 @@ object FileUtil {
         FileVisitResult.CONTINUE
       }
     })
+  }
+
+  def rmRF(toRemove: Path): Array[(String, Boolean)] = {
+    def removeElement(path: Path): (String, Boolean) = {
+      val result = Try {
+        Files.deleteIfExists(toRemove)
+      } match {
+        case Failure(_) => false
+        case Success(value) => value
+      }
+      path.toAbsolutePath.toString -> result
+    }
+
+    if (Files.isDirectory(toRemove)) {
+      Using(Files.walk(toRemove)) {
+        paths =>
+          paths
+            .sorted(Comparator.reverseOrder())
+            .collect(Collectors.toList())
+            .asScala
+            .map(removeElement)
+            .toArray
+      }.getOrElse(Array.empty)
+    } else {
+      Array(removeElement(toRemove))
+    }
+  }
+
+  def extract(source: Path, dest: Path): Unit = {
+    Files.createDirectories(dest)
+    Using(new ZipInputStream(Files.newInputStream(source))) {
+      in => extract(in, dest)
+    }
+  }
+
+  def extract(in: ZipInputStream, dest: Path): Unit = {
+    Files.createDirectories(dest)
+
+    var entry = in.getNextEntry
+    while (entry != null) {
+      val filePath = dest.resolve(entry.getName)
+      if (entry.isDirectory) {
+        Files.createDirectories(filePath)
+      } else {
+        Using(Files.newOutputStream(filePath)) {
+          out => writeData(in, out)
+        }
+      }
+      entry = in.getNextEntry
+    }
+  }
+
+  def zip(source: Path, dest: Path): Unit = {
+    Using(new ZipOutputStream(Files.newOutputStream(dest))) {
+      out => zip(source, out)
+    }
+  }
+
+  def zip(source: Path, dest: ZipOutputStream): Unit = zip(source, source, dest)
+
+
+  def zip(base: Path, source: Path, dest: ZipOutputStream): Unit = {
+    Using(Files.walk(source)) { paths =>
+      paths.forEachOrdered(
+        path => {
+          val name = base.relativize(path).toString
+          if (!Files.isDirectory(path)) {
+            dest.putNextEntry(new ZipEntry(name))
+            Using(Files.newInputStream(path)) {
+              in => writeData(in, dest)
+            }
+          } else {
+            dest.putNextEntry(new ZipEntry(s"$name/"))
+            zip(base, path, dest)
+          }
+        })
+    }
+  }
+
+  private def writeData(in: InputStream, out: OutputStream): Unit = {
+    val buffer = new Array[Byte](bufferSize)
+    var len = in.read(buffer)
+    while (len > 0) {
+      out.write(buffer, 0, len)
+      len = in.read(buffer)
+    }
   }
 }

--- a/bundle-ml/src/test/scala/ml/combust/bundle/TestUtil.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/TestUtil.scala
@@ -1,17 +1,11 @@
 package ml.combust.bundle
 
-import java.io.File
+import java.nio.file.{Files, Path}
 
 /**
   * Created by hollinwilkins on 8/23/16.
   */
 object TestUtil {
-  val baseDir = new File("/tmp/bundle-ml")
-  TestUtil.delete(baseDir)
-  baseDir.mkdirs()
-
-  def delete(file: File): Array[(String, Boolean)] = {
-    Option(file.listFiles).map(_.flatMap(f => delete(f))).getOrElse(Array()) :+ (file.getPath -> file.delete)
-  }
+  val baseDir: Path = Files.createTempDirectory("mleap-bundle-tests").toAbsolutePath
 }
 

--- a/bundle-ml/src/test/scala/ml/combust/bundle/serializer/BundleFileSystemSpec.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/serializer/BundleFileSystemSpec.scala
@@ -7,12 +7,12 @@ import ml.combust.bundle.test.TestSupport._
 import ml.combust.bundle.{BundleFile, BundleRegistry}
 import ml.combust.bundle.test.ops._
 import ml.combust.bundle.test.{TestBundleFileSystem, TestContext}
-import org.scalatest.FunSpec
-import resource.managed
+import org.scalatest.funspec.AnyFunSpec
+import scala.util.Using
 
 import scala.util.Random
 
-class BundleFileSystemSpec extends FunSpec {
+class BundleFileSystemSpec extends org.scalatest.funspec.AnyFunSpec {
   implicit val testContext = TestContext(BundleRegistry("test-registry").
     registerFileSystem(new TestBundleFileSystem))
 

--- a/bundle-ml/src/test/scala/ml/combust/bundle/serializer/NoteSerializationSpec.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/serializer/NoteSerializationSpec.scala
@@ -3,19 +3,19 @@ package ml.combust.bundle.serializer
 import java.net.URI
 
 import ml.combust.bundle.{BundleFile, BundleRegistry, TestUtil}
-import org.scalatest.FunSpec
-import resource._
+import org.scalatest.funspec.AnyFunSpec
+import scala.util.Using
 
 /**
   * Created by hollinwilkins on 12/24/16.
   */
-class NoteSerializationSpec extends FunSpec {
+class NoteSerializationSpec extends org.scalatest.funspec.AnyFunSpec {
   implicit val registry = BundleRegistry("test-registry")
 
   describe("Bundle.ML notes serialization") {
     it("serializes and deserializes text notes") {
       val uri = new URI(s"jar:file:${TestUtil.baseDir}/notes.bundle.zip")
-      for(serializer <- managed(BundleFile(uri))) {
+      Using(BundleFile(uri)) { serializer =>
         serializer.writeNote("note.txt", "Another note")
         serializer.writeNote("test.txt", "Hello, there!")
 

--- a/bundle-ml/src/test/scala/ml/combust/bundle/test/TestSupport.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/test/TestSupport.scala
@@ -1,11 +1,12 @@
 package ml.combust.bundle.test
 
-import java.net.URI
+import ml.combust.bundle.dsl.Bundle
 
+import java.net.URI
 import ml.combust.bundle.{BundleFile, BundleWriter}
 import ml.combust.bundle.test.ops.Transformer
 
-import resource._
+import scala.util.{Try, Using}
 
 /**
   * Created by hollinwilkins on 12/24/16.
@@ -16,14 +17,14 @@ trait TestSupport {
   }
 
   implicit class BundleFileOps(file: BundleFile) {
-    def loadBundle()(implicit context: TestContext) = file.load[TestContext, Transformer]()
+    def loadBundle()(implicit context: TestContext): Try[Bundle[Transformer]] = file.load[TestContext, Transformer]()
   }
 
   implicit class URIFileOps(uri: URI) {
-    def loadBundle()(implicit context: TestContext) = {
-      (for (bf <- managed(BundleFile.load(uri))) yield {
+    def loadBundle()(implicit context: TestContext): Try[Bundle[Transformer]] = {
+      Using(BundleFile.load(uri)) { bf =>
         bf.load[TestContext, Transformer]().get
-      }).tried
+      }
     }
   }
 }

--- a/mleap-avro/src/main/scala/ml/combust/mleap/avro/DefaultFrameReader.scala
+++ b/mleap-avro/src/main/scala/ml/combust/mleap/avro/DefaultFrameReader.scala
@@ -16,7 +16,7 @@ import scala.util.Try
   * Created by hollinwilkins on 11/2/16.
   */
 class DefaultFrameReader extends FrameReader {
-  val valueConverter = ValueConverter()
+  private val valueConverter = ValueConverter()
 
   override def fromBytes(bytes: Array[Byte], charset: Charset = BuiltinFormats.charset): Try[DefaultLeapFrame] = Try {
     val datumReader = new GenericDatumReader[GenericData.Record]()

--- a/mleap-avro/src/main/scala/ml/combust/mleap/avro/DefaultFrameWriter.scala
+++ b/mleap-avro/src/main/scala/ml/combust/mleap/avro/DefaultFrameWriter.scala
@@ -9,7 +9,7 @@ import org.apache.avro.generic.{GenericData, GenericDatumWriter}
 import SchemaConverter._
 import ml.combust.mleap.runtime.frame.LeapFrame
 import ml.combust.mleap.runtime.serialization.{BuiltinFormats, FrameWriter}
-import resource._
+import scala.util.Using
 
 import scala.util.{Failure, Try}
 
@@ -20,7 +20,7 @@ class DefaultFrameWriter[LF <: LeapFrame[LF]](frame: LF) extends FrameWriter {
   val valueConverter = ValueConverter()
 
   override def toBytes(charset: Charset = BuiltinFormats.charset): Try[Array[Byte]] = {
-    (for(out <- managed(new ByteArrayOutputStream())) yield {
+    Using(new ByteArrayOutputStream()) { out =>
       val writers = frame.schema.fields.map(_.dataType).map(valueConverter.mleapToAvro)
       val avroSchema = frame.schema: Schema
       val record = new GenericData.Record(avroSchema)
@@ -44,6 +44,6 @@ class DefaultFrameWriter[LF <: LeapFrame[LF]](frame: LF) extends FrameWriter {
       writer.close()
 
       out.toByteArray
-    }).tried
+    }
   }
 }

--- a/mleap-avro/src/main/scala/ml/combust/mleap/avro/DefaultRowWriter.scala
+++ b/mleap-avro/src/main/scala/ml/combust/mleap/avro/DefaultRowWriter.scala
@@ -10,7 +10,7 @@ import SchemaConverter._
 import ml.combust.mleap.runtime.serialization.{BuiltinFormats, RowWriter}
 import ml.combust.mleap.core.types.StructType
 import ml.combust.mleap.runtime.frame.Row
-import resource._
+import scala.util.Using
 
 import scala.util.Try
 
@@ -26,7 +26,7 @@ class DefaultRowWriter(override val schema: StructType) extends RowWriter {
   var record = new GenericData.Record(avroSchema)
 
   override def toBytes(row: Row, charset: Charset = BuiltinFormats.charset): Try[Array[Byte]] = {
-    (for(out <- managed(new ByteArrayOutputStream(1024))) yield {
+    Using(new ByteArrayOutputStream(1024)) { out =>
       encoder = EncoderFactory.get().binaryEncoder(out, encoder)
 
       var i = 0
@@ -38,6 +38,6 @@ class DefaultRowWriter(override val schema: StructType) extends RowWriter {
       encoder.flush()
 
       out.toByteArray
-    }).tried
+    }
   }
 }

--- a/mleap-avro/src/main/scala/ml/combust/mleap/avro/ValueConverter.scala
+++ b/mleap-avro/src/main/scala/ml/combust/mleap/avro/ValueConverter.scala
@@ -6,7 +6,7 @@ import ml.combust.mleap.tensor.{ByteString, DenseTensor, SparseTensor, Tensor}
 import org.apache.avro.generic.GenericData
 import org.apache.avro.util.Utf8
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
   * Created by hollinwilkins on 10/31/16.

--- a/mleap-avro/src/test/scala/ml/combust/mleap/avro/DefaultFrameSerializerSpec.scala
+++ b/mleap-avro/src/test/scala/ml/combust/mleap/avro/DefaultFrameSerializerSpec.scala
@@ -5,12 +5,12 @@ import ml.combust.mleap.runtime.serialization.FrameReader
 import ml.combust.mleap.tensor.{ByteString, Tensor}
 import ml.combust.mleap.runtime.MleapSupport._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 10/31/16.
   */
-class DefaultFrameSerializerSpec extends FunSpec {
+class DefaultFrameSerializerSpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(StructField("test_double", ScalarType.Double),
     StructField("test_float", ScalarType.Float),
     StructField("test_string", ScalarType.String),

--- a/mleap-base/src/main/scala/ml/combust/mleap/ClassLoaderUtil.scala
+++ b/mleap-base/src/main/scala/ml/combust/mleap/ClassLoaderUtil.scala
@@ -1,36 +1,36 @@
 package ml.combust.mleap
 
-import scala.util.control.NonFatal
+
+import scala.jdk.OptionConverters.RichOptional
 
 /**
-  * Created by hollinwilkins on 10/31/16.
-  */
+ * Created by hollinwilkins on 10/31/16.
+ */
 object ClassLoaderUtil {
+  private val walker: StackWalker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)
+
+  /**
+   * refer to the [[StackWalker]]'s `getCallerClass` javadoc.
+   */
+  private val MAGIC = 2
+
   def findClassLoader(baseName: String): ClassLoader = {
-    def findCaller(get: Int ⇒ Class[_]): ClassLoader =
-      Iterator.from(2 /*is the magic number, promise*/ ).map(get) dropWhile { c ⇒
+    def findCaller: Option[ClassLoader] = {
+
+      walker.walk(s => s.skip(MAGIC).dropWhile(clz => {
+        val c = clz.getDeclaringClass.getCanonicalName
         c != null &&
-          (c.getName.startsWith(baseName) ||
-            c.getName.startsWith("scala.Option") ||
-            c.getName.startsWith("scala.collection.Iterator") ||
-            c.getName.startsWith("ml.combust.bundle.util.ClassLoaderUtil"))
-      } next () match {
-        case null => getClass.getClassLoader
-        case c => c.getClassLoader
-      }
+          (c.startsWith(baseName) ||
+            c.startsWith("scala.Option") ||
+            c.startsWith("ml.combust.mleap.ClassLoaderUtil"))
+        })
+        .findFirst()
+        .toScala
+        .map(_.getDeclaringClass.getClassLoader))
+    }
 
     Option(Thread.currentThread.getContextClassLoader) orElse
-      (getCallerClass map findCaller) getOrElse
-      getClass.getClassLoader
-  }
-
-  val getCallerClass: Option[Int ⇒ Class[_]] = {
-    try {
-      val c = Class.forName("sun.reflect.Reflection")
-      val m = c.getMethod("getCallerClass", Array(classOf[Int]): _*)
-      Some((i: Int) ⇒ m.invoke(null, Array[AnyRef](i.asInstanceOf[java.lang.Integer]): _*).asInstanceOf[Class[_]])
-    } catch {
-      case NonFatal(e) ⇒ None
-    }
+      findCaller getOrElse
+      walker.getCallerClass.getClassLoader
   }
 }

--- a/mleap-benchmark/src/main/scala/ml/combust/mleap/benchmark/Benchmark.scala
+++ b/mleap-benchmark/src/main/scala/ml/combust/mleap/benchmark/Benchmark.scala
@@ -1,10 +1,23 @@
 package ml.combust.mleap.benchmark
 
 import com.typesafe.config.Config
+import ml.combust.bundle.BundleFile
+import ml.combust.bundle.dsl.Bundle
+import ml.combust.mleap.runtime.MleapSupport.MleapBundleFileOps
+import ml.combust.mleap.runtime.frame.Transformer
+
+import java.nio.file.Path
+import scala.util.Using
 
 /**
   * Created by hollinwilkins on 2/4/17.
   */
 trait Benchmark {
   def benchmark(config: Config): Unit
+
+  protected def mleapBundleForPath(path: Path): Bundle[Transformer] = {
+    Using(BundleFile(path)) { bf =>
+      bf.loadMleapBundle()
+    }.flatten.get
+  }
 }

--- a/mleap-benchmark/src/main/scala/ml/combust/mleap/benchmark/Boot.scala
+++ b/mleap-benchmark/src/main/scala/ml/combust/mleap/benchmark/Boot.scala
@@ -42,11 +42,11 @@ object Boot extends App {
     }.children(modelPath, framePath)
   }
 
-  parser.parse(args, ConfigFactory.empty()) match {
-    case Some(config) =>
-      Class.forName(config.getString("benchmark")).
-        newInstance().
-        asInstanceOf[Benchmark].benchmark(config)
-    case None => // do nothing
+  parser.parse(args, ConfigFactory.empty()).foreach { config =>
+      Class.forName(config.getString("benchmark"))
+        .getDeclaredConstructor()
+        .newInstance()
+        .asInstanceOf[Benchmark]
+        .benchmark(config)
   }
 }

--- a/mleap-benchmark/src/main/scala/ml/combust/mleap/benchmark/MleapRowTransformBenchmark.scala
+++ b/mleap-benchmark/src/main/scala/ml/combust/mleap/benchmark/MleapRowTransformBenchmark.scala
@@ -1,22 +1,18 @@
 package ml.combust.mleap.benchmark
-import java.io.File
-
 import com.typesafe.config.Config
-import ml.combust.bundle.BundleFile
+import ml.combust.mleap.runtime.frame.{RowTransformer, Transformer}
 import ml.combust.mleap.runtime.serialization.{BuiltinFormats, FrameReader}
-import ml.combust.mleap.runtime.MleapSupport._
-import ml.combust.mleap.runtime.frame.RowTransformer
 import org.scalameter.{Bench, Gen}
-import resource._
+
+import java.io.File
+import java.nio.file.Path
 
 /**
   * Created by hollinwilkins on 2/4/17.
   */
 class MleapRowTransformBenchmark extends Benchmark {
   override def benchmark(config: Config): Unit = {
-    val model = (for(bf <- managed(BundleFile(new File(config.getString("model-path"))))) yield {
-      bf.loadMleapBundle()
-    }).tried.flatMap(identity).get.root
+    val model: Transformer = mleapBundleForPath(Path.of(config.getString("model-path"))).root
     val frame = FrameReader(BuiltinFormats.json).read(new File(config.getString("frame-path"))).get
 
     val rowTransformer = model.transform(RowTransformer(frame.schema)).get

--- a/mleap-benchmark/src/main/scala/ml/combust/mleap/benchmark/MleapTransformBenchmark.scala
+++ b/mleap-benchmark/src/main/scala/ml/combust/mleap/benchmark/MleapTransformBenchmark.scala
@@ -1,22 +1,18 @@
 package ml.combust.mleap.benchmark
 
 import java.io.File
-
 import com.typesafe.config.Config
-import ml.combust.bundle.BundleFile
 import ml.combust.mleap.runtime.serialization.{BuiltinFormats, FrameReader}
-import ml.combust.mleap.runtime.MleapSupport._
 import org.scalameter.{Bench, Gen}
-import resource._
+
+import java.nio.file.Path
 
 /**
   * Created by hollinwilkins on 2/4/17.
   */
 class MleapTransformBenchmark extends Benchmark {
   override def benchmark(config: Config): Unit = {
-    val model = (for(bf <- managed(BundleFile(new File(config.getString("model-path"))))) yield {
-      bf.loadMleapBundle()
-    }).tried.flatMap(identity).get.root
+    val model = mleapBundleForPath(Path.of(config.getString("model-path"))).root
     val frame = FrameReader(BuiltinFormats.json).read(new File(config.getString("frame-path"))).get
 
     val start = config.getInt("start")

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/classification/DecisionTreeClassifierModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/classification/DecisionTreeClassifierModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.classification
 
 import ml.combust.mleap.core.types.{ScalarType, StructField, TensorType}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class DecisionTreeClassifierModelSpec extends FunSpec {
+class DecisionTreeClassifierModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("decision tree classifier model") {
     val model = DecisionTreeClassifierModel(null, 3, 2)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/classification/GBTClassifierModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/classification/GBTClassifierModelSpec.scala
@@ -3,12 +3,12 @@ package ml.combust.mleap.core.classification
 import ml.combust.mleap.core.test.TestUtil
 import ml.combust.mleap.core.types.{BasicType, ScalarType, StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 9/28/16.
   */
-class GBTClassifierModelSpec extends FunSpec {
+class GBTClassifierModelSpec extends org.scalatest.funspec.AnyFunSpec {
   val tree1 = TestUtil.buildDecisionTreeRegression(0.5, 0, goLeft = true)
   val tree2 = TestUtil.buildDecisionTreeRegression(0.75, 1, goLeft = false)
   val tree3 = TestUtil.buildDecisionTreeRegression(-0.1, 2, goLeft = true)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/classification/LogisticRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/classification/LogisticRegressionModelSpec.scala
@@ -2,12 +2,12 @@ package ml.combust.mleap.core.classification
 
 import ml.combust.mleap.core.types.{ScalarType, StructField, TensorType}
 import org.apache.spark.ml.linalg.{Matrices, Vectors}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 5/23/17.
   */
-class LogisticRegressionModelSpec extends FunSpec {
+class LogisticRegressionModelSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("BinaryLogisticRegression") {
     val weights = Vectors.dense(1.0, 2.0, 4.0)
     val intercept = 0.7

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/classification/MultiLayerPerceptronClassifierModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/classification/MultiLayerPerceptronClassifierModelSpec.scala
@@ -2,9 +2,9 @@ package ml.combust.mleap.core.classification
 
 import ml.combust.mleap.core.types._
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class MultiLayerPerceptronClassifierModelSpec extends FunSpec {
+class MultiLayerPerceptronClassifierModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("multi layer perceptron classifier model") {
     val model = new MultiLayerPerceptronClassifierModel(Seq(3, 1), Vectors.dense(Array(1.9, 2.2, 4, 1)))

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/classification/NaiveBayesModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/classification/NaiveBayesModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.classification
 
 import ml.combust.mleap.core.types.{ScalarType, StructField, TensorType}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class NaiveBayesModelSpec extends FunSpec {
+class NaiveBayesModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("naive bayes model") {
     val model = new NaiveBayesModel(3, 2, null, null, null)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/classification/OneVsRestModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/classification/OneVsRestModelSpec.scala
@@ -2,9 +2,9 @@ package ml.combust.mleap.core.classification
 
 import ml.combust.mleap.core.types.{ScalarType, StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class OneVsRestModelSpec extends FunSpec {
+class OneVsRestModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("one vs rest model") {
     val model = new OneVsRestModel(Array(

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/classification/RandomForestClassifierModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/classification/RandomForestClassifierModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.classification
 
 import ml.combust.mleap.core.types.{ScalarType, StructField, TensorType}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class RandomForestClassifierModelSpec extends FunSpec {
+class RandomForestClassifierModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("random forest classifier model") {
     val model = new RandomForestClassifierModel(Seq(), Seq(), 3, 2)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/classification/SupportVectorMachineModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/classification/SupportVectorMachineModelSpec.scala
@@ -2,9 +2,9 @@ package ml.combust.mleap.core.classification
 
 import ml.combust.mleap.core.types.{ScalarType, StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class SupportVectorMachineModelSpec extends FunSpec {
+class SupportVectorMachineModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("svm model") {
     val model = new SupportVectorMachineModel(Vectors.dense(1, 2, 3), 2)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/clustering/BisectingKMeansModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/clustering/BisectingKMeansModelSpec.scala
@@ -3,9 +3,9 @@ package ml.combust.mleap.core.clustering
 import ml.combust.mleap.core.types._
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.linalg.mleap.VectorWithNorm
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class BisectingKMeansModelSpec extends FunSpec {
+class BisectingKMeansModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("bisecting kmeans model") {
     val model = new BisectingKMeansModel(ClusteringTreeNode(23,

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/clustering/GaussianMixtureModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/clustering/GaussianMixtureModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.clustering
 
 import ml.combust.mleap.core.types.{ScalarType, StructField, TensorType}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class GaussianMixtureModelSpec extends FunSpec {
+class GaussianMixtureModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("gaussian mixture model") {
     val model = new GaussianMixtureModel(Array(null, null, null), Array(1, 2, 3))

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/clustering/KMeansModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/clustering/KMeansModelSpec.scala
@@ -2,12 +2,12 @@ package ml.combust.mleap.core.clustering
 
 import ml.combust.mleap.core.types.{ScalarType, StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 9/30/16.
   */
-class KMeansModelSpec extends FunSpec {
+class KMeansModelSpec extends org.scalatest.funspec.AnyFunSpec {
   val v1 = Vectors.dense(Array(1.0, 2.0, 55.0))
   val v2 = Vectors.dense(Array(11.0, 200.0, 55.0))
   val v3 = Vectors.dense(Array(100.0, 22.0, 55.0))

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/clustering/LDAModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/clustering/LDAModelSpec.scala
@@ -2,9 +2,9 @@ package ml.combust.mleap.core.clustering
 
 import breeze.linalg.{DenseMatrix, Matrix}
 import ml.combust.mleap.core.types.{StructField, TensorType}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class LDAModelSpec extends FunSpec {
+class LDAModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
 
   describe("lda model") {

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/BinarizerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/BinarizerModelSpec.scala
@@ -2,12 +2,12 @@ package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types._
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by fshabbir on 12/1/16.
   */
-class BinarizerModelSpec extends FunSpec {
+class BinarizerModelSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("binarizer with several inputs"){
     val binarizer = BinarizerModel(0.3, TensorShape(3))
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/BucketedRandomProjectionLSHModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/BucketedRandomProjectionLSHModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{StructField, TensorType}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class BucketedRandomProjectionLSHModelSpec extends FunSpec {
+class BucketedRandomProjectionLSHModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema"){
     val model = new BucketedRandomProjectionLSHModel(Seq(), 5, 3)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/BucketizerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/BucketizerModelSpec.scala
@@ -1,12 +1,12 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{BasicType, ScalarType, StructField}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by mikhail on 9/19/16.
   */
-class BucketizerModelSpec extends FunSpec {
+class BucketizerModelSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("bucketizer") {
     val bucketizer = BucketizerModel(Array(0.0, 10.0, 20.0, 100.0))
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/ChiSqSelectorModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/ChiSqSelectorModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{StructField, TensorType}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class ChiSqSelectorModelSpec extends FunSpec {
+class ChiSqSelectorModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema"){
     val model = new ChiSqSelectorModel(Seq(1,2,3), 3)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/CoalesceModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/CoalesceModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{ScalarType, StructField}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class CoalesceModelSpec extends FunSpec {
+class CoalesceModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema"){
     val model = CoalesceModel(Seq(true, true, true))

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/CountVectorizerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/CountVectorizerModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class CountVectorizerModelSpec extends FunSpec {
+class CountVectorizerModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("binarizer with one input") {
     val model = new CountVectorizerModel(Array("1", "2", "3"), true, 2)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/DCTModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/DCTModelSpec.scala
@@ -2,12 +2,12 @@ package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 4/12/17.
   */
-class DCTModelSpec extends FunSpec {
+class DCTModelSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("dct model") {
     val model = DCTModel(false, 3)
     describe("issue167") {

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/ElementwiseProductModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/ElementwiseProductModelSpec.scala
@@ -2,12 +2,12 @@ package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by mikhail on 9/25/16.
   */
-class ElementwiseProductModelSpec extends FunSpec{
+class ElementwiseProductModelSpec extends org.scalatest.funspec.AnyFunSpec{
   describe("elementwise product model") {
     val scaler = ElementwiseProductModel(Vectors.dense(Array(0.5, 1.0, 1.0)))
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/FeatureHasherModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/FeatureHasherModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class FeatureHasherModelSpec  extends FunSpec {
+class FeatureHasherModelSpec  extends org.scalatest.funspec.AnyFunSpec {
 
   val schema = Seq(
     StructField("doubleCol", DataType(BasicType.Double, ScalarShape())),

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/HashingTermFrequencyModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/HashingTermFrequencyModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class HashingTermFrequencyModelSpec extends FunSpec {
+class HashingTermFrequencyModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("Hashing Term Frequency Model") {
     val model = HashingTermFrequencyModel()

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/IDFModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/IDFModelSpec.scala
@@ -2,9 +2,9 @@ package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class IDFModelSpec extends FunSpec {
+class IDFModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("idf model") {
     val model = IDFModel(Vectors.dense(Array(1.0, 2.0)))

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/ImputerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/ImputerModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{ScalarType, StructField}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class ImputerModelSpec extends FunSpec {
+class ImputerModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema"){
     val model = ImputerModel(12, 23.4, "mean")

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/InteractionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/InteractionModelSpec.scala
@@ -3,12 +3,12 @@ package ml.combust.mleap.core.feature
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.tensor.{DenseTensor, SparseTensor}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 4/26/17.
   */
-class InteractionModelSpec extends FunSpec {
+class InteractionModelSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("with all numeric inputs") {
 
     val encoderSpec: Array[Array[Int]] = Array(Array(1), Array(1, 1))

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MathBinaryModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MathBinaryModelSpec.scala
@@ -2,12 +2,12 @@ package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.feature.BinaryOperation._
 import ml.combust.mleap.core.types.{ScalarType, StructField}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 12/27/16.
   */
-class MathBinaryModelSpec extends FunSpec {
+class MathBinaryModelSpec extends org.scalatest.funspec.AnyFunSpec {
   def binaryLike(operation: BinaryOperation,
                  name: String,
                  a: Double,

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MathUnaryModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MathUnaryModelSpec.scala
@@ -3,12 +3,12 @@ package ml.combust.mleap.core.feature
 import ml.combust.mleap.core.feature.UnaryOperation._
 import ml.combust.mleap.core.feature.LogitHelper
 import ml.combust.mleap.core.types.{ScalarType, StructField}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 12/27/16.
   */
-class MathUnaryModelSpec extends FunSpec {
+class MathUnaryModelSpec extends org.scalatest.funspec.AnyFunSpec {
   def unaryLike(operation: UnaryOperation,
                 name: String,
                 input: Double,

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MaxAbsScalerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MaxAbsScalerModelSpec.scala
@@ -2,14 +2,14 @@ package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 import org.apache.spark.ml.util.TestingUtils._
 
 /**
   * Created by mikhail on 9/18/16.
   */
-class MaxAbsScalerModelSpec extends FunSpec {
+class MaxAbsScalerModelSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("Max Abs Scaler Model") {
     val scaler = MaxAbsScalerModel(Vectors.dense(Array(20.0, 10.0, 10.0, 20.0)))
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MinHashLSHModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MinHashLSHModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{StructField, TensorType}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class MinHashLSHModelSpec extends FunSpec {
+class MinHashLSHModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("min has lsh model") {
     val model = MinHashLSHModel(Seq(), 3)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MinMaxScalerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MinMaxScalerModelSpec.scala
@@ -2,14 +2,14 @@ package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 import org.apache.spark.ml.util.TestingUtils._
 
 /**
   * Created by mikhail on 9/18/16.
   */
-class MinMaxScalerModelSpec extends FunSpec{
+class MinMaxScalerModelSpec extends org.scalatest.funspec.AnyFunSpec{
   describe("min max scaler model") {
     val scaler = MinMaxScalerModel(Vectors.dense(Array(1.0, 0.0, 5.0, 10.0)), Vectors.dense(Array(15.0, 10.0, 15.0, 20.0)))
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MultinomialLabelerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MultinomialLabelerModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class MultinomialLabelerModelSpec extends FunSpec {
+class MultinomialLabelerModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("multinomal labeler model") {
     val model = MultinomialLabelerModel(9.0, ReverseStringIndexerModel(Seq("hello1", "world2", "!3")))

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/NGramModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/NGramModelSpec.scala
@@ -1,12 +1,12 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{BasicType, ListType, StructField}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by mikhail on 10/16/16.
   */
-class NGramModelSpec extends FunSpec{
+class NGramModelSpec extends org.scalatest.funspec.AnyFunSpec{
   describe("ngram model") {
     val ngram = NGramModel(2)
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/NormalizerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/NormalizerModelSpec.scala
@@ -2,12 +2,12 @@ package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 9/24/16.
   */
-class NormalizerModelSpec extends FunSpec {
+class NormalizerModelSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("normalizer model") {
 
     val normalizer = NormalizerModel(20.0, 3)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/OneHotEncoderModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/OneHotEncoderModelSpec.scala
@@ -1,12 +1,12 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{ScalarType, StructField, TensorType}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hwilkins on 1/21/16.
   */
-class OneHotEncoderModelSpec extends FunSpec {
+class OneHotEncoderModelSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("encoder model") {
 
     val encoder = OneHotEncoderModel(Array(5))

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/PcaModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/PcaModelSpec.scala
@@ -2,12 +2,12 @@ package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{StructField, TensorType}
 import org.apache.spark.ml.linalg.{DenseMatrix, Matrices, Vectors}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 10/12/16.
   */
-class PcaModelSpec extends FunSpec {
+class PcaModelSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("pca model") {
     val pc = new DenseMatrix(3, 2, Array[Double](1, -1, 2,
       0, -3, 1))

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/PolynomialExpansionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/PolynomialExpansionModelSpec.scala
@@ -2,12 +2,12 @@ package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by mikhail on 10/16/16.
   */
-class PolynomialExpansionModelSpec extends FunSpec {
+class PolynomialExpansionModelSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("polynomial expansion model") {
     val model = PolynomialExpansionModel(2, 2)
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/RegexIndexerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/RegexIndexerModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{ScalarType, StructField}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class RegexIndexerModelSpec extends FunSpec {
+class RegexIndexerModelSpec extends org.scalatest.funspec.AnyFunSpec {
   private val indexer = RegexIndexerModel(Seq(
     ("""(?i)HELLO""".r.unanchored, 23),
     ("""(?i)NO""".r.unanchored, 32),

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/RegexTokenizerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/RegexTokenizerModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class RegexTokenizerModelSpec extends FunSpec {
+class RegexTokenizerModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("regex tokenizer model") {
     val model = RegexTokenizerModel(regex = """\s""".r, matchGaps = true,

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/ReverseStringIndexerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/ReverseStringIndexerModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class ReverseStringIndexerModelSpec extends FunSpec {
+class ReverseStringIndexerModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("reverse string indexer model") {
     val model = ReverseStringIndexerModel(Seq("one", "two", "three"))

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/StandardScalerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/StandardScalerModelSpec.scala
@@ -2,12 +2,12 @@ package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hwilkins on 1/21/16.
   */
-class StandardScalerModelSpec extends FunSpec {
+class StandardScalerModelSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("standard scaler with dense data") {
     describe("with mean") {
       val scaler = StandardScalerModel(None, Some(Vectors.dense(Array(50.0, 20.0, 30.0))))

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/StopWordsRemoverModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/StopWordsRemoverModelSpec.scala
@@ -1,12 +1,12 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{BasicType, ListType, StructField}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by mikhail on 10/16/16.
   */
-class StopWordsRemoverModelSpec extends FunSpec {
+class StopWordsRemoverModelSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("StopWordsRemoverModel"){
 
     val remover = StopWordsRemoverModel(Array("I", "and", "you"), true)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/StringIndexerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/StringIndexerModelSpec.scala
@@ -1,13 +1,13 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{ScalarType, StructField}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.prop.TableDrivenPropertyChecks
 
 /**
   * Created by hwilkins on 1/21/16.
   */
-class StringIndexerModelSpec extends FunSpec with TableDrivenPropertyChecks {
+class StringIndexerModelSpec extends org.scalatest.funspec.AnyFunSpec with TableDrivenPropertyChecks {
   describe("#apply") {
     it("returns the index of the string") {
       val indexer = StringIndexerModel(Array("hello", "there", "dude"))

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/StringMapModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/StringMapModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{ScalarType, StructField}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class StringMapModelSpec extends FunSpec {
+class StringMapModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   val model = StringMapModel(Map("label1" -> 1.0, "label2" -> 1.0, "label3" -> 2.0))
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/TokenizerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/TokenizerModelSpec.scala
@@ -1,12 +1,12 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{BasicType, ListType, ScalarType, StructField}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hwilkins on 1/21/16.
   */
-class TokenizerModelSpec extends FunSpec {
+class TokenizerModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   val tokenizer = TokenizerModel()
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/VectorAssemblerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/VectorAssemblerModelSpec.scala
@@ -4,12 +4,12 @@ import java.math.BigDecimal
 
 import ml.combust.mleap.core.types._
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hwilkins on 1/21/16.
   */
-class VectorAssemblerModelSpec extends FunSpec {
+class VectorAssemblerModelSpec extends org.scalatest.funspec.AnyFunSpec {
   val assembler = VectorAssemblerModel(Seq(
     ScalarShape(), ScalarShape(),
     TensorShape(2),

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/VectorIndexerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/VectorIndexerModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{StructField, TensorType}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class VectorIndexerModelSpec extends FunSpec {
+class VectorIndexerModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("vector indexer model") {
     val model = VectorIndexerModel(3, Map())

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/VectorSlicerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/VectorSlicerModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{StructField, TensorType}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class VectorSlicerModelSpec extends FunSpec {
+class VectorSlicerModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("vector slicer model") {
     val model = VectorSlicerModel(indices = Array(1), inputSize = 2)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/WordLengthFilterModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/WordLengthFilterModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class WordLengthFilterModelSpec extends FunSpec {
+class WordLengthFilterModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("word length filter model") {
     val model = new WordLengthFilterModel(5)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/WordToVectorModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/WordToVectorModelSpec.scala
@@ -3,9 +3,9 @@ package ml.combust.mleap.core.feature
 import ml.combust.mleap.core.types.{BasicType, ListType, StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
 import org.scalactic.TolerantNumerics
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class WordToVectorModelSpec extends FunSpec {
+class WordToVectorModelSpec extends org.scalatest.funspec.AnyFunSpec {
   implicit val doubleEquality = TolerantNumerics.tolerantDoubleEquality(0.000001)
 
   describe("word to vector model") {

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/recommendation/ALSModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/recommendation/ALSModelSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.recommendation
 
 import ml.combust.mleap.core.types.{ScalarType, StructField}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class ALSModelSpec extends FunSpec {
+class ALSModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("ALS") {
     val userFactors = Map(0 -> Array(1.0f, 2.0f), 1 -> Array(3.0f, 1.0f), 2 -> Array(2.0f, 3.0f))

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/reflection/MleapReflectionSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/reflection/MleapReflectionSpec.scala
@@ -2,12 +2,12 @@ package ml.combust.mleap.core.reflection
 
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.tensor.{ByteString, Tensor}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 10/21/16.
   */
-class MleapReflectionSpec extends FunSpec {
+class MleapReflectionSpec extends AnyFunSpec {
   describe("#dataType") {
     import ml.combust.mleap.core.reflection.MleapReflection.dataType
 
@@ -49,7 +49,7 @@ class MleapReflectionSpec extends FunSpec {
 
     describe("#with an invalid Scala type") {
       it("throws an illegal argument exception") {
-        assertThrows[IllegalArgumentException] { dataType[FunSpec] }
+        assertThrows[IllegalArgumentException] { dataType[AnyFunSpec] }
       }
     }
   }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/regression/AFTSurvivalRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/regression/AFTSurvivalRegressionModelSpec.scala
@@ -2,9 +2,9 @@ package ml.combust.mleap.core.regression
 
 import ml.combust.mleap.core.types.{ScalarType, StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class AFTSurvivalRegressionModelSpec extends FunSpec {
+class AFTSurvivalRegressionModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("AFT survival regression model") {
     val model = new AFTSurvivalRegressionModel(Vectors.dense(1, 2, 3), 2, Array(4, 5, 6, 7), 3)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/regression/DecisionTreeRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/regression/DecisionTreeRegressionModelSpec.scala
@@ -3,12 +3,12 @@ package ml.combust.mleap.core.regression
 import ml.combust.mleap.core.tree.{ContinuousSplit, InternalNode, LeafNode}
 import ml.combust.mleap.core.types.{ScalarType, StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hwilkins on 1/21/16.
   */
-class DecisionTreeRegressionModelSpec extends FunSpec {
+class DecisionTreeRegressionModelSpec extends org.scalatest.funspec.AnyFunSpec {
   val node = InternalNode(LeafNode(Seq(0.78)), LeafNode(Seq(0.34)), ContinuousSplit(0, 0.5))
   val regression = DecisionTreeRegressionModel(node, 5)
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/regression/GBTRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/regression/GBTRegressionModelSpec.scala
@@ -3,12 +3,12 @@ package ml.combust.mleap.core.regression
 import ml.combust.mleap.core.test.TestUtil
 import ml.combust.mleap.core.types.{ScalarType, StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 9/28/16.
   */
-class GBTRegressionModelSpec extends FunSpec {
+class GBTRegressionModelSpec extends org.scalatest.funspec.AnyFunSpec {
   val tree1 = TestUtil.buildDecisionTreeRegression(0.5, 0, goLeft = true)
   val tree2 = TestUtil.buildDecisionTreeRegression(0.75, 1, goLeft = false)
   val tree3 = TestUtil.buildDecisionTreeRegression(0.1, 2, goLeft = true)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/regression/GeneralizedLinearRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/regression/GeneralizedLinearRegressionModelSpec.scala
@@ -2,9 +2,9 @@ package ml.combust.mleap.core.regression
 
 import ml.combust.mleap.core.types.{ScalarShape, ScalarType, StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class GeneralizedLinearRegressionModelSpec extends FunSpec {
+class GeneralizedLinearRegressionModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("generalized linear regression model") {
     val model = new GeneralizedLinearRegressionModel(Vectors.dense(1, 2, 3), 23, null)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/regression/IsotonicRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/regression/IsotonicRegressionModelSpec.scala
@@ -2,12 +2,12 @@ package ml.combust.mleap.core.regression
 
 import ml.combust.mleap.core.types.{ScalarType, StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 12/27/16.
   */
-class IsotonicRegressionModelSpec extends FunSpec {
+class IsotonicRegressionModelSpec extends org.scalatest.funspec.AnyFunSpec {
   val regression = IsotonicRegressionModel(boundaries = Array(0.0, 4.0, 5.0, 7.0, 8.0),
     predictions = Seq(100.0, 200.0, 300.0, 400.0, 500.0),
     isotonic = true,

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/regression/LinearRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/regression/LinearRegressionModelSpec.scala
@@ -1,13 +1,13 @@
 package ml.combust.mleap.core.regression
 
 import ml.combust.mleap.core.types.{ScalarType, StructField, TensorType}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 import org.apache.spark.ml.linalg.Vectors
 
 /**
   * Created by hwilkins on 1/21/16.
   */
-class LinearRegressionModelSpec extends FunSpec {
+class LinearRegressionModelSpec extends org.scalatest.funspec.AnyFunSpec {
   val linearRegression = LinearRegressionModel(Vectors.dense(Array(0.5, 0.75, 0.25)), .33)
 
   describe("#apply") {

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/regression/RandomForestRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/regression/RandomForestRegressionModelSpec.scala
@@ -3,12 +3,12 @@ package ml.combust.mleap.core.regression
 import ml.combust.mleap.core.test.TestUtil
 import ml.combust.mleap.core.types.{ScalarType, StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hwilkins on 1/21/16.
   */
-class RandomForestRegressionModelSpec extends FunSpec {
+class RandomForestRegressionModelSpec extends org.scalatest.funspec.AnyFunSpec {
   val tree1 = TestUtil.buildDecisionTreeRegression(0.5, 0, goLeft = true)
   val tree2 = TestUtil.buildDecisionTreeRegression(0.75, 1, goLeft = false)
   val tree3 = TestUtil.buildDecisionTreeRegression(0.1, 2, goLeft = true)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/sklearn/PolynomialFeaturesModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/sklearn/PolynomialFeaturesModelSpec.scala
@@ -2,9 +2,9 @@ package ml.combust.mleap.core.sklearn
 
 import ml.combust.mleap.core.types.{StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class PolynomialFeaturesModelSpec extends FunSpec {
+class PolynomialFeaturesModelSpec extends org.scalatest.funspec.AnyFunSpec {
 
   val model = new PolynomialFeaturesModel("[x0,x1,x0^2,x0 x1,x1^2,x0^3,x0^2 x1,x0 x1^2,x1^3]")
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/tree/NodeSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/tree/NodeSpec.scala
@@ -1,12 +1,12 @@
 package ml.combust.mleap.core.tree
 
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 import org.apache.spark.ml.linalg.Vectors
 
 /**
   * Created by hwilkins on 1/21/16.
   */
-class InternalNodeSpec extends FunSpec {
+class InternalNodeSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("#typeName") {
     it("is InternalNode") {  }
   }
@@ -32,7 +32,7 @@ class InternalNodeSpec extends FunSpec {
   }
 }
 
-class LeafNodeSpec extends FunSpec {
+class LeafNodeSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("#predictImpl") {
     it("returns itself") {
       val node = LeafNode(0.45)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/tree/SplitSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/tree/SplitSpec.scala
@@ -1,12 +1,12 @@
 package ml.combust.mleap.core.tree
 
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hwilkins on 1/20/16.
   */
-class CategoricalSplitSpec extends FunSpec {
+class CategoricalSplitSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("#shouldGoLeft") {
     describe("with features") {
       describe("when isLeft is true") {
@@ -78,7 +78,7 @@ class CategoricalSplitSpec extends FunSpec {
   }
 }
 
-class ContinuousSplitSpec extends FunSpec {
+class ContinuousSplitSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("#shouldGoLeft") {
     describe("with features") {
       describe("when below threshold") {

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/types/CastingSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/types/CastingSpec.scala
@@ -2,13 +2,13 @@ package ml.combust.mleap.core.types
 
 import ml.combust.mleap.tensor.{ByteString, Tensor, SparseTensor}
 import org.apache.spark.ml.linalg.{Vector => SparkVector, Vectors}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 import scala.util.Success
 
 /**
   * Created by hollinwilkins on 9/18/17.
   */
-class CastingSpec extends FunSpec {
+class CastingSpec extends org.scalatest.funspec.AnyFunSpec {
   def createValue(base: BasicType, value: Double): Any = base match {
     case BasicType.Boolean => if (value == 0) false else true
     case BasicType.Byte => value.toByte

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/types/StructTypeSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/types/StructTypeSpec.scala
@@ -1,23 +1,25 @@
 package ml.combust.mleap.core.types
 
-import java.io.{ByteArrayOutputStream, PrintStream}
+import org.scalatest.funsuite.AnyFunSuite
 
-import org.scalatest.{FunSuite, GivenWhenThen, TryValues}
+import java.io.{ByteArrayOutputStream, PrintStream}
+import org.scalatest.{GivenWhenThen, TryValues}
 
 import scala.util.Success
 
 /**
   * Created by pahsan on 3/8/16.
   */
-class StructTypeSpec extends FunSuite with GivenWhenThen with TryValues{
-  val fields = Seq(StructField("first", ScalarType.String),
-                   StructField("second", ScalarType.String),
-                   StructField("third", ScalarType.String),
-                   StructField("fourth", ScalarType.String),
-                   StructField("fifth", ScalarType.String)
+class StructTypeSpec extends AnyFunSuite with GivenWhenThen with TryValues{
+  private val fields = Seq(
+    StructField("first", ScalarType.String),
+    StructField("second", ScalarType.String),
+    StructField("third", ScalarType.String),
+    StructField("fourth", ScalarType.String),
+    StructField("fifth", ScalarType.String)
   )
 
-  val testStruct = StructType(fields).get
+  private val testStruct = StructType(fields).get
 
   test("getField should return the desired field wrapped in an Option") {
     assert(testStruct.getField("first").get.name == "first")

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/util/VectorConvertersSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/util/VectorConvertersSpec.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.core.util
 
 import ml.combust.mleap.tensor.{DenseTensor, SparseTensor}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class VectorConvertersSpec extends FunSpec {
+class VectorConvertersSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("mleapTensorToSparkVector works when") {
 
     it("using a Sparse Tensor") {

--- a/mleap-databricks-runtime-fat/build.sbt
+++ b/mleap-databricks-runtime-fat/build.sbt
@@ -6,9 +6,11 @@ Common.noPublishSettings
 
 enablePlugins(AssemblyPlugin)
 
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
+assembly / assemblyOption ~= {
+  _.withIncludeScala(false)
+}
 
-assemblyShadeRules in assembly := Seq(
+assembly / assemblyShadeRules := Seq(
   "spray.json.**",
   "com.google.protobuf.**",
   "com.trueaccord.**",

--- a/mleap-databricks-runtime-testkit/src/main/scala/ml/combust/mleap/databricks/runtime/testkit/Boot.scala
+++ b/mleap-databricks-runtime-testkit/src/main/scala/ml/combust/mleap/databricks/runtime/testkit/Boot.scala
@@ -3,10 +3,11 @@ package ml.combust.mleap.databricks.runtime.testkit
 import org.apache.spark.sql.SparkSession
 
 object Boot extends App {
-  val session = SparkSession.builder().
-    appName("TestMleapDatabricksRuntime").
-    master("local[2]").
-    getOrCreate()
+  val session = SparkSession.builder()
+    .appName("TestMleapDatabricksRuntime")
+    .config("spark.ui.enabled", "false")
+    .master("local[2]")
+    .getOrCreate()
   val sqlContext = session.sqlContext
 
   new TestSparkMl(session).run()

--- a/mleap-databricks-runtime/build.sbt
+++ b/mleap-databricks-runtime/build.sbt
@@ -2,6 +2,6 @@ import ml.combust.mleap.{Common, MleapProject}
 
 Common.defaultMleapSettings
 
-packageBin in Compile := (assembly in (MleapProject.databricksRuntimeFat, Compile)).value
+Compile / packageBin := (MleapProject.databricksRuntimeFat / Compile / assembly).value
 
 publishMavenStyle := true

--- a/mleap-executor-testkit/src/main/scala/ml/combust/mleap/executor/testkit/TestUtil.scala
+++ b/mleap-executor-testkit/src/main/scala/ml/combust/mleap/executor/testkit/TestUtil.scala
@@ -2,22 +2,24 @@ package ml.combust.mleap.executor.testkit
 
 import java.io.File
 import java.net.URI
-
 import ml.combust.bundle.BundleFile
 import ml.combust.bundle.dsl.Bundle
 import ml.combust.mleap.core.types.StructType
 import ml.combust.mleap.runtime.MleapSupport._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, RowTransformer, Transformer}
 import ml.combust.mleap.runtime.serialization.FrameReader
-import resource.managed
+
+import java.nio.file.Path
+import scala.util.Using
 
 object TestUtil {
+  private val classLoader = getClass.getClassLoader
   lazy val rfUri: URI = {
-    getClass.getClassLoader.getResource("models/airbnb.model.rf.zip").toURI
+    classLoader.getResource("models/airbnb.model.rf.zip").toURI
   }
 
   lazy val lrUri: URI = {
-    getClass.getClassLoader.getResource("models/airbnb.model.lr.zip").toURI
+    classLoader.getResource("models/airbnb.model.lr.zip").toURI
   }
 
   lazy val faultyFrame: DefaultLeapFrame = {
@@ -25,24 +27,17 @@ object TestUtil {
   }
 
   lazy val frame: DefaultLeapFrame = {
-    FrameReader().read(new File(getClass.getClassLoader.getResource("leap_frame/frame.airbnb.json").getFile)).get
+    FrameReader().read(Path.of(classLoader.getResource("leap_frame/frame.airbnb.json").toURI)).get
   }
 
-  lazy val rfBundle : Bundle[Transformer] = {
-    val bundle = (for(bundle <- managed(BundleFile(new File(rfUri.getPath)))) yield {
-      bundle.loadMleapBundle().get
-    }).tried.get
+  lazy val rfBundle : Bundle[Transformer] = loadBundle(rfUri)
 
-    bundle
-  }
+  lazy val lrBundle : Bundle[Transformer] = loadBundle(lrUri)
 
-  lazy val lrBundle : Bundle[Transformer] = {
-    val bundle = (for(bundle <- managed(BundleFile(new File(lrUri.getPath)))) yield {
-      bundle.loadMleapBundle().get
-    }).tried.get
-
-    bundle
-  }
 
   lazy val rfRowTransformer: RowTransformer = rfBundle.root.transform(RowTransformer(frame.schema)).get
+  private def loadBundle(uri: URI): Bundle[Transformer] =
+    Using(BundleFile(new File(uri))) { bundle =>
+      bundle.loadMleapBundle()
+    }.flatten.get
 }

--- a/mleap-executor-tests/src/test/scala/ml/combust/mleap/executor/ExecuteTransformSpec.scala
+++ b/mleap-executor-tests/src/test/scala/ml/combust/mleap/executor/ExecuteTransformSpec.scala
@@ -8,15 +8,18 @@ import ml.combust.mleap.runtime.transformer.feature.VectorAssembler
 import ml.combust.mleap.runtime.transformer.regression.LinearRegression
 import ml.combust.mleap.tensor.Tensor
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.{FunSpec, Matchers}
 import ml.combust.mleap.core.types._
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Span}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.{Success, Try}
 
-class ExecuteTransformSpec extends FunSpec with ScalaFutures with Matchers {
+class ExecuteTransformSpec extends AnyFunSpec with ScalaFutures with Matchers {
+  override def patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(500, Millis))
+  implicit val cfg = patienceConfig
 
   describe("execute transform") {
 

--- a/mleap-executor-tests/src/test/scala/ml/combust/mleap/executor/MleapExecutorSpec.scala
+++ b/mleap-executor-tests/src/test/scala/ml/combust/mleap/executor/MleapExecutorSpec.scala
@@ -16,7 +16,6 @@ class MleapExecutorSpec extends TestKit(ActorSystem("MleapExecutorSpec"))
 
   override lazy val transformService: MleapExecutor = MleapExecutor(system)
   private val frame = TestUtil.frame
-  override implicit val materializer: Materializer = ActorMaterializer()(system)
 
   override protected def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system, 5.seconds, verifySystemShutdown = true)

--- a/mleap-executor-tests/src/test/scala/ml/combust/mleap/executor/repository/RepositoryBundleLoaderSpec.scala
+++ b/mleap-executor-tests/src/test/scala/ml/combust/mleap/executor/repository/RepositoryBundleLoaderSpec.scala
@@ -1,29 +1,33 @@
 package ml.combust.mleap.executor.repository
 
+import ml.combust.bundle.dsl.Bundle
 import ml.combust.mleap.executor.testkit.TestUtil
+import ml.combust.mleap.runtime.frame.Transformer
 import ml.combust.mleap.runtime.transformer.Pipeline
-import org.scalatest.concurrent.PatienceConfiguration.Timeout
-import org.scalatest.{FunSpec, Matchers}
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.AsyncFunSpec
+import org.scalatest.matchers.should.Matchers
 
-import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
-class RepositoryBundleLoaderSpec extends FunSpec with ScalaFutures with Matchers {
+class RepositoryBundleLoaderSpec extends AsyncFunSpec with Matchers with BeforeAndAfterAll {
+
+  import scala.language.implicitConversions
+
+  val repo = new FileRepository()
+
+  override def afterAll(): Unit = {
+    repo.shutdown()
+  }
 
   describe("repository bundle loader") {
-
-    implicit val executionContext = ExecutionContext.Implicits.global
-
     it("loads bundle successfully") {
-      val repo = new FileRepository()
-      val bundleLoader = new RepositoryBundleLoader(repo, executionContext)
-      val result = bundleLoader.loadBundle(TestUtil.lrUri)
-      whenReady(result, Timeout(10.seconds)) {
+      val bundleLoader = new RepositoryBundleLoader(repo, ExecutionContext.Implicits.global)
+      val result: Future[Bundle[Transformer]] = bundleLoader.loadBundle(TestUtil.lrUri)
+      result.map {
         bundle => bundle.root shouldBe a [Pipeline]
       }
 
-      repo.shutdown()
     }
   }
 }

--- a/mleap-executor/README.md
+++ b/mleap-executor/README.md
@@ -100,10 +100,11 @@ Await.result(transformService.unloadModel(UnloadModelRequest(
 Find an example leap frame at `mleap-executor-testkit/src/main/resources/leap_frame/frame.airbnb.json`.
 
 ```scala
+import java.nio.file.Path
 import ml.combust.mleap.runtime.serialization.FrameReader
 
 // Load the leap frame from a file
-val frameFile = new File("/absolute/path/to/frame.json")
+val frameFile = Path.of("/absolute/path/to/frame.json")
 val frame = FrameReader().read(frameFile).get
 
 // Transform the leap frame using the airbnb model we loaded earlier

--- a/mleap-executor/src/main/scala/ml/combust/mleap/executor/Transform.scala
+++ b/mleap-executor/src/main/scala/ml/combust/mleap/executor/Transform.scala
@@ -70,7 +70,7 @@ object ExecuteTransform {
               }.getOrElse(Try(frame))
           }
       }
-    }.flatMap(identity)
+    }.flatten
   }
 }
 

--- a/mleap-executor/src/main/scala/ml/combust/mleap/executor/repository/RepositoryBundleLoader.scala
+++ b/mleap-executor/src/main/scala/ml/combust/mleap/executor/repository/RepositoryBundleLoader.scala
@@ -7,7 +7,7 @@ import ml.combust.bundle.dsl.Bundle
 import ml.combust.mleap.runtime.MleapContext
 import ml.combust.mleap.runtime.MleapSupport._
 import ml.combust.mleap.runtime.frame.Transformer
-import resource._
+import scala.util.Using
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -25,9 +25,9 @@ class RepositoryBundleLoader(repository: Repository,
 
     repository.downloadBundle(uri).flatMap {
       path =>
-        Future.fromTry((for(bf <- managed(BundleFile(path.toFile))) yield {
+        Future.fromTry(Using(BundleFile(path.toFile)) { bf =>
           bf.loadMleapBundle()
-        }).tried.flatMap(identity))
+        }.flatten)
     }
   }
 }

--- a/mleap-grpc-server/src/main/scala/ml/combust/mleap/grpc/server/GrpcServer.scala
+++ b/mleap-grpc-server/src/main/scala/ml/combust/mleap/grpc/server/GrpcServer.scala
@@ -1,7 +1,6 @@
 package ml.combust.mleap.grpc.server
 
 import java.util.concurrent.TimeUnit
-
 import io.grpc.stub.StreamObserver
 import ml.combust.mleap.executor.{CreateFrameFlowRequest, CreateRowFlowRequest, MleapExecutor}
 import ml.combust.mleap.pb._
@@ -12,7 +11,7 @@ import com.google.protobuf.ByteString
 import ml.combust.mleap.grpc.stream.GrpcAkkaStreams
 import ml.combust.mleap.grpc.TypeConverters._
 import akka.NotUsed
-import akka.stream.Materializer
+import akka.actor.ActorSystem
 import io.grpc
 import io.grpc.Context
 import ml.combust.mleap
@@ -23,14 +22,14 @@ import ml.combust.mleap.runtime.types.BundleTypeConverters._
 
 import scala.language.implicitConversions
 import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 import scala.util.{Failure, Success, Try}
 
 class GrpcServer(mleapExecutor: MleapExecutor,
                  config: GrpcServerConfig)
-                (implicit ec: ExecutionContext,
-                 materializer: Materializer) extends Mleap {
+                (implicit system: ActorSystem) extends Mleap {
   private val DEFAULT_TIMEOUT: FiniteDuration = FiniteDuration(5, TimeUnit.SECONDS)
+  implicit val ec: ExecutionContext = system.dispatcher
 
   def getTimeout(ms: Long): FiniteDuration = if (ms == 0) {
     DEFAULT_TIMEOUT

--- a/mleap-grpc-server/src/main/scala/ml/combust/mleap/grpc/server/RunServer.scala
+++ b/mleap-grpc-server/src/main/scala/ml/combust/mleap/grpc/server/RunServer.scala
@@ -28,8 +28,6 @@ class RunServer(config: Config)
       val coordinator = CoordinatedShutdown(system)
       this.coordinator = Some(coordinator)
 
-      implicit val materializer: Materializer = ActorMaterializer()
-
       val grpcServerConfig = new GrpcServerConfig(config.getConfig("default"))
       val mleapExecutor = MleapExecutor(system)
       val port: Int = config.getInt("port")

--- a/mleap-grpc-server/src/test/scala/ml/combust/mleap/grpc/server/GrpcSpec.scala
+++ b/mleap-grpc-server/src/test/scala/ml/combust/mleap/grpc/server/GrpcSpec.scala
@@ -27,8 +27,6 @@ class GrpcSpec extends TestKit(ActorSystem("grpc-server-test"))
     client
   }
 
-  override implicit def materializer: Materializer = ActorMaterializer()(system)
-
   override protected def afterAll(): Unit = {
     server.shutdown()
     channel.shutdown()

--- a/mleap-grpc-server/src/test/scala/ml/combust/mleap/grpc/server/TestUtil.scala
+++ b/mleap-grpc-server/src/test/scala/ml/combust/mleap/grpc/server/TestUtil.scala
@@ -4,7 +4,6 @@ import java.io.File
 import java.net.URI
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import io.grpc.{ManagedChannel, Server}
 import io.grpc.inprocess.{InProcessChannelBuilder, InProcessServerBuilder}
@@ -30,7 +29,10 @@ object TestUtil {
 
   def createServer(system: ActorSystem) : Server = {
     val config = new GrpcServerConfig(ConfigFactory.load().getConfig("ml.combust.mleap.grpc.server.default"))
-    val ssd = MleapGrpc.bindService(new GrpcServer(MleapExecutor(system), config)(global, ActorMaterializer.create(system)), global)
+    val ssd = MleapGrpc.bindService(
+      new GrpcServer(MleapExecutor(system), config)(system),
+      system.dispatcher
+    )
     val builder = InProcessServerBuilder.forName(uniqueServerName)
     builder.directExecutor().addService(ssd).intercept(new ErrorInterceptor)
     val server = builder.build

--- a/mleap-grpc/src/main/scala/ml/combust/mleap/grpc/GrpcClient.scala
+++ b/mleap-grpc/src/main/scala/ml/combust/mleap/grpc/GrpcClient.scala
@@ -170,7 +170,7 @@ class GrpcClient(stub: MleapStub)
     }
 
     Flow.fromGraph {
-      GraphDSL.create(_responseSource) {
+      GraphDSL.createGraph(_responseSource) {
         implicit builder =>
           responseSource =>
             import GraphDSL.Implicits._
@@ -267,7 +267,7 @@ class GrpcClient(stub: MleapStub)
     }
 
     Flow.fromGraph {
-      GraphDSL.create(_responseSource) {
+      GraphDSL.createGraph(_responseSource) {
         implicit builder =>
           responseSource =>
             import GraphDSL.Implicits._

--- a/mleap-runtime/src/main/java/ml/combust/mleap/runtime/javadsl/BundleBuilderSupport.scala
+++ b/mleap-runtime/src/main/java/ml/combust/mleap/runtime/javadsl/BundleBuilderSupport.scala
@@ -7,7 +7,7 @@ import ml.combust.bundle.dsl.Bundle
 import ml.combust.mleap.runtime.MleapContext
 import ml.combust.mleap.runtime.frame.Transformer
 import ml.combust.mleap.runtime.MleapSupport._
-import resource._
+import scala.util.Using
 
 /**
   * Created by hollinwilkins on 4/21/17.
@@ -16,16 +16,16 @@ class BundleBuilderSupport {
   def load(file: File, context: MleapContext): Bundle[Transformer] = {
     implicit val c: MleapContext = context
 
-    (for(bf <- managed(BundleFile(file))) yield {
+    Using(BundleFile(file)) { bf =>
       bf.loadMleapBundle()(context).get
-    }).tried.get
+    }.get
   }
 
   def save(transformer: Transformer, file: File, context: MleapContext): Unit = {
     implicit val c: MleapContext = context
-    
-    (for(bf <- managed(BundleFile(file))) yield {
+
+    Using(BundleFile(file)) { bf =>
       transformer.writeBundle.save(bf)(context).get
-    }).tried.get
+    }.get
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/binary/DefaultFrameReader.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/binary/DefaultFrameReader.scala
@@ -8,7 +8,7 @@ import ml.combust.mleap.core.types.StructType
 import ml.combust.mleap.json.JsonSupport._
 import ml.combust.mleap.runtime.frame.{ArrayRow, DefaultLeapFrame, Row}
 import spray.json._
-import resource._
+import scala.util.Using
 
 import scala.collection.mutable
 import scala.util.Try
@@ -19,7 +19,7 @@ import scala.util.Try
 class DefaultFrameReader extends FrameReader {
   override def fromBytes(bytes: Array[Byte],
                          charset: Charset = BuiltinFormats.charset): Try[DefaultLeapFrame] = {
-    (for(in <- managed(new ByteArrayInputStream(bytes))) yield {
+    Using(new ByteArrayInputStream(bytes)) { in =>
       val din = new DataInputStream(in)
       val length = din.readInt()
       val schemaBytes = new Array[Byte](length)
@@ -42,6 +42,6 @@ class DefaultFrameReader extends FrameReader {
       }
 
       DefaultLeapFrame(schema, rows)
-    }).tried
+    }
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/binary/DefaultFrameWriter.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/binary/DefaultFrameWriter.scala
@@ -7,7 +7,7 @@ import ml.combust.mleap.json.JsonSupport._
 import ml.combust.mleap.runtime.frame.LeapFrame
 import ml.combust.mleap.runtime.serialization.{BuiltinFormats, FrameWriter}
 import spray.json._
-import resource._
+import scala.util.Using
 
 import scala.util.Try
 
@@ -16,7 +16,7 @@ import scala.util.Try
   */
 class DefaultFrameWriter[LF <: LeapFrame[LF]](frame: LF) extends FrameWriter {
   override def toBytes(charset: Charset = BuiltinFormats.charset): Try[Array[Byte]] = {
-    (for(out <- managed(new ByteArrayOutputStream())) yield {
+    Using(new ByteArrayOutputStream()) { out =>
       val serializers = frame.schema.fields.map(_.dataType).map(ValueSerializer.serializerForDataType)
       val dout = new DataOutputStream(out)
       val schemaBytes = frame.schema.toJson.prettyPrint.getBytes(BuiltinFormats.charset)
@@ -35,6 +35,6 @@ class DefaultFrameWriter[LF <: LeapFrame[LF]](frame: LF) extends FrameWriter {
 
       dout.flush()
       out.toByteArray
-    }).tried
+    }
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/binary/DefaultRowReader.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/binary/DefaultRowReader.scala
@@ -6,7 +6,7 @@ import java.nio.charset.Charset
 import ml.combust.mleap.runtime.serialization.{BuiltinFormats, RowReader}
 import ml.combust.mleap.core.types.StructType
 import ml.combust.mleap.runtime.frame.{ArrayRow, Row}
-import resource._
+import scala.util.Using
 
 import scala.util.Try
 
@@ -17,7 +17,7 @@ class DefaultRowReader(override val schema: StructType) extends RowReader {
   private val serializers = schema.fields.map(_.dataType).map(ValueSerializer.serializerForDataType)
 
   override def fromBytes(bytes: Array[Byte], charset: Charset = BuiltinFormats.charset): Try[Row] = {
-    (for(in <- managed(new ByteArrayInputStream(bytes))) yield {
+    Using(new ByteArrayInputStream(bytes)) { in =>
       val din = new DataInputStream(in)
       val row = ArrayRow(new Array[Any](schema.fields.length))
       var i = 0
@@ -26,6 +26,6 @@ class DefaultRowReader(override val schema: StructType) extends RowReader {
         i = i + 1
       }
       row
-    }).tried
+    }
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/binary/DefaultRowWriter.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/binary/DefaultRowWriter.scala
@@ -6,7 +6,7 @@ import java.nio.charset.Charset
 import ml.combust.mleap.runtime.serialization.{BuiltinFormats, RowWriter}
 import ml.combust.mleap.core.types.StructType
 import ml.combust.mleap.runtime.frame.Row
-import resource._
+import scala.util.Using
 
 import scala.util.Try
 
@@ -17,7 +17,7 @@ class DefaultRowWriter(override val schema: StructType) extends RowWriter {
   private val serializers = schema.fields.map(_.dataType).map(ValueSerializer.serializerForDataType)
 
   override def toBytes(row: Row, charset: Charset = BuiltinFormats.charset): Try[Array[Byte]] = {
-    (for(out <- managed(new ByteArrayOutputStream())) yield {
+    Using(new ByteArrayOutputStream()) { out =>
       val dout = new DataOutputStream(out)
       var i = 0
       for(s <- serializers) {
@@ -26,6 +26,6 @@ class DefaultRowWriter(override val schema: StructType) extends RowWriter {
       }
       dout.flush()
       out.toByteArray
-    }).tried
+    }
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/MleapSupport.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/MleapSupport.scala
@@ -7,7 +7,7 @@ import ml.combust.bundle.{BundleFile, BundleWriter}
 import ml.combust.mleap.core.types.StructType
 import ml.combust.mleap.runtime.frame.{LeapFrameConverter, Transformer}
 import ml.combust.mleap.runtime.serialization.{BuiltinFormats, FrameWriter, RowReader, RowWriter}
-import resource._
+import scala.util.Using
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
@@ -28,9 +28,9 @@ trait MleapSupport {
   implicit class URIBundleFileOps(uri: URI) {
     def loadMleapBundle()
                        (implicit context: MleapContext): Try[Bundle[Transformer]] = {
-      (for (bf <- managed(BundleFile.load(uri))) yield {
-        bf.load[MleapContext, Transformer]().get
-      }).tried
+      Using(BundleFile.load(uri)) { bf =>
+        bf.load[MleapContext, Transformer]()
+      }.flatten
     }
   }
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/BuiltinFormats.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/BuiltinFormats.scala
@@ -7,7 +7,8 @@ import java.nio.charset.Charset
   */
 object BuiltinFormats {
   val charset = Charset.forName("UTF-8")
-  val json = "ml.combust.mleap.json"
-  val binary = "ml.combust.mleap.binary"
+
+  val json = classOf[ml.combust.mleap.json.DefaultFrameReader].getPackageName
+  val binary = classOf[ml.combust.mleap.binary.DefaultFrameReader].getPackageName
   val avro = "ml.combust.mleap.avro"
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/FrameReader.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/FrameReader.scala
@@ -1,13 +1,11 @@
 package ml.combust.mleap.runtime.serialization
 
-import java.io._
-import java.nio.charset.Charset
-
 import ml.combust.mleap.ClassLoaderUtil
 import ml.combust.mleap.runtime.frame.DefaultLeapFrame
-import org.apache.commons.io.IOUtils
-import resource._
 
+import java.io._
+import java.nio.charset.Charset
+import java.nio.file.{Files, Path}
 import scala.util.Try
 
 /**
@@ -17,25 +15,29 @@ object FrameReader {
   def apply(format: String = BuiltinFormats.json,
             clOption: Option[ClassLoader] = None): FrameReader = {
     val cl = clOption.getOrElse(ClassLoaderUtil.findClassLoader(classOf[FrameReader].getCanonicalName))
-    cl.loadClass(s"$format.DefaultFrameReader").
-      newInstance().
-      asInstanceOf[FrameReader]
+    cl.loadClass(s"$format.DefaultFrameReader")
+      .getDeclaredConstructor()
+      .newInstance()
+      .asInstanceOf[FrameReader]
   }
 }
 
 trait FrameReader {
   def fromBytes(bytes: Array[Byte], charset: Charset = BuiltinFormats.charset): Try[DefaultLeapFrame]
 
-  def read(file: File): Try[DefaultLeapFrame] = read(file, BuiltinFormats.charset)
+  def read(file: File): Try[DefaultLeapFrame] = read(file.toPath, BuiltinFormats.charset)
+
   def read(file: File, charset: Charset): Try[DefaultLeapFrame] = {
-    (for(in <- managed(new FileInputStream(file))) yield {
-      read(in, charset)
-    }).tried.flatMap(identity)
+    read(file.toPath, charset)
+  }
+  def read(file: Path): Try[DefaultLeapFrame] = read(file, BuiltinFormats.charset)
+
+  def read(file: Path, charset: Charset): Try[DefaultLeapFrame] = {
+    Try(Files.readAllBytes(file)).flatMap(bytes => fromBytes(bytes, charset))
   }
 
   def read(in: InputStream): Try[DefaultLeapFrame] = read(in, BuiltinFormats.charset)
   def read(in: InputStream, charset: Charset): Try[DefaultLeapFrame] = {
-    Try(IOUtils.toByteArray(in)).flatMap(bytes => fromBytes(bytes, charset))
+    Try(in.readAllBytes()).flatMap(bytes => fromBytes(bytes, charset))
   }
-
-  }
+}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/FrameWriter.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/FrameWriter.scala
@@ -5,7 +5,7 @@ import java.nio.charset.Charset
 
 import ml.combust.mleap.ClassLoaderUtil
 import ml.combust.mleap.runtime.frame.LeapFrame
-import resource._
+import scala.util.Using
 
 import scala.reflect.ClassTag
 import scala.util.Try
@@ -31,9 +31,9 @@ trait FrameWriter {
 
   def save(file: File): Try[Any] = save(file, BuiltinFormats.charset)
   def save(file: File, charset: Charset = BuiltinFormats.charset): Try[Any] = {
-    (for(out <- managed(new FileOutputStream(file))) yield {
+    Using(new FileOutputStream(file)) { out =>
       save(out, charset)
-    }).tried.flatMap(identity)
+    }.flatten
   }
 
   def save(out: OutputStream): Try[Any] = save(out, BuiltinFormats.charset)

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/json/SchemaSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/json/SchemaSpec.scala
@@ -3,12 +3,12 @@ package ml.combust.mleap.json
 import ml.combust.mleap.core.types._
 import JsonSupport._
 import spray.json._
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 9/25/17.
   */
-class SchemaSpec extends FunSpec {
+class SchemaSpec extends org.scalatest.funspec.AnyFunSpec {
   private val BASIC_TYPES = Seq(
     BasicType.Boolean,
     BasicType.Byte,

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/MleapSupportSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/MleapSupportSpec.scala
@@ -8,9 +8,9 @@ import ml.combust.mleap.core.types.NodeShape
 import ml.combust.mleap.runtime.transformer.feature.StringIndexer
 import MleapSupport._
 
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class MleapSupportSpec extends FunSpec {
+class MleapSupportSpec extends org.scalatest.funspec.AnyFunSpec {
   private val testDir = Files.createTempDirectory("MleapSupportSpec")
 
   private val stringIndexer = StringIndexer(shape = NodeShape().

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/frame/LeapFrameConverterSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/frame/LeapFrameConverterSpec.scala
@@ -2,9 +2,9 @@ package ml.combust.mleap.runtime.frame
 
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.MleapSupport._
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class LeapFrameConverterSpec extends FunSpec {
+class LeapFrameConverterSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("LeapFrameConverter") {
     val expectedSchema = StructType(Seq(StructField("test_string", ScalarType.String),

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/frame/LeapFrameSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/frame/LeapFrameSpec.scala
@@ -5,13 +5,13 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 import ml.combust.mleap.core.types.{SchemaSpec, _}
 import ml.combust.mleap.runtime.function.UserDefinedFunction
 import ml.combust.mleap.tensor.ByteString
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /** Base trait for testing LeapFrame implementations.
   *
   * @tparam LF LeapFrame type
   */
-trait LeapFrameSpec[LF <: LeapFrame[LF]] extends FunSpec {
+trait LeapFrameSpec[LF <: LeapFrame[LF]] extends org.scalatest.funspec.AnyFunSpec {
   val fields = Seq(StructField("test_string", ScalarType.String),
     StructField("test_double", ScalarType.Double))
   val schema: StructType = StructType(fields).get

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/frame/RowSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/frame/RowSpec.scala
@@ -1,13 +1,13 @@
 package ml.combust.mleap.runtime.frame
 
 import ml.combust.mleap.tensor.Tensor
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /** Base trait for testing [[Row]] implementations.
   *
   * @tparam R row class
   */
-trait RowSpec[R <: Row] extends FunSpec {
+trait RowSpec[R <: Row] extends org.scalatest.funspec.AnyFunSpec {
   def create(values: Any *): R
 
   def row(): Unit = {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/frame/RowTransformerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/frame/RowTransformerSpec.scala
@@ -2,12 +2,12 @@ package ml.combust.mleap.runtime.frame
 
 import ml.combust.mleap.core.types.{ScalarType, StructType}
 import ml.combust.mleap.runtime.function.UserDefinedFunction
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 10/5/17.
   */
-class RowTransformerSpec extends FunSpec {
+class RowTransformerSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("non-shuffling transforms") {
     it("correctly transforms incoming rows") {
       val udf: UserDefinedFunction = (in: Double) => in + 42.0

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/SelectorSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/SelectorSpec.scala
@@ -1,11 +1,11 @@
 package ml.combust.mleap.runtime.function
 
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 10/22/16.
   */
-class SelectorSpec extends FunSpec {
+class SelectorSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("#applye") {
     it("creates selectors implicitly") {
       val fieldSelector: Selector = "hey"

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/UserDefinedFunctionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/UserDefinedFunctionSpec.scala
@@ -2,12 +2,12 @@ package ml.combust.mleap.runtime.function
 
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.tensor.Tensor
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 10/21/16.
   */
-class UserDefinedFunctionSpec extends FunSpec {
+class UserDefinedFunctionSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("#apply") {
     it("creates the udf") {
       val udf0: UserDefinedFunction = () => "hello"

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/serialization/FrameReaderSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/serialization/FrameReaderSpec.scala
@@ -2,9 +2,7 @@ package ml.combust.mleap.runtime.serialization
 
 import java.io.File
 
-import org.scalatest.FunSpec
-
-class FrameReaderSpec extends FunSpec {
+class FrameReaderSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("frame reader") {
     it("can read frame") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/serialization/FrameSerializerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/serialization/FrameSerializerSpec.scala
@@ -4,12 +4,12 @@ import ml.combust.mleap.core.types._
 import ml.combust.mleap.tensor.{ByteString, Tensor}
 import ml.combust.mleap.runtime.MleapSupport._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 11/1/16.
   */
-class FrameSerializerSpec extends FunSpec {
+class FrameSerializerSpec extends org.scalatest.funspec.AnyFunSpec {
   private val schema = StructType(StructField("features", TensorType(BasicType.Double)),
     StructField("name", ScalarType.String),
     StructField("list_data", ListType(BasicType.String)),

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/PipelineSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/PipelineSpec.scala
@@ -6,9 +6,9 @@ import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.transformer.feature.VectorAssembler
 import ml.combust.mleap.runtime.transformer.regression.LinearRegression
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class PipelineSpec extends FunSpec {
+class PipelineSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has inputs or outputs of its transformers") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/GBTClassifierSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/GBTClassifierSpec.scala
@@ -5,12 +5,12 @@ import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.test.TestUtil
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.combust.mleap.tensor.Tensor
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 9/28/16.
   */
-class GBTClassifierSpec extends FunSpec {
+class GBTClassifierSpec extends AnyFunSpec {
   val schema = StructType(Seq(StructField("features", TensorType(BasicType.Double)))).get
   val dataset = Seq(Row(Tensor.denseVector(Array(0.2, 0.7, 0.4))))
   val frame = DefaultLeapFrame(schema, dataset)

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/LinearSVCSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/LinearSVCSpec.scala
@@ -1,6 +1,6 @@
 package ml.combust.mleap.runtime.transformer.classification
 
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 import ml.combust.mleap.core.types._
 import org.apache.spark.ml.linalg.Vectors
 import ml.combust.mleap.core.classification.LinearSVCModel
@@ -9,8 +9,7 @@ import ml.combust.mleap.core.classification.LinearSVCModel
   * Test spec for LinearSVC.
   * Note that Linear SVC is not a probabilistic classifier, so we use the basicClassifier() call.
   */
-class LinearSVCSpec extends FunSpec
-{
+class LinearSVCSpec extends AnyFunSpec {
     describe("input/output schema")
     {
         it("has the correct inputs and outputs")

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/LogisticRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/LogisticRegressionSpec.scala
@@ -5,16 +5,16 @@ import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.combust.mleap.tensor.Tensor
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 9/15/16.
   */
-class LogisticRegressionSpec extends FunSpec {
-  val schema = StructType(Seq(StructField("features", TensorType(BasicType.Double)))).get
-  val dataset = Seq(Row(Tensor.denseVector(Array(0.5, -0.5, 1.0))))
-  val frame = DefaultLeapFrame(schema, dataset)
-  val logisticRegression = LogisticRegression(shape = NodeShape.probabilisticClassifier(),
+class LogisticRegressionSpec extends AnyFunSpec {
+  private val schema = StructType(Seq(StructField("features", TensorType(BasicType.Double)))).get
+  private val dataset = Seq(Row(Tensor.denseVector(Array(0.5, -0.5, 1.0))))
+  private val frame = DefaultLeapFrame(schema, dataset)
+  private val logisticRegression = LogisticRegression(shape = NodeShape.probabilisticClassifier(),
     model = LogisticRegressionModel(BinaryLogisticRegressionModel(coefficients = Vectors.dense(Array(1.0, 1.0, 2.0)),
       intercept = -0.2,
       threshold = 0.75)))
@@ -23,7 +23,7 @@ class LogisticRegressionSpec extends FunSpec {
     describe("#transform") {
       it("executes the logistic regression model and outputs the prediction") {
         val frame2 = logisticRegression.transform(frame).get
-        val prediction = frame2.dataset(0).getDouble(1)
+        val prediction = frame2.dataset.head.getDouble(1)
 
         assert(prediction == 1.0)
       }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/MultiLayerPerceptronClassifierSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/MultiLayerPerceptronClassifierSpec.scala
@@ -3,9 +3,8 @@ package ml.combust.mleap.runtime.transformer.classification
 import ml.combust.mleap.core.classification.MultiLayerPerceptronClassifierModel
 import ml.combust.mleap.core.types._
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
 
-class MultiLayerPerceptronClassifierSpec extends FunSpec {
+class MultiLayerPerceptronClassifierSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/NaiveBayesClassifierSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/NaiveBayesClassifierSpec.scala
@@ -2,9 +2,8 @@ package ml.combust.mleap.runtime.transformer.classification
 
 import ml.combust.mleap.core.classification.NaiveBayesModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
 
-class NaiveBayesClassifierSpec extends FunSpec {
+class NaiveBayesClassifierSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/OneVsRestSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/OneVsRestSpec.scala
@@ -3,9 +3,8 @@ package ml.combust.mleap.runtime.transformer.classification
 import ml.combust.mleap.core.classification.{BinaryLogisticRegressionModel, OneVsRestModel}
 import ml.combust.mleap.core.types._
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
 
-class OneVsRestSpec extends FunSpec {
+class OneVsRestSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("input/output schema") {
     it("has the correct inputs and outputs without probability column") {
       val transformer = OneVsRest(shape = NodeShape.basicClassifier(),

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/RandomForestClassifierSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/RandomForestClassifierSpec.scala
@@ -2,9 +2,8 @@ package ml.combust.mleap.runtime.transformer.classification
 
 import ml.combust.mleap.core.classification.RandomForestClassifierModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
 
-class RandomForestClassifierSpec extends FunSpec {
+class RandomForestClassifierSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/SupportVectorMachineSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/SupportVectorMachineSpec.scala
@@ -3,9 +3,8 @@ package ml.combust.mleap.runtime.transformer.classification
 import ml.combust.mleap.core.classification.SupportVectorMachineModel
 import ml.combust.mleap.core.types._
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
 
-class SupportVectorMachineSpec extends FunSpec {
+class SupportVectorMachineSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/clustering/BisectingKMeansSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/clustering/BisectingKMeansSpec.scala
@@ -4,9 +4,8 @@ import ml.combust.mleap.core.clustering.{BisectingKMeansModel, ClusteringTreeNod
 import ml.combust.mleap.core.types._
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.linalg.mleap.VectorWithNorm
-import org.scalatest.FunSpec
 
-class BisectingKMeansSpec extends FunSpec {
+class BisectingKMeansSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/clustering/GaussianMixtureSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/clustering/GaussianMixtureSpec.scala
@@ -2,9 +2,8 @@ package ml.combust.mleap.runtime.transformer.clustering
 
 import ml.combust.mleap.core.clustering.GaussianMixtureModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
 
-class GaussianMixtureSpec extends FunSpec {
+class GaussianMixtureSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs with only prediction column") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/clustering/KMeansSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/clustering/KMeansSpec.scala
@@ -5,12 +5,12 @@ import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.combust.mleap.tensor.DenseTensor
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 9/30/16.
   */
-class KMeansSpec extends FunSpec {
+class KMeansSpec extends AnyFunSpec {
   val v1 = Vectors.dense(Array(1.0, 2.0, 55.0))
   val v2 = Vectors.dense(Array(11.0, 200.0, 55.0))
   val v3 = Vectors.dense(Array(100.0, 22.0, 55.0))

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/clustering/LDASpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/clustering/LDASpec.scala
@@ -3,9 +3,9 @@ package ml.combust.mleap.runtime.transformer.clustering
 import breeze.linalg.{DenseMatrix, Matrix}
 import ml.combust.mleap.core.clustering.LocalLDAModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class LDASpec extends FunSpec {
+class LDASpec extends AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/ensemble/CategoricalDrilldownSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/ensemble/CategoricalDrilldownSpec.scala
@@ -4,7 +4,7 @@ import ml.combust.mleap.core.Model
 import ml.combust.mleap.core.types.{NodeShape, ScalarType, StructType}
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, MultiTransformer, Row, Transformer}
 import ml.combust.mleap.runtime.function.UserDefinedFunction
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 case class TestClassifierModel(shift: Int) extends Model {
   def apply(feature: Int): Double = {
@@ -27,7 +27,7 @@ case class TestClassifier(override val uid: String = Transformer.uniqueName("dri
     inputSchema)
 }
 
-class CategoricalDrilldownSpec extends FunSpec {
+class CategoricalDrilldownSpec extends AnyFunSpec {
   val classifier1 = TestClassifier(shape = NodeShape().withStandardInput("feature").
     withOutput("output", "prediction").
     withOutput("probability", "probability"),

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/BinarizerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/BinarizerSpec.scala
@@ -4,12 +4,12 @@ import ml.combust.mleap.core.feature.BinarizerModel
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.combust.mleap.tensor.Tensor
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by fshabbir on 12/1/16.
   */
-class BinarizerSpec extends FunSpec {
+class BinarizerSpec extends AnyFunSpec {
   val binarizer = Binarizer(shape = NodeShape.feature(
     inputCol = "test_vec",
     outputCol = "test_binarizer"),

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/BucketedRandomProjectionLSHSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/BucketedRandomProjectionLSHSpec.scala
@@ -2,9 +2,9 @@ package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.BucketedRandomProjectionLSHModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class BucketedRandomProjectionLSHSpec extends FunSpec {
+class BucketedRandomProjectionLSHSpec extends AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/BucketizerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/BucketizerSpec.scala
@@ -3,12 +3,12 @@ package ml.combust.mleap.runtime.transformer.feature
 import ml.combust.mleap.core.feature.{BucketizerModel, HandleInvalid}
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 9/28/16.
   */
-class BucketizerSpec extends FunSpec {
+class BucketizerSpec extends AnyFunSpec {
   val schema = StructType(Seq(StructField("test_double", ScalarType.Double))).get
   val dataset = Seq(Row(11.0), Row(0.0), Row(55.0))
   val frame = DefaultLeapFrame(schema, dataset)

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/ChiSqSelectorSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/ChiSqSelectorSpec.scala
@@ -2,9 +2,9 @@ package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.ChiSqSelectorModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class ChiSqSelectorSpec extends FunSpec {
+class ChiSqSelectorSpec extends AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/CoalesceSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/CoalesceSpec.scala
@@ -3,12 +3,12 @@ package ml.combust.mleap.runtime.transformer.feature
 import ml.combust.mleap.core.feature.CoalesceModel
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 1/5/17.
   */
-class CoalesceSpec extends FunSpec {
+class CoalesceSpec extends AnyFunSpec {
   val schema = StructType(StructField("test1", ScalarType.Double),
     StructField("test2", ScalarType.Double),
     StructField("test3", ScalarType.Double),

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/CountVectorizerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/CountVectorizerSpec.scala
@@ -2,9 +2,9 @@ package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.CountVectorizerModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class CountVectorizerSpec extends FunSpec {
+class CountVectorizerSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/DCTSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/DCTSpec.scala
@@ -2,9 +2,8 @@ package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.DCTModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
 
-class DCTSpec extends FunSpec {
+class DCTSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/ElementWiseProductSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/ElementWiseProductSpec.scala
@@ -5,12 +5,11 @@ import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.combust.mleap.tensor.Tensor
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
 
 /**
-  * Created by hollinwilkins on 9/28/16.
-  */
-class ElementWiseProductSpec extends FunSpec {
+ * Created by hollinwilkins on 9/28/16.
+ */
+class ElementWiseProductSpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(Seq(StructField("test_vec", TensorType(BasicType.Double)))).get
   val dataset = Seq(Row(Tensor.denseVector(Array(0.0, 20.0, 20.0))))
   val frame = DefaultLeapFrame(schema, dataset)
@@ -29,7 +28,9 @@ class ElementWiseProductSpec extends FunSpec {
     describe("with invalid input column") {
       val ewp2 = ewp.copy(shape = NodeShape.feature(inputCol = "bad_input"))
 
-      it("returns a Failure") { assert(ewp2.transform(frame).isFailure) }
+      it("returns a Failure") {
+        assert(ewp2.transform(frame).isFailure)
+      }
     }
   }
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/FeatureHasherSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/FeatureHasherSpec.scala
@@ -2,9 +2,8 @@ package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.FeatureHasherModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
 
-class FeatureHasherSpec extends FunSpec {
+class FeatureHasherSpec extends org.scalatest.funspec.AnyFunSpec {
 
   val inputSchema = Map(
     "input0" → StructField("doubleCol", DataType(BasicType.Double, ScalarShape())),

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/HashingTermFrequencySpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/HashingTermFrequencySpec.scala
@@ -2,15 +2,14 @@ package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.HashingTermFrequencyModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
 
-class HashingTermFrequencySpec extends FunSpec {
+class HashingTermFrequencySpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {
       val transformer = HashingTermFrequency(shape = NodeShape().
-              withStandardInput("input").
-              withStandardOutput("output"), model = HashingTermFrequencyModel())
+        withStandardInput("input").
+        withStandardOutput("output"), model = HashingTermFrequencyModel())
       assert(transformer.schema.fields ==
         Seq(StructField("input", ListType(BasicType.String)),
           StructField("output", TensorType.Double(262144))))

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/IDFSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/IDFSpec.scala
@@ -3,9 +3,8 @@ package ml.combust.mleap.runtime.transformer.feature
 import ml.combust.mleap.core.feature.IDFModel
 import ml.combust.mleap.core.types._
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
 
-class IDFSpec extends FunSpec {
+class IDFSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/ImputerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/ImputerSpec.scala
@@ -3,16 +3,15 @@ package ml.combust.mleap.runtime.transformer.feature
 import ml.combust.mleap.core.feature.ImputerModel
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
-import org.scalatest.FunSpec
 
 /**
-  * Created by hollinwilkins on 1/4/17.
-  */
-class ImputerSpec extends FunSpec {
+ * Created by hollinwilkins on 1/4/17.
+ */
+class ImputerSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("imputer") {
     val transformer = Imputer(
       shape = NodeShape().withStandardInput("test_a").
-              withStandardOutput("test_out"),
+        withStandardOutput("test_out"),
       model = ImputerModel(45.7, 23.6, ""))
 
     describe("null values") {
@@ -40,7 +39,7 @@ class ImputerSpec extends FunSpec {
       val dataset = Seq(Row(42.0), Row(23.6), Row(Double.NaN))
       val frame = DefaultLeapFrame(schema, dataset)
       val transformer2 = transformer.copy(shape = NodeShape().
-              withStandardInput("test_a").
+        withStandardInput("test_a").
         withStandardOutput("test_out"),
         model = transformer.model.copy(nullableInput = false))
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/InteractionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/InteractionSpec.scala
@@ -2,17 +2,16 @@ package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.InteractionModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
 
-class InteractionSpec extends FunSpec {
+class InteractionSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {
       val transformer = Interaction(shape = NodeShape().
-                    withInput("input0", "feature1").
-                    withInput("input1", "feature2").
-                    withInput("input2", "feature3").
-              withStandardOutput("features"),
+        withInput("input0", "feature1").
+        withInput("input1", "feature2").
+        withInput("input2", "feature3").
+        withStandardOutput("features"),
         model = InteractionModel(Array(Array(1), Array(1, 1), Array(2, 2)),
           Seq(ScalarShape(), TensorShape(2), TensorShape(2))))
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MapEntrySelectorSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MapEntrySelectorSpec.scala
@@ -3,26 +3,25 @@ package ml.combust.mleap.runtime.transformer.feature
 import ml.combust.mleap.core.feature.MapEntrySelectorModel
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
-import org.scalatest.FunSpec
 
-class MapEntrySelectorSpec extends FunSpec {
+class MapEntrySelectorSpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(Seq(
     StructField("test_map", MapType(BasicType.String, BasicType.Double)),
     StructField("my_key", ScalarType.String)
   )).get
   val dataset = Seq(
-    Row(Map("a"->1.0), "a"),
-    Row(Map("b"->2.0), "key_does_not_exist"),
-    Row(Map("c"->3.0), "c")
+    Row(Map("a" -> 1.0), "a"),
+    Row(Map("b" -> 2.0), "key_does_not_exist"),
+    Row(Map("c" -> 3.0), "c")
   )
   val frame = DefaultLeapFrame(schema, dataset)
 
   val transformer = MapEntrySelector(
-    shape=NodeShape()
+    shape = NodeShape()
       .withStandardInput("test_map")
       .withInput("key", "my_key")
       .withStandardOutput("result"),
-    model=MapEntrySelectorModel[String, Double](defaultValue = 42.42)
+    model = MapEntrySelectorModel[String, Double](defaultValue = 42.42)
   )
 
   describe("#transform") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MathBinarySpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MathBinarySpec.scala
@@ -4,12 +4,11 @@ import ml.combust.mleap.core.feature.BinaryOperation._
 import ml.combust.mleap.core.feature.MathBinaryModel
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
-import org.scalatest.FunSpec
 
 /**
-  * Created by hollinwilkins on 12/27/16.
-  */
-class MathBinarySpec extends FunSpec {
+ * Created by hollinwilkins on 12/27/16.
+ */
+class MathBinarySpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(StructField("test_a", ScalarType.Double), StructField("test_b", ScalarType.Double)).get
   val dataset = Seq(Row(5.6, 7.9))
   val frame = DefaultLeapFrame(schema, dataset)
@@ -17,8 +16,8 @@ class MathBinarySpec extends FunSpec {
   describe("with a and b inputs") {
     val transformer = MathBinary(
       shape = NodeShape().withInput("input_a", "test_a").
-                    withInput("input_b", "test_b").
-              withStandardOutput("test_out"),
+        withInput("input_b", "test_b").
+        withStandardOutput("test_out"),
       model = MathBinaryModel(Divide, None, None))
 
     it("calculates the correct value") {
@@ -37,7 +36,7 @@ class MathBinarySpec extends FunSpec {
   describe("with a input") {
     val transformer = MathBinary(
       shape = NodeShape().withInput("input_a", "test_a").
-              withStandardOutput("test_out"),
+        withStandardOutput("test_out"),
       model = MathBinaryModel(Multiply, None, Some(3.333)))
 
     it("calculates the value using the b default") {
@@ -55,7 +54,7 @@ class MathBinarySpec extends FunSpec {
   describe("with b input") {
     val transformer = MathBinary(
       shape = NodeShape().withInput("input_b", "test_b").
-              withStandardOutput("test_out"),
+        withStandardOutput("test_out"),
       model = MathBinaryModel(Multiply, Some(3.333), None))
 
     it("calculates the value using the a default") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MathUnarySpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MathUnarySpec.scala
@@ -4,12 +4,11 @@ import ml.combust.mleap.core.feature.MathUnaryModel
 import ml.combust.mleap.core.feature.UnaryOperation.Sin
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
-import org.scalatest.FunSpec
 
 /**
-  * Created by hollinwilkins on 12/27/16.
-  */
-class MathUnarySpec extends FunSpec {
+ * Created by hollinwilkins on 12/27/16.
+ */
+class MathUnarySpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(StructField("test_a", ScalarType.Double)).get
   val dataset = Seq(Row(42.0))
   val frame = DefaultLeapFrame(schema, dataset)

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MaxAbsScalerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MaxAbsScalerSpec.scala
@@ -5,12 +5,11 @@ import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.combust.mleap.tensor.Tensor
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
 
 /**
-  * Created by mikhail on 9/25/16.
-  */
-class MaxAbsScalerSpec extends FunSpec{
+ * Created by mikhail on 9/25/16.
+ */
+class MaxAbsScalerSpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(Seq(StructField("test_vec", TensorType(BasicType.Double)))).get
   val dataset = Seq(Row(Tensor.denseVector(Array(0.0, 20.0, 20.0))))
   val frame = DefaultLeapFrame(schema, dataset)
@@ -33,7 +32,9 @@ class MaxAbsScalerSpec extends FunSpec{
     describe("with invalid input column") {
       val maxAbsScaler2 = maxAbsScaler.copy(shape = NodeShape.feature(inputCol = "bad_input"))
 
-      it("returns a Failure") { assert(maxAbsScaler2.transform(frame).isFailure) }
+      it("returns a Failure") {
+        assert(maxAbsScaler2.transform(frame).isFailure)
+      }
     }
   }
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MinHashLSHSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MinHashLSHSpec.scala
@@ -2,9 +2,8 @@ package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.MinHashLSHModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
 
-class MinHashLSHSpec extends FunSpec {
+class MinHashLSHSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MinMaxScalerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MinMaxScalerSpec.scala
@@ -1,22 +1,21 @@
 package ml.combust.mleap.runtime.transformer.feature
 
-import java.io.File
-
 import ml.combust.bundle.BundleFile
 import ml.combust.mleap.core.feature.MinMaxScalerModel
 import ml.combust.mleap.core.types._
+import ml.combust.mleap.runtime.MleapSupport._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.combust.mleap.runtime.transformer.Pipeline
 import ml.combust.mleap.tensor.Tensor
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
-import resource.managed
-import ml.combust.mleap.runtime.MleapSupport._
+
+import java.io.File
+import scala.util.Using
 
 /**
-  * Created by mikhail on 9/25/16.
-  */
-class MinMaxScalerSpec extends FunSpec{
+ * Created by mikhail on 9/25/16.
+ */
+class MinMaxScalerSpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(Seq(StructField("test_vec", TensorType(BasicType.Double)))).get
   val dataset = Seq(Row(Tensor.denseVector(Array(0.0, 20.0, 20.0))))
   val frame = DefaultLeapFrame(schema, dataset)
@@ -53,11 +52,11 @@ class MinMaxScalerSpec extends FunSpec{
   }
 
   describe("min max scaler with defaults for min/max still works") {
-    it ("loads correctly in mleap") {
+    it("loads correctly in mleap") {
       val file = new File(getClass.getResource("/min_max_scaler_tf.zip").toURI)
-      val pipeline = (for (bf <- managed(BundleFile(file))) yield {
+      val pipeline = Using(BundleFile(file)) { bf =>
         bf.loadMleapBundle().get.root
-      }).tried.get.asInstanceOf[Pipeline]
+      }.get.asInstanceOf[Pipeline]
 
       assert(pipeline.model.transformers.size == 2)
     }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MultinomialLabelerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MultinomialLabelerSpec.scala
@@ -4,27 +4,26 @@ import ml.combust.mleap.core.feature.{MultinomialLabelerModel, ReverseStringInde
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.combust.mleap.tensor.Tensor
-import org.scalatest.FunSpec
 
 /**
-  * Created by hollinwilkins on 1/18/17.
-  */
-class MultinomialLabelerSpec extends FunSpec {
+ * Created by hollinwilkins on 1/18/17.
+ */
+class MultinomialLabelerSpec extends org.scalatest.funspec.AnyFunSpec {
 
   val schema = StructType(Seq(StructField("test_vec", TensorType(BasicType.Double)))).get
   val dataset = Seq(Row(Tensor.denseVector(Array(0.0, 10.0, 20.0))))
   val frame = DefaultLeapFrame(schema, dataset)
   val transformer = MultinomialLabeler(
-    shape = NodeShape().withInput("features","test_vec").
-          withOutput("probabilities", "probs").
-          withOutput("labels", "labels"),
+    shape = NodeShape().withInput("features", "test_vec").
+      withOutput("probabilities", "probs").
+      withOutput("labels", "labels"),
     model = MultinomialLabelerModel(9.0, ReverseStringIndexerModel(Seq("hello1", "world2", "!3"))))
 
 
   describe("#transform") {
     it("outputs the labels and probabilities for all classes with a probability greater than the threshold") {
-      val frame2 = for(f <- transformer.transform(frame);
-                       f2 <- f.select("probs", "labels")) yield f2
+      val frame2 = for (f <- transformer.transform(frame);
+                        f2 <- f.select("probs", "labels")) yield f2
 
       assert(frame2.isSuccess)
       val data = frame2.get.dataset

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/NGramSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/NGramSpec.scala
@@ -3,19 +3,18 @@ package ml.combust.mleap.runtime.transformer.feature
 import ml.combust.mleap.core.feature.NGramModel
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
-import org.scalatest.FunSpec
 
 /**
-  * Created by mikhail on 10/16/16.
-  */
-class NGramSpec extends FunSpec{
+ * Created by mikhail on 10/16/16.
+ */
+class NGramSpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(Seq(StructField("test_string_seq", ListType(BasicType.String)))).get
   val dataset = Seq(Row("a b c".split(" ").toSeq), Row("d e f".split(" ").toSeq), Row("g h i".split(" ").toSeq))
-  val frame = DefaultLeapFrame(schema,dataset)
+  val frame = DefaultLeapFrame(schema, dataset)
 
   val ngram = NGram(
     shape = NodeShape().withStandardInput("test_string_seq").
-          withStandardOutput("output_ngram"),
+      withStandardOutput("output_ngram"),
     model = NGramModel(2)
   )
 
@@ -31,9 +30,11 @@ class NGramSpec extends FunSpec{
 
   describe("with invalid input column") {
     val ngram2 = ngram.copy(shape = NodeShape().withStandardInput("bad_input").
-          withStandardOutput("output"))
+      withStandardOutput("output"))
 
-    it("returns a failure") {assert(ngram2.transform(frame).isFailure)}
+    it("returns a failure") {
+      assert(ngram2.transform(frame).isFailure)
+    }
   }
 
   describe("input/output schema") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/NormalizerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/NormalizerSpec.scala
@@ -4,12 +4,11 @@ import ml.combust.mleap.core.feature.NormalizerModel
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.combust.mleap.tensor.Tensor
-import org.scalatest.FunSpec
 
 /**
-  * Created by hollinwilkins on 9/24/16.
-  */
-class NormalizerSpec extends FunSpec {
+ * Created by hollinwilkins on 9/24/16.
+ */
+class NormalizerSpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(Seq(StructField("test_vec", TensorType(BasicType.Double)))).get
   val dataset = Seq(Row(Tensor.denseVector(Array(0.0, 20.0, 40.0))))
   val frame = DefaultLeapFrame(schema, dataset)
@@ -32,7 +31,9 @@ class NormalizerSpec extends FunSpec {
     describe("with invalid input column") {
       val normalizer2 = normalizer.copy(shape = NodeShape.feature(inputCol = "bad_input"))
 
-      it("returns a Failure") { assert(normalizer2.transform(frame).isFailure) }
+      it("returns a Failure") {
+        assert(normalizer2.transform(frame).isFailure)
+      }
     }
   }
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/OneHotEncoderSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/OneHotEncoderSpec.scala
@@ -1,16 +1,15 @@
 package ml.combust.mleap.runtime.transformer.feature
 
-import java.io.File
-
 import ml.combust.bundle.BundleFile
 import ml.combust.mleap.core.feature.OneHotEncoderModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
-import resource.managed
 import ml.combust.mleap.runtime.MleapSupport._
 import ml.combust.mleap.runtime.transformer.Pipeline
 
-class OneHotEncoderSpec extends FunSpec {
+import java.io.File
+import scala.util.Using
+
+class OneHotEncoderSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs in a single-input/output context") {
@@ -20,7 +19,7 @@ class OneHotEncoderSpec extends FunSpec {
       assert(
         transformer.schema.fields ==
           Seq(StructField("input0", ScalarType.Double.nonNullable),
-              StructField("output0", TensorType.Double(5))))
+            StructField("output0", TensorType.Double(5))))
     }
 
     it("has the correct inputs and output in a multi-input/output context") {
@@ -37,11 +36,11 @@ class OneHotEncoderSpec extends FunSpec {
   }
 
   describe("one hot encoder pre Spark 2.3.0") {
-    it ("loads correctly in mleap") {
+    it("loads correctly in mleap") {
       val file = new File(getClass.getResource("/one_hot_encoder_pipeline.zip").toURI)
-      val pipeline = (for (bf <- managed(BundleFile(file))) yield {
+      val pipeline = Using(BundleFile(file)) { bf =>
         bf.loadMleapBundle().get.root
-      }).tried.get.asInstanceOf[Pipeline]
+      }.get.asInstanceOf[Pipeline]
 
       assert(pipeline.model.transformers.size == 2)
     }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/PcaSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/PcaSpec.scala
@@ -5,12 +5,11 @@ import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.combust.mleap.tensor.Tensor
 import org.apache.spark.ml.linalg.{DenseMatrix, Vectors}
-import org.scalatest.FunSpec
 
 /**
-  * Created by hollinwilkins on 10/12/16.
-  */
-class PcaSpec extends FunSpec {
+ * Created by hollinwilkins on 10/12/16.
+ */
+class PcaSpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(Seq(StructField("test_vec", TensorType(BasicType.Double)))).get
   val dataset = Seq(Row(Tensor.denseVector(Array(2.0, 1.0, 0.0))))
   val frame = DefaultLeapFrame(schema, dataset)
@@ -33,7 +32,9 @@ class PcaSpec extends FunSpec {
     describe("with invalid input column") {
       val pca2 = pca.copy(shape = NodeShape.feature(inputCol = "bad_input"))
 
-      it("returns a Failure") { assert(pca2.transform(frame).isFailure) }
+      it("returns a Failure") {
+        assert(pca2.transform(frame).isFailure)
+      }
     }
   }
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/PolynomialExpansionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/PolynomialExpansionSpec.scala
@@ -4,12 +4,11 @@ import ml.combust.mleap.core.feature.PolynomialExpansionModel
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.combust.mleap.tensor.Tensor
-import org.scalatest.FunSpec
 
 /**
-  * Created by mikhail on 10/16/16.
-  */
-class PolynomialExpansionSpec extends FunSpec {
+ * Created by mikhail on 10/16/16.
+ */
+class PolynomialExpansionSpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(Seq(StructField("test_vec", TensorType(BasicType.Double)))).get
   val dataset = Seq(Row(Tensor.denseVector(Array(2.0, 3.0))))
   val frame = DefaultLeapFrame(schema, dataset)

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/RegexIndexerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/RegexIndexerSpec.scala
@@ -3,9 +3,8 @@ package ml.combust.mleap.runtime.transformer.feature
 import ml.combust.mleap.core.feature.RegexIndexerModel
 import ml.combust.mleap.core.types.{NodeShape, ScalarType, StructField, StructType}
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
-import org.scalatest.FunSpec
 
-class RegexIndexerSpec extends FunSpec {
+class RegexIndexerSpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(Seq(StructField("test_string", ScalarType.String))).get
   val dataset = Seq(Row("hEllo"), Row("NpOE"), Row("NEy"))
   val frame = DefaultLeapFrame(schema, dataset)
@@ -24,7 +23,7 @@ class RegexIndexerSpec extends FunSpec {
   describe("#transform") {
     it("transforms strings into indices") {
       val data = (for (frame2 <- indexer.transform(frame);
-                      frame3 <- frame2.select("test_index")) yield {
+                       frame3 <- frame2.select("test_index")) yield {
         frame3.dataset.map(_.getInt(0))
       }).get
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/RegexTokenizerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/RegexTokenizerSpec.scala
@@ -3,16 +3,15 @@ package ml.combust.mleap.runtime.transformer.feature
 import ml.combust.mleap.core.feature.RegexTokenizerModel
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
-import org.scalatest.FunSpec
 
-class RegexTokenizerSpec extends FunSpec {
+class RegexTokenizerSpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(Seq(StructField("test_string", ScalarType.String))).get
   val dataset = Seq(Row("dies isT Ein TEST text te"))
   val frame = DefaultLeapFrame(schema, dataset)
 
   val gapRegexTokenizer = RegexTokenizer(
     shape = NodeShape().withStandardInput("test_string").
-          withStandardOutput("test_tokens"),
+      withStandardOutput("test_tokens"),
     model = RegexTokenizerModel(
       regex = """\s""".r,
       matchGaps = true,
@@ -23,7 +22,7 @@ class RegexTokenizerSpec extends FunSpec {
 
   val wordRegexTokenizer = RegexTokenizer(
     shape = NodeShape().withStandardInput("test_string").
-          withStandardOutput("test_tokens"),
+      withStandardOutput("test_tokens"),
     model = RegexTokenizerModel(
       regex = """\w+""".r,
       matchGaps = false,

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/ReverseStringIndexerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/ReverseStringIndexerSpec.scala
@@ -4,9 +4,8 @@ import ml.combust.mleap.core.feature.ReverseStringIndexerModel
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.combust.mleap.tensor.Tensor
-import org.scalatest.FunSpec
 
-class ReverseStringIndexerSpec extends FunSpec {
+class ReverseStringIndexerSpec extends org.scalatest.funspec.AnyFunSpec {
   val scalarFrame = DefaultLeapFrame(
     StructType(StructField("input", ScalarType.Double.nonNullable)).get,
     Seq(Row(1.0))

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/StandardScalerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/StandardScalerSpec.scala
@@ -1,19 +1,18 @@
 package ml.combust.mleap.runtime.transformer.feature
 
-import java.io.File
-import java.net.URI
-
 import ml.combust.bundle.BundleFile
 import ml.combust.bundle.serializer.SerializationFormat
 import ml.combust.mleap.core.feature.StandardScalerModel
 import ml.combust.mleap.core.types._
+import ml.combust.mleap.runtime.MleapSupport._
 import ml.combust.mleap.runtime.test.TestUtil
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
-import resource.managed
-import ml.combust.mleap.runtime.MleapSupport._
 
-class StandardScalerSpec extends FunSpec {
+import java.io.File
+import java.net.URI
+import scala.util.Using
+
+class StandardScalerSpec extends org.scalatest.funspec.AnyFunSpec {
 
   val means = Some(Vectors.dense(Array(50.0, 20.0, 30.0)))
   val std = Some(Vectors.dense(Array(5.0, 1.0, 3.0)))
@@ -32,16 +31,16 @@ class StandardScalerSpec extends FunSpec {
   describe("serialization") {
     it("serializes std as well as mean correctly") {
       val uri = new URI(s"jar:file:${TestUtil.baseDir}/standard-scaler.json.zip")
-      for (file <- managed(BundleFile(uri))) {
+      Using(BundleFile(uri)) { file =>
         transformer.writeBundle.name("bundle")
           .format(SerializationFormat.Json)
           .save(file)
       }
 
       val file = new File(s"${TestUtil.baseDir}/standard-scaler.json.zip")
-      val scaler = (for (bf <- managed(BundleFile(file))) yield {
+      val scaler = Using(BundleFile(file)) { bf =>
         bf.loadMleapBundle().get.root
-      }).tried.get.asInstanceOf[StandardScaler]
+      }.get.asInstanceOf[StandardScaler]
 
       assert(transformer.model.std sameElements scaler.model.std)
       assert(transformer.model.mean sameElements scaler.model.mean)

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/StopWordsRemoverSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/StopWordsRemoverSpec.scala
@@ -3,19 +3,18 @@ package ml.combust.mleap.runtime.transformer.feature
 import ml.combust.mleap.core.feature.StopWordsRemoverModel
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
-import org.scalatest.FunSpec
 
 /**
-  * Created by mikhail on 10/16/16.
-  */
-class StopWordsRemoverSpec extends FunSpec{
+ * Created by mikhail on 10/16/16.
+ */
+class StopWordsRemoverSpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(Seq(StructField("test_string_seq", ListType(BasicType.String)))).get
   val dataset = Seq(Row("I used MLeap transformer".split(" ").toSeq), Row("You use Mleap transformer".split(" ").toSeq))
-  val frame = DefaultLeapFrame(schema,dataset)
+  val frame = DefaultLeapFrame(schema, dataset)
 
   val stopWordsTransformer = StopWordsRemover(
     shape = NodeShape().withStandardInput("test_string_seq").
-          withStandardOutput("output_seq"),
+      withStandardOutput("output_seq"),
     model = StopWordsRemoverModel(Seq("I", "You", "the"), caseSensitive = true)
   )
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/StringIndexerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/StringIndexerSpec.scala
@@ -3,12 +3,11 @@ package ml.combust.mleap.runtime.transformer.feature
 import ml.combust.mleap.core.feature.{HandleInvalid, StringIndexerModel}
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row, RowTransformer}
-import org.scalatest.FunSpec
 
 /**
-  * Created by hollinwilkins on 9/15/16.
-  */
-class StringIndexerSpec extends FunSpec {
+ * Created by hollinwilkins on 9/15/16.
+ */
+class StringIndexerSpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(Seq(StructField("test_string", ScalarType.String))).get
   val dataset = Seq(Row("index1"), Row("index2"), Row("index3"))
   val frame = DefaultLeapFrame(schema, dataset)
@@ -31,15 +30,19 @@ class StringIndexerSpec extends FunSpec {
 
     describe("with invalid input column") {
       val stringIndexer2 = stringIndexer.copy(shape = NodeShape().withStandardInput("bad_input").
-              withStandardOutput("output"))
+        withStandardOutput("output"))
 
-      it("returns a Failure") { assert(stringIndexer2.transform(frame).isFailure) }
+      it("returns a Failure") {
+        assert(stringIndexer2.transform(frame).isFailure)
+      }
     }
 
     describe("with invalid string") {
       val frame2 = frame.copy(dataset = Seq(Row("bad_index")))
 
-      it("returns a Failure") { assert(stringIndexer.transform(frame2).isFailure) }
+      it("returns a Failure") {
+        assert(stringIndexer.transform(frame2).isFailure)
+      }
     }
 
     describe("with skip logic") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/StringMapSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/StringMapSpec.scala
@@ -3,12 +3,11 @@ package ml.combust.mleap.runtime.transformer.feature
 import ml.combust.mleap.core.feature.StringMapModel
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
-import org.scalatest.FunSpec
 
 /**
-  * Created by hollinwilkins on 1/5/17.
-  */
-class StringMapSpec extends FunSpec {
+ * Created by hollinwilkins on 1/5/17.
+ */
+class StringMapSpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(Seq(StructField("test_string", ScalarType.String))).get
   val dataset = Seq(Row("index1"), Row("index2"), Row("index3"))
   val frame = DefaultLeapFrame(schema, dataset)
@@ -31,7 +30,9 @@ class StringMapSpec extends FunSpec {
     describe("with invalid string") {
       val frame2 = frame.copy(dataset = Seq(Row("bad_index")))
 
-      it("returns a Failure") { assert(stringMap.transform(frame2).isFailure) }
+      it("returns a Failure") {
+        assert(stringMap.transform(frame2).isFailure)
+      }
     }
   }
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/TokenizerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/TokenizerSpec.scala
@@ -2,14 +2,13 @@ package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.TokenizerModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
 
-class TokenizerSpec extends FunSpec {
+class TokenizerSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input") {
     it("has the correct inputs and outputs") {
       val transformer = Tokenizer(shape = NodeShape().withStandardInput("input").
-              withStandardOutput("output"), model = TokenizerModel.defaultTokenizer)
+        withStandardOutput("output"), model = TokenizerModel.defaultTokenizer)
       assert(transformer.schema.fields ==
         Seq(StructField("input", ScalarType.String.nonNullable),
           StructField("output", ListType(BasicType.String))))

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/VectorAssemblerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/VectorAssemblerSpec.scala
@@ -1,15 +1,14 @@
 package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.VectorAssemblerModel
-import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.combust.mleap.core.types._
+import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.combust.mleap.tensor.Tensor
-import org.scalatest.FunSpec
 
 /**
-  * Created by hollinwilkins on 9/15/16.
-  */
-class VectorAssemblerSpec extends FunSpec {
+ * Created by hollinwilkins on 9/15/16.
+ */
+class VectorAssemblerSpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(Seq(StructField("feature1", TensorType(BasicType.Double)),
     StructField("feature2", ScalarType.Double),
     StructField("feature3", ScalarType.Int))).get
@@ -17,9 +16,9 @@ class VectorAssemblerSpec extends FunSpec {
   val frame = DefaultLeapFrame(schema, dataset)
   val vectorAssembler = VectorAssembler(
     shape = NodeShape().withInput("input0", "feature1").
-              withInput("input1", "feature2").
-              withInput("input2", "feature3").
-          withStandardOutput("features"),
+      withInput("input1", "feature2").
+      withInput("input2", "feature3").
+      withStandardOutput("features"),
     model = VectorAssemblerModel(Seq(TensorShape(3), ScalarShape(), ScalarShape())))
 
   describe("#transform") {
@@ -32,10 +31,12 @@ class VectorAssemblerSpec extends FunSpec {
 
     describe("with invalid input") {
       val vectorAssembler2 = vectorAssembler.copy(shape = NodeShape().withInput("input0", "bad_input").
-              withStandardOutput("features"),
-      model = VectorAssemblerModel(Seq(ScalarShape())))
+        withStandardOutput("features"),
+        model = VectorAssemblerModel(Seq(ScalarShape())))
 
-      it("returns a Failure") { assert(vectorAssembler2.transform(frame).isFailure) }
+      it("returns a Failure") {
+        assert(vectorAssembler2.transform(frame).isFailure)
+      }
     }
   }
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/VectorIndexerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/VectorIndexerSpec.scala
@@ -2,9 +2,8 @@ package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.VectorIndexerModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
 
-class VectorIndexerSpec extends FunSpec {
+class VectorIndexerSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/VectorSlicerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/VectorSlicerSpec.scala
@@ -2,9 +2,8 @@ package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.VectorSlicerModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
 
-class VectorSlicerSpec extends FunSpec {
+class VectorSlicerSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/WordLengthFilterSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/WordLengthFilterSpec.scala
@@ -2,14 +2,13 @@ package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.WordLengthFilterModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
 
-class WordLengthFilterSpec extends FunSpec {
+class WordLengthFilterSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {
       val transformer = WordLengthFilter(shape = NodeShape().withStandardInput("input").
-              withStandardOutput("output"),
+        withStandardOutput("output"),
         model = new WordLengthFilterModel(5))
 
       assert(transformer.schema.fields ==

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/WordToVectorSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/WordToVectorSpec.scala
@@ -2,15 +2,14 @@ package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.WordToVectorModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
 
-class WordToVectorSpec extends FunSpec {
+class WordToVectorSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {
       val transformer = WordToVector(shape = NodeShape().withStandardInput("input").
-              withStandardOutput("output"),
-              model =  WordToVectorModel(Map("test" -> 1), Array(12)))
+        withStandardOutput("output"),
+        model = WordToVectorModel(Map("test" -> 1), Array(12)))
 
       assert(transformer.schema.fields ==
         Seq(StructField("input", ListType(BasicType.String)),

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/recommendation/ALSSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/recommendation/ALSSpec.scala
@@ -8,11 +8,10 @@ import ml.combust.bundle.serializer.SerializationFormat
 import ml.combust.mleap.core.recommendation.ALSModel
 import ml.combust.mleap.core.types.{NodeShape, ScalarType, StructField}
 import ml.combust.mleap.runtime.test.TestUtil
-import org.scalatest.FunSpec
-import resource.managed
+import scala.util.Using
 import ml.combust.mleap.runtime.MleapSupport._
 
-class ALSSpec extends FunSpec {
+class ALSSpec extends org.scalatest.funspec.AnyFunSpec {
 
   val userFactors = Map(0 -> Array(1.0f, 2.0f), 1 -> Array(3.0f, 1.0f), 2 -> Array(2.0f, 3.0f))
   val itemFactors = Map(0 -> Array(1.0f, 2.0f), 1 -> Array(3.0f, 1.0f), 2 -> Array(2.0f, 3.0f), 3 -> Array(1.0f, 2.0f))
@@ -33,16 +32,16 @@ class ALSSpec extends FunSpec {
   describe("serialization") {
     it("serializes ALS transformer correctly") {
       val uri = new URI(s"jar:file:${TestUtil.baseDir}/als.json.zip")
-      for (file <- managed(BundleFile(uri))) {
+      Using(BundleFile(uri)) { file =>
         transformer.writeBundle.name("bundle")
           .format(SerializationFormat.Json)
           .save(file)
       }
 
       val file = new File(s"${TestUtil.baseDir}/als.json.zip")
-      val als = (for (bf <- managed(BundleFile(file))) yield {
+      val als = Using(BundleFile(file)) { bf =>
         bf.loadMleapBundle().get.root
-      }).tried.get.asInstanceOf[ALS]
+      }.get.asInstanceOf[ALS]
 
       val (tfUsers, tfUserFactors) = transformer.model.userFactors.toSeq.unzip
       val (tfItems, tfItemFactors) = transformer.model.itemFactors.toSeq.unzip

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/AFTSurvivalRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/AFTSurvivalRegressionSpec.scala
@@ -3,9 +3,9 @@ package ml.combust.mleap.runtime.transformer.regression
 import ml.combust.mleap.core.regression.AFTSurvivalRegressionModel
 import ml.combust.mleap.core.types._
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class AFTSurvivalRegressionSpec extends FunSpec {
+class AFTSurvivalRegressionSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/DecisionTreeRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/DecisionTreeRegressionSpec.scala
@@ -7,13 +7,13 @@ import ml.combust.mleap.core.tree.{ContinuousSplit, InternalNode, LeafNode}
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.MleapSupport._
 import ml.combust.mleap.runtime.test.TestUtil
-import org.scalatest.FunSpec
-import resource.managed
+import org.scalatest.funspec.AnyFunSpec
+import scala.util.Using
 
 import java.io.File
 import java.net.URI
 
-class DecisionTreeRegressionSpec extends FunSpec {
+class DecisionTreeRegressionSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {
@@ -40,7 +40,7 @@ class DecisionTreeRegressionSpec extends FunSpec {
       // serialization
       val fileName = s"${TestUtil.baseDir}/decision_tree_regression_saved_model.json.zip"
       val uri = new URI(s"jar:file:$fileName")
-      for (file <- managed(BundleFile(uri))) {
+      Using(BundleFile(uri)) { file =>
         transformer.writeBundle.name("bundle")
           .format(SerializationFormat.Json)
           .save(file)
@@ -48,9 +48,9 @@ class DecisionTreeRegressionSpec extends FunSpec {
 
       // de-serialization
       val file = new File(fileName)
-      val loadedTransformer = (for (bf <- managed(BundleFile(file))) yield {
+      val loadedTransformer = Using(BundleFile(file)) { bf =>
         bf.loadMleapBundle().get.root
-      }).tried.get.asInstanceOf[DecisionTreeRegression]
+      }.get.asInstanceOf[DecisionTreeRegression]
 
       // checks
       assert(transformer.inputSchema.fields equals (loadedTransformer.inputSchema.fields))

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/GBTRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/GBTRegressionSpec.scala
@@ -5,12 +5,12 @@ import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.test.TestUtil
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.combust.mleap.tensor.Tensor
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 9/28/16.
   */
-class GBTRegressionSpec extends FunSpec {
+class GBTRegressionSpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(Seq(StructField("features", TensorType(BasicType.Double)))).get
   val dataset = Seq(Row(Tensor.denseVector(Array(0.2, 0.7, 0.4))))
   val frame = DefaultLeapFrame(schema, dataset)

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/GeneralizedLinearRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/GeneralizedLinearRegressionSpec.scala
@@ -3,9 +3,9 @@ package ml.combust.mleap.runtime.transformer.regression
 import ml.combust.mleap.core.regression.GeneralizedLinearRegressionModel
 import ml.combust.mleap.core.types._
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class GeneralizedLinearRegressionSpec extends FunSpec {
+class GeneralizedLinearRegressionSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs with prediction column only") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/IsotonicRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/IsotonicRegressionSpec.scala
@@ -2,9 +2,9 @@ package ml.combust.mleap.runtime.transformer.regression
 
 import ml.combust.mleap.core.regression.IsotonicRegressionModel
 import ml.combust.mleap.core.types._
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class IsotonicRegressionSpec extends FunSpec {
+class IsotonicRegressionSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs without feature index") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/LinearRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/LinearRegressionSpec.scala
@@ -5,12 +5,12 @@ import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.combust.mleap.tensor.Tensor
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Created by hollinwilkins on 9/15/16.
   */
-class LinearRegressionSpec extends FunSpec {
+class LinearRegressionSpec extends org.scalatest.funspec.AnyFunSpec {
   val schema = StructType(Seq(StructField("features", TensorType(BasicType.Double)))).get
   val dataset = Seq(Row(Tensor.denseVector(Array(20.0, 10.0, 5.0))))
   val frame = DefaultLeapFrame(schema, dataset)

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/RandomForestRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/regression/RandomForestRegressionSpec.scala
@@ -3,9 +3,9 @@ package ml.combust.mleap.runtime.transformer.regression
 import ml.combust.mleap.core.regression.RandomForestRegressionModel
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.test.TestUtil
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class RandomForestRegressionSpec extends FunSpec {
+class RandomForestRegressionSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
     it("has the correct inputs and outputs") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/sklearn/PolynomialFeaturesSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/sklearn/PolynomialFeaturesSpec.scala
@@ -4,9 +4,9 @@ import ml.combust.mleap.core.sklearn.PolynomialFeaturesModel
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 import ml.combust.mleap.tensor.Tensor
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class PolynomialFeaturesSpec extends FunSpec {
+class PolynomialFeaturesSpec extends org.scalatest.funspec.AnyFunSpec {
 
   val transformer = PolynomialFeatures(shape = NodeShape.feature(
     inputCol = "test_vec",

--- a/mleap-spark-base/src/main/scala/ml/combust/mleap/spark/SparkSupport.scala
+++ b/mleap-spark-base/src/main/scala/ml/combust/mleap/spark/SparkSupport.scala
@@ -12,7 +12,7 @@ import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.mleap.TypeConverters
 import org.apache.spark.sql.types.StructType
-import resource._
+import scala.util.Using
 
 import scala.util.Try
 
@@ -32,9 +32,9 @@ trait SparkSupport {
   implicit class URIBundleFileOps(uri: URI) {
     def loadMleapBundle()
                        (implicit context: SparkBundleContext): Try[Bundle[Transformer]] = {
-      (for (bf <- managed(BundleFile.load(uri))) yield {
+      Using(BundleFile.load(uri)) { bf =>
         bf.load[SparkBundleContext, Transformer]().get
-      }).tried
+      }
     }
   }
 

--- a/mleap-spark-base/src/main/scala/org/apache/spark/ml/bundle/BundleHelper.scala
+++ b/mleap-spark-base/src/main/scala/org/apache/spark/ml/bundle/BundleHelper.scala
@@ -19,9 +19,9 @@ object BundleHelper {
       |implicit val sbc = SparkBundleContext().withDataset(transformedDataset)
       |
       |// Serialize the pipeline as you would normally
-      |(for(bf <- managed(BundleFile(file))) yield {
+      |Using(BundleFile(file))) { bf =>
       |  sparkTransformer.writeBundle.save(bf).get
-      |}).tried.get
+      |}.get
       |*****************************************************************************************************
     """.stripMargin
   }

--- a/mleap-spark-base/src/main/scala/org/apache/spark/ml/bundle/SimpleSparkOp.scala
+++ b/mleap-spark-base/src/main/scala/org/apache/spark/ml/bundle/SimpleSparkOp.scala
@@ -44,7 +44,7 @@ abstract class SimpleSparkOp[N <: Transformer](implicit ct: ClassTag[N]) extends
           |
           |implicit val sbc = SparkBundleContext().withDataset(transformedDataset)
           |
-          |for(bf <- managed(BundleFile(file))) {
+          |Using(BundleFile(file)) { bf =>
           |  sparkTransformer.writeBundle.format(SerializationFormat.Json).save(bf).get
           |}
           |```

--- a/mleap-spark-base/src/test/scala/ml/combust/mleap/spark/SparkTransformBuilderSpec.scala
+++ b/mleap-spark-base/src/test/scala/ml/combust/mleap/spark/SparkTransformBuilderSpec.scala
@@ -8,7 +8,7 @@ import SparkSupport._
 import ml.combust.mleap.core.{Model, types}
 import ml.combust.mleap.core.types.{NodeShape, ScalarType, StructField}
 import ml.combust.mleap.runtime.frame.{FrameBuilder, Transformer}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 import scala.collection.JavaConverters._
 import scala.util.Try
@@ -36,7 +36,7 @@ case class MyTransformer() extends Transformer {
   }
 }
 
-class SparkTransformBuilderSpec extends FunSpec {
+class SparkTransformBuilderSpec extends org.scalatest.funspec.AnyFunSpec {
   describe("transformer with multiple outputs") {
     it("works with Spark as well") {
       val spark = SparkSession.builder().

--- a/mleap-spring-boot/src/main/scala/ml/combust/mleap/springboot/ModelLoader.scala
+++ b/mleap-spring-boot/src/main/scala/ml/combust/mleap/springboot/ModelLoader.scala
@@ -7,7 +7,7 @@ import ml.combust.mleap.pb
 import org.springframework.beans.factory.annotation.{Autowired, Value}
 import org.springframework.stereotype.Component
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import java.nio.file.{Files, Path, Paths}
 
 import ml.combust.mleap.executor.MleapExecutor

--- a/mleap-spring-boot/src/main/scala/ml/combust/mleap/springboot/StarterConfiguration.scala
+++ b/mleap-spring-boot/src/main/scala/ml/combust/mleap/springboot/StarterConfiguration.scala
@@ -37,7 +37,7 @@ class StarterConfiguration {
   def protobufHttpMessageConverter() = new ProtobufHttpMessageConverter
 
   @Bean
-  def jsonPrinter() = new Printer(includingDefaultValueFields = true, formattingLongAsNumber = true)
+  def jsonPrinter() = new Printer().includingDefaultValueFields.formattingLongAsNumber
 
   @Bean
   def jsonParser() = new Parser()

--- a/mleap-spring-boot/src/test/scala/ml/combust/mleap/springboot/JsonScoringSpec.scala
+++ b/mleap-spring-boot/src/test/scala/ml/combust/mleap/springboot/JsonScoringSpec.scala
@@ -19,8 +19,8 @@ import scalapb.json4s.{Parser, Printer}
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 class JsonScoringSpec extends ScoringBase[String, String, String, String, String] {
 
-  lazy val printer = new Printer(includingDefaultValueFields = true, formattingLongAsNumber = true)
-  lazy val parser = new Parser()
+  private lazy val printer = new Printer().includingDefaultValueFields.formattingLongAsNumber
+  private lazy val parser = new Parser()
 
   override def createLoadModelRequest(modelName: String, uri:URI, createTmpFile: Boolean): HttpEntity[String] = {
     val request = LoadModelRequest(modelName = modelName,
@@ -111,12 +111,12 @@ class JsonScoringSpec extends ScoringBase[String, String, String, String, String
 }
 
 object JsonScoringSpec {
-  lazy val httpEntityWithJsonHeaders = new HttpEntity[Unit](jsonHeaders)
-
-  lazy val jsonHeaders = {
+  val jsonHeaders: HttpHeaders = {
     val headers = new HttpHeaders
     headers.add("Content-Type", "application/json")
     headers.add("timeout", "2000")
     headers
   }
+
+  val httpEntityWithJsonHeaders = new HttpEntity[Unit](jsonHeaders)
 }

--- a/mleap-spring-boot/src/test/scala/ml/combust/mleap/springboot/ScoringBase.scala
+++ b/mleap-spring-boot/src/test/scala/ml/combust/mleap/springboot/ScoringBase.scala
@@ -3,11 +3,9 @@ package ml.combust.mleap.springboot
 import java.net.URI
 import java.util
 import java.util.UUID
-
 import ml.combust.mleap.pb.SelectMode.{SELECT_MODE_RELAXED, SELECT_MODE_STRICT}
 import ml.combust.mleap.pb.{Mleap, TransformOptions}
 import ml.combust.mleap.springboot.TestUtil._
-import org.scalatest.{FunSpec, Matchers}
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.http.{HttpEntity, HttpMethod, HttpStatus, ResponseEntity}
@@ -16,16 +14,22 @@ import org.springframework.http.converter.protobuf.ProtobufHttpMessageConverter
 import org.springframework.test.context.TestContextManager
 import ml.combust.mleap.runtime.frame.DefaultLeapFrame
 import ml.combust.mleap.runtime.serialization.FrameReader
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.reflect._
 
-abstract class ScoringBase[T, U, V, X, Y](implicit cu: ClassTag[U], cv: ClassTag[V], cy: ClassTag[Y]) extends FunSpec with Matchers {
+abstract class ScoringBase[T, U, V, X, Y](implicit cu: ClassTag[U], cv: ClassTag[V], cy: ClassTag[Y])
+  extends AnyFunSpec with Matchers {
 
   @Autowired
   var restTemplate: TestRestTemplate = _
-  new TestContextManager(this.getClass).prepareTestInstance(this)
-  restTemplate.getRestTemplate.setMessageConverters(util.Arrays.asList(new ProtobufHttpMessageConverter(),
-    new StringHttpMessageConverter(), new ByteArrayHttpMessageConverter()))
+  private val manager = new TestContextManager(this.getClass)
+  manager.prepareTestInstance(this)
+  restTemplate.getRestTemplate.setMessageConverters(
+    util.Arrays.asList(new ProtobufHttpMessageConverter(),
+      new StringHttpMessageConverter(),
+      new ByteArrayHttpMessageConverter()))
 
   def createLoadModelRequest(modelName: String, uri:URI, createTmpFile: Boolean): HttpEntity[T]
 

--- a/mleap-tensor/src/test/scala/ml/combust/mleap/tensor/TensorSpec.scala
+++ b/mleap-tensor/src/test/scala/ml/combust/mleap/tensor/TensorSpec.scala
@@ -1,8 +1,6 @@
 package ml.combust.mleap.tensor
 
-import org.scalatest.FunSpec
-
-class TensorSpec extends FunSpec {
+class TensorSpec extends org.scalatest.funspec.AnyFunSpec {
   def toIndices(dimensions: Seq[Int]): Seq[Seq[Int]] = combine(dimensions.map(d => 0 until d))
 
   def combine[A](xs: Traversable[Traversable[A]]): Seq[Seq[A]] =

--- a/mleap-tensorflow/src/main/scala/ml/combust/mleap/tensorflow/TensorflowModel.scala
+++ b/mleap-tensorflow/src/main/scala/ml/combust/mleap/tensorflow/TensorflowModel.scala
@@ -1,8 +1,8 @@
 package ml.combust.mleap.tensorflow
 
-import ml.combust.bundle.serializer.FileUtil
+import ml.combust.bundle.util.FileUtil
 import ml.combust.mleap.core.Model
-import ml.combust.mleap.core.types.{DataType, StructField, StructType, TensorType}
+import ml.combust.mleap.core.types.{StructField, StructType, TensorType}
 import ml.combust.mleap.tensor.Tensor
 import ml.combust.mleap.tensorflow.converter.{MleapConverter, TensorflowConverter}
 import org.tensorflow
@@ -11,7 +11,7 @@ import org.tensorflow.proto.framework.GraphDef
 import java.io.ByteArrayInputStream
 import java.nio.file.Files
 import java.util.zip.ZipInputStream
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.util.Try
 
@@ -95,9 +95,9 @@ case class TensorflowModel( @transient var graph: Option[tensorflow.Graph] = Non
     val savedModelStream = new ZipInputStream(
       new ByteArrayInputStream(modelBytes)
     )
-    FileUtil().extract(savedModelStream, dest.toFile)
+    FileUtil.extract(savedModelStream, dest)
     val modelBundle = tensorflow.SavedModelBundle.load(dest.toString)
-    FileUtil().rmRF(dest.toFile)
+    FileUtil.rmRF(dest)
     (modelBundle.session, modelBundle.graph)
   }
 

--- a/mleap-tensorflow/src/test/scala/ml/combust/mleap/tensorflow/TensorflowModelSpec.scala
+++ b/mleap-tensorflow/src/test/scala/ml/combust/mleap/tensorflow/TensorflowModelSpec.scala
@@ -1,10 +1,10 @@
 package ml.combust.mleap.tensorflow
 
-import ml.combust.bundle.serializer.FileUtil
+import ml.combust.bundle.util.FileUtil
 import ml.combust.mleap.core.types.TensorType
 import ml.combust.mleap.tensor.{DenseTensor, Tensor}
 import ml.combust.mleap.tensorflow.converter.MleapConverter
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 import org.tensorflow.{SavedModelBundle, Signature}
 import org.tensorflow.ndarray.Shape
 import org.tensorflow.types.TFloat32
@@ -17,7 +17,7 @@ import scala.collection.JavaConverters._
 /**
   * Created by hollinwilkins on 1/12/17.
   */
-class TensorflowModelSpec extends FunSpec {
+class TensorflowModelSpec extends AnyFunSpec {
 
   describe("with an adding tensorflow model") {
     it("adds two floats together") {
@@ -88,8 +88,13 @@ class TensorflowModelSpec extends FunSpec {
         val format = Some("saved_model")
         val byteStream = new ByteArrayOutputStream()
         val zf = new ZipOutputStream(byteStream)
-        try FileUtil().zip(testFolder.toFile, zf) finally if (zf != null) zf.close()
-        FileUtil().rmRF(testFolder.toFile)
+        try {
+          FileUtil.zip(testFolder, zf)
+        } finally {
+          if (zf != null)
+            zf.close()
+        }
+        FileUtil.rmRF(testFolder)
         val model = TensorflowModel(
           inputs = inputs,
           outputs = outputs,

--- a/mleap-tensorflow/src/test/scala/ml/combust/mleap/tensorflow/converter/MleapConverterSpec.scala
+++ b/mleap-tensorflow/src/test/scala/ml/combust/mleap/tensorflow/converter/MleapConverterSpec.scala
@@ -2,11 +2,11 @@ package ml.combust.mleap.tensorflow.converter
 
 import ml.combust.mleap.core.types.TensorType
 import ml.combust.mleap.tensor.{ByteString, Tensor}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 import org.tensorflow.types._
 import org.tensorflow.ndarray.Shape
 
-class MleapConverterSpec extends FunSpec {
+class MleapConverterSpec extends org.scalatest.funspec.AnyFunSpec {
   val random = new scala.util.Random
   val shape = Seq(3, 3, 3, 3, 3, 3, 3)
   val size = shape.product

--- a/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/bundle/ops/XGBoostRegressionOp.scala
+++ b/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/bundle/ops/XGBoostRegressionOp.scala
@@ -10,7 +10,7 @@ import ml.combust.mleap.bundle.ops.MleapOp
 import ml.combust.mleap.runtime.MleapContext
 import ml.combust.mleap.xgboost.runtime.{XGBoostRegression, XGBoostRegressionModel}
 import ml.dmlc.xgboost4j.scala.XGBoost
-import resource._
+import scala.util.Using
 
 /**
   * Created by hollinwilkins on 9/16/17.

--- a/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/XGBoostClassificationModelParitySpec.scala
+++ b/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/XGBoostClassificationModelParitySpec.scala
@@ -6,11 +6,11 @@ import ml.combust.mleap.tensor.{SparseTensor, Tensor}
 import ml.combust.mleap.xgboost.runtime.testing.{BoosterUtils, BundleSerializationUtils, CachedDatasetUtils, ClassifierUtils, FloatingPointApproximations}
 import ml.dmlc.xgboost4j.scala.Booster
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 import XgbConverters._
 
 
-class XGBoostClassificationModelParitySpec extends FunSpec
+class XGBoostClassificationModelParitySpec extends org.scalatest.funspec.AnyFunSpec
   with BoosterUtils
   with CachedDatasetUtils
   with BundleSerializationUtils

--- a/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/XGBoostPredictorClassificationModelParitySpec.scala
+++ b/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/XGBoostPredictorClassificationModelParitySpec.scala
@@ -7,11 +7,11 @@ import ml.combust.mleap.tensor.SparseTensor
 import ml.combust.mleap.xgboost.runtime.testing.{BoosterUtils, BundleSerializationUtils, CachedDatasetUtils, ClassifierUtils, FloatingPointApproximations}
 import ml.dmlc.xgboost4j.scala.Booster
 import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 import XgbConverters._
 
 
-class XGBoostPredictorClassificationModelParitySpec extends FunSpec
+class XGBoostPredictorClassificationModelParitySpec extends org.scalatest.funspec.AnyFunSpec
   with BoosterUtils
   with CachedDatasetUtils
   with BundleSerializationUtils

--- a/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/XGBoostPredictorRegressionModelParitySpec.scala
+++ b/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/XGBoostPredictorRegressionModelParitySpec.scala
@@ -4,11 +4,11 @@ import biz.k11i.xgboost.Predictor
 import ml.combust.mleap.core.types._
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Transformer}
 import ml.combust.mleap.xgboost.runtime.testing.{BoosterUtils, BundleSerializationUtils, CachedDatasetUtils, ClassifierUtils, FloatingPointApproximations, RegressionUtils}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 import XgbConverters._
 
 
-class XGBoostPredictorRegressionModelParitySpec extends FunSpec
+class XGBoostPredictorRegressionModelParitySpec extends org.scalatest.funspec.AnyFunSpec
   with BoosterUtils
   with CachedDatasetUtils
   with BundleSerializationUtils

--- a/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/XGBoostRegressionModelParitySpec.scala
+++ b/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/XGBoostRegressionModelParitySpec.scala
@@ -5,11 +5,11 @@ import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Transformer}
 import ml.combust.mleap.tensor.Tensor
 import ml.combust.mleap.xgboost.runtime.testing.{BoosterUtils, BundleSerializationUtils, CachedDatasetUtils, FloatingPointApproximations, RegressionUtils}
 import ml.dmlc.xgboost4j.scala.Booster
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 import XgbConverters._
 
 
-class XGBoostRegressionModelParitySpec extends FunSpec
+class XGBoostRegressionModelParitySpec extends org.scalatest.funspec.AnyFunSpec
   with BoosterUtils
   with CachedDatasetUtils
   with BundleSerializationUtils

--- a/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/testing/BundleSerializationUtils.scala
+++ b/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/testing/BundleSerializationUtils.scala
@@ -8,7 +8,7 @@ import ml.combust.bundle.serializer.SerializationFormat
 import ml.combust.mleap.runtime.{MleapContext, frame}
 import ml.combust.mleap.runtime.frame.Transformer
 import ml.combust.mleap.xgboost.runtime.bundle.ops.{XGBoostClassificationOp, XGBoostPredictorClassificationOp, XGBoostPredictorRegressionOp, XGBoostRegressionOp}
-import resource.managed
+import scala.util.Using
 
 
 trait BundleSerializationUtils {
@@ -24,7 +24,7 @@ trait BundleSerializationUtils {
 
     val file = new File(s"${tempDirPath}/${this.getClass.getName}.zip")
 
-    for(bf <- managed(BundleFile(file))) {
+    Using(BundleFile(file)) { bf =>
       transformer.writeBundle.format(SerializationFormat.Json).save(bf).get
     }
     file
@@ -35,9 +35,9 @@ trait BundleSerializationUtils {
 
     import ml.combust.mleap.runtime.MleapSupport._
 
-    (for(bf <- managed(BundleFile(bundleFile))) yield {
-      bf.loadMleapBundle().get.root
-    }).tried.get
+    Using(BundleFile(bundleFile)) { bf =>
+      bf.loadMleapBundle()
+    }.flatten.get.root
   }
 
   def loadXGBoostPredictorFromBundle(bundleFile: File)

--- a/mleap-xgboost-spark/build.sbt
+++ b/mleap-xgboost-spark/build.sbt
@@ -3,6 +3,6 @@ import ml.combust.mleap.{Dependencies, Common}
 Common.defaultMleapSettings
 Dependencies.xgboostSpark
 
-javaOptions in Test ++= sys.env.get("XGBOOST_JNI").map {
+Test / javaOptions ++= sys.env.get("XGBOOST_JNI").map {
   jniPath => Seq(s"-Djava.library.path=$jniPath")
 }.getOrElse(Seq())

--- a/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
+++ b/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
@@ -9,7 +9,7 @@ import ml.dmlc.xgboost4j.scala.spark.XGBoostClassificationModel
 import ml.dmlc.xgboost4j.scala.{XGBoost => SXGBoost}
 import org.apache.spark.ml.bundle._
 import org.apache.spark.ml.linalg.Vector
-import resource._
+import scala.util.Using
 
 /**
   * Created by hollinwilkins on 9/16/17.
@@ -46,9 +46,9 @@ class XGBoostClassificationModelOp extends SimpleSparkOp[XGBoostClassificationMo
 
     override def load(model: Model)
                      (implicit context: BundleContext[SparkBundleContext]): XGBoostClassificationModel = {
-      val booster = (for(in <- managed(Files.newInputStream(context.file("xgboost.model")))) yield {
+      val booster = Using(Files.newInputStream(context.file("xgboost.model"))) { in =>
         SXGBoost.loadModel(in)
-      }).tried.get
+      }.get
 
       val xgb = new XGBoostClassificationModel("", model.value("num_classes").getInt, booster)
 

--- a/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelOp.scala
+++ b/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelOp.scala
@@ -9,7 +9,7 @@ import ml.dmlc.xgboost4j.scala.spark.XGBoostRegressionModel
 import ml.dmlc.xgboost4j.scala.{XGBoost => SXGBoost}
 import org.apache.spark.ml.bundle._
 import org.apache.spark.ml.linalg.Vector
-import resource.managed
+import scala.util.Using
 
 /**
   * Created by hollinwilkins on 9/16/17.
@@ -39,9 +39,9 @@ class XGBoostRegressionModelOp extends SimpleSparkOp[XGBoostRegressionModel] {
 
     override def load(model: Model)
                      (implicit context: BundleContext[SparkBundleContext]): XGBoostRegressionModel = {
-      val booster = (for(in <- managed(Files.newInputStream(context.file("xgboost.model")))) yield {
+      val booster = Using(Files.newInputStream(context.file("xgboost.model"))) { in =>
         SXGBoost.loadModel(in)
-      }).tried.get
+      }.get
 
       val xgb = new XGBoostRegressionModel("", booster)
 

--- a/project/BuildInfo.scala
+++ b/project/BuildInfo.scala
@@ -1,6 +1,6 @@
 package ml.combust.mleap
 
-import com.typesafe.sbt.GitPlugin.autoImport._
+import com.github.sbt.git.GitPlugin.autoImport._
 import sbt.Keys._
 import sbtbuildinfo.BuildInfoPlugin.autoImport._
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -13,22 +13,21 @@ object Common {
   lazy val defaultMleapXgboostSparkSettings = defaultMleapSettings ++ sonatypeSettings
   lazy val defaultMleapServingSettings = defaultMleapSettings ++ noPublishSettings
 
+
   lazy val defaultSettings = buildSettings ++ sonatypeSettings
 
   lazy val buildSettings: Seq[Def.Setting[_]] = Seq(
-    scalaVersion := "2.12.13",
+    scalaVersion := "2.12.18",
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
-    fork in Test := true,
-    javaOptions in test += sys.env.getOrElse("JVM_OPTS", ""),
+    ThisBuild / libraryDependencySchemes +=
+      "org.scala-lang.modules" %% "scala-collection-compat" % VersionScheme.Always,
     resolvers += Resolver.mavenLocal,
     resolvers += Resolver.jcenterRepo,
     resolvers ++= {
       // Only add Sonatype Snapshots if this version itself is a snapshot version
-      if(isSnapshot.value) {
-        Seq(
-          "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
-          "ASF Snapshots" at "https://repository.apache.org/content/groups/snapshots"
-        )
+      if (isSnapshot.value) {
+        Resolver.sonatypeOssRepos("snapshots") :+
+          ("ASF Snapshots" at "https://repository.apache.org/content/groups/snapshots")
       } else {
         Seq()
       }
@@ -39,7 +38,7 @@ object Common {
   lazy val bundleSettings: Seq[Def.Setting[_]] = Seq(organization := "ml.combust.bundle")
 
   lazy val noPublishSettings: Seq[Def.Setting[_]] = Seq(
-    publishTo in publishSigned := None,
+    publishSigned / publishTo := None,
     publishTo := None
   )
 
@@ -49,12 +48,12 @@ object Common {
     publishMavenStyle := true,
     publishTo := Some({
       if (isSnapshot.value) {
-        Opts.resolver.sonatypeSnapshots
+        Opts.resolver.sonatypeOssSnapshots.head
       } else {
         Opts.resolver.sonatypeStaging
       }
     }),
-    publishArtifact in Test := false,
+    Test / publishArtifact := false,
     pomIncludeRepository := { _ => false },
     licenses := Seq("Apache 2.0 License" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
     homepage := Some(url("https://github.com/combust/mleap")),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,23 +7,26 @@ object Dependencies {
   import DependencyHelpers._
 
   val sparkVersion = "3.4.0"
-  val scalaTestVersion = "3.0.8"
-  val junitVersion = "5.8.2"
-  val akkaVersion = "2.6.14" // Stay below akka v2.7.0 since they swapped to a BSL license
-  val akkaHttpVersion = "10.2.4" // Stay below akka-http v10.3.0 since they swapped to a BSL license
-  val springBootVersion = "2.6.2"
+  val scalaTestVersion = "3.2.16"
+  val scalaPbJson4sVersion = "0.11.1"
+  val junitVersion = "5.9.2"
+  val akkaVersion = "2.6.21" // Stay below akka v2.7.0 since they swapped to a BSL license
+  val akkaHttpVersion = "10.2.10" // Stay below akka-http v10.3.0 since they swapped to a BSL license
+  val springBootVersion = "2.7.0"
   lazy val logbackVersion = "1.2.3"
-  lazy val loggingVersion = "3.9.0"
+  lazy val loggingVersion = "3.9.5"
   lazy val slf4jVersion = "2.0.6"
-  lazy val awsSdkVersion = "1.11.1033"
+  lazy val awsSdkVersion = "1.12.470"
+  lazy val scalaCollectionCompat = "2.8.1"
   val tensorflowJavaVersion = "0.5.0" // Match Tensorflow 2.10.1 https://github.com/tensorflow/java/#tensorflow-version-support
-  val xgboostVersion = "1.7.3"
+  val xgboostVersion = "1.7.6"
   val breezeVersion = "2.1.0"
   val hadoopVersion = "3.3.4" // matches spark version
   val platforms = "windows-x86_64,linux-x86_64,macosx-x86_64"
   val tensorflowPlatforms : Array[String] =  sys.env.getOrElse("TENSORFLOW_PLATFORMS", platforms).split(",")
 
   object Compile {
+    val `scala-collection-compat` = "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompat
     val sparkMllibLocal = "org.apache.spark" %% "spark-mllib-local" % sparkVersion excludeAll(ExclusionRule(organization = "org.scalatest"))
     val spark = Seq("org.apache.spark" %% "spark-core" % sparkVersion,
       "org.apache.spark" %% "spark-sql" % sparkVersion,
@@ -33,13 +36,11 @@ object Dependencies {
       "org.apache.spark" %% "spark-avro" % sparkVersion
     )
     val avroDep = "org.apache.avro" % "avro" % "1.11.1"
-    val sprayJson = "io.spray" %% "spray-json" % "1.3.2"
-    val arm = "com.jsuereth" %% "scala-arm" % "2.0"
-    val config = "com.typesafe" % "config" % "1.3.0"
+    val sprayJson = "io.spray" %% "spray-json" % "1.3.6"
+    val config = "com.typesafe" % "config" % "1.4.2"
     val scalaReflect = ScalaVersionDependentModuleID.versioned("org.scala-lang" % "scala-reflect" % _)
     val scalaTest = "org.scalatest" %% "scalatest" % scalaTestVersion
     val jTransform = "com.github.rwl" % "jtransforms" % "2.4.0" exclude("junit", "junit")
-    val commonsIo = "commons-io" % "commons-io" % "2.5"
     var tensorflowCoreApi = "org.tensorflow" % "tensorflow-core-api" % tensorflowJavaVersion
     (Seq("") ++ tensorflowPlatforms).foreach(platform => tensorflowCoreApi = tensorflowCoreApi classifier platform)
     val tensorflowDeps = Seq(tensorflowCoreApi)
@@ -49,24 +50,31 @@ object Dependencies {
     val akkaStream = "com.typesafe.akka" %% "akka-stream" % akkaVersion
     val akkaHttp = "com.typesafe.akka" %% "akka-http" % akkaHttpVersion
     val akkaHttpSprayJson = "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion
-    val scalameter = "com.storm-enroute" %% "scalameter" % "0.8.2"
-    val scopt = "com.github.scopt" %% "scopt" % "3.5.0"
+    // Scalameter 0.19 is the last version published for 2.12
+    val scalameter: Seq[ModuleID] = Seq("scalameter", "scalameter-core").map(
+      "com.storm-enroute" %% _ % "0.19" excludeAll(
+        ExclusionRule("com.storm-enroute"),
+        ExclusionRule("org.scala-lang.modules"),
+      ))
+    val scopt = "com.github.scopt" %% "scopt" % "4.1.0"
 
     val springBoot = "org.springframework.boot" % "spring-boot-starter-web" % springBootVersion
     val springBootActuator = "org.springframework.boot" % "spring-boot-starter-actuator" % springBootVersion
 
-    val commonsLang = "org.apache.commons" % "commons-lang3" % "3.7"
+    val commonsLang = "org.apache.commons" % "commons-lang3" % "3.12.0"
     val scalaPb = Seq(
       "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf",
       "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion,
-      "com.thesamet.scalapb" %% "scalapb-json4s" % scalapb.compiler.Version.scalapbVersion
+      "com.thesamet.scalapb" %% "scalapb-json4s" % scalaPbJson4sVersion
     )
 
     val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion
 
+    val `logback-core-dep` = "ch.qos.logback" % "logback-core"
+    val `logback-classic-dep` = "ch.qos.logback" % "logback-classic"
     lazy val logging = Seq(
-      "ch.qos.logback" % "logback-core" % logbackVersion,
-      "ch.qos.logback" % "logback-classic" % logbackVersion,
+      `logback-core-dep` % logbackVersion,
+      `logback-classic-dep` % logbackVersion,
       "com.typesafe.scala-logging" %% "scala-logging" % loggingVersion
     )
 
@@ -79,10 +87,11 @@ object Dependencies {
     val hadoop = "org.apache.hadoop" % "hadoop-client" % hadoopVersion
 
     val slf4jDep = "org.slf4j" % "slf4j-log4j12" % slf4jVersion
+    val scalapbCompilerPlugin =  "com.thesamet.scalapb" %% "compilerplugin" % "0.11.13"
   }
 
   object Test {
-    val scalaTest = "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
+    val scalaTest = Compile.scalaTest % "test"
     val akkaHttpTestkit =  "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % "test"
     val akkaTestKit = "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test"
     val springBootTest = "org.springframework.boot" % "spring-boot-starter-test" % springBootVersion % "test"
@@ -103,17 +112,17 @@ object Dependencies {
 
   val tensor = l ++= Seq(sprayJson, Test.scalaTest)
 
-  val bundleMl = l ++= Seq(arm, config, sprayJson, Test.scalaTest)
+  val bundleMl = l ++= Seq(config, `scala-collection-compat`, sprayJson, Test.scalaTest)
 
   val bundleHdfs = l ++= Seq(Provided.hadoop, Test.scalaTest)
 
-  val base = l ++= Seq()
+  val base = l ++= Seq(`scala-collection-compat`)
 
   val core = l ++= Seq(sparkMllibLocal, jTransform, breeze, Test.scalaTest) ++ Test.sparkTest
 
-  def runtime(scalaVersion: SettingKey[String]) = l ++= (Seq(Test.scalaTest, Test.junit, commonsIo) ++ scalaReflect.modules(scalaVersion.value))
+  def runtime(scalaVersion: SettingKey[String]) = l ++= (Seq(Test.scalaTest, Test.junit) ++ scalaReflect.modules(scalaVersion.value))
 
-  val sparkBase = l ++= Provided.spark ++ Seq(Test.scalaTest)
+  val sparkBase = l ++= Provided.spark ++ Seq(scalaTest) ++ Provided.sparkTestLib
 
   val sparkTestkit = l ++= Provided.spark ++ Provided.sparkTestLib ++ Seq(scalaTest)
 
@@ -142,9 +151,11 @@ object Dependencies {
   val grpc = l ++= Seq(
     "io.grpc" % "grpc-netty" % scalapb.compiler.Version.grpcJavaVersion) ++ scalaPb
 
-  val springBootServing = l ++= Seq(springBoot, springBootActuator, commonsLang, Test.scalaTest, Test.springBootTest) ++ scalaPb
+  val springBootServing = l ++= Seq(springBoot, springBootActuator, commonsLang,
+    `logback-classic-dep` % "1.2.3", // remove once we can support JDK 17 and spring boot 3.1.0
+    Test.scalaTest, Test.springBootTest) ++ scalaPb
 
-  val benchmark = l ++= Seq(scalameter, scopt) ++ Compile.spark
+  val benchmark = l ++= Seq(scopt) ++ scalameter ++ Compile.spark
 
   val databricksRuntimeTestkit = l ++= Provided.spark
 

--- a/project/DockerConfig.scala
+++ b/project/DockerConfig.scala
@@ -3,9 +3,10 @@ import com.typesafe.sbt.packager.docker.ExecCmd
 import com.typesafe.sbt.packager.linux.LinuxPlugin.autoImport._
 
 object DockerConfig {
-  val baseSettings = Seq(daemonUser in Docker := "root",
+  val baseSettings = Seq(Docker / daemonUser  := "root",
     dockerExposedPorts := Seq(65327, 65328),
-    dockerBaseImage := "openjdk:8-jre-slim",
+    // https://github.com/docker-library/openjdk/issues/505
+    dockerBaseImage := "eclipse-temurin:11-jre-jammy",
     dockerRepository := Some("combustml"),
     dockerBuildOptions := Seq("-t", dockerAlias.value.toString),
     dockerCommands := dockerCommands.value.filterNot {

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -19,7 +19,7 @@ object Release {
       tagRelease,
       publishArtifacts,
       releaseStepCommand("sonatypeRelease"),
-      releaseStepTask(publish in autoImport.Docker in MleapProject.serving),
+      releaseStepTask(MleapProject.serving / autoImport.Docker / publish ),
       setNextVersion,
       commitNextVersion,
       pushChanges

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.9
+sbt.version=1.9.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,16 +1,17 @@
 logLevel := Level.Warn
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.13")
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.1.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
+addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1")
 
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.1"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.13"
 
 addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.21.0")
+
+addDependencyTreePlugin

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.23.0"
+ThisBuild / version := "0.23.0"


### PR DESCRIPTION
1. Using sbt 1.9
2. Using most recent versions of the scala libraries where possible
3. Replaced scala-arm with more idiomatic scala 2.13+ way (scala-arm was not updated for a long time)
4. Updated scalatest.
5. Updated ClassloaderUtils to use java 9 compatible code.
6. Using java 9 code instead of the commons-io.