### PR TITLE
Scala 2.13: Second take

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ services:
 
 language: scala
 scala:
-  - 2.12.18
+  - 2.13.15
 jdk:
   - openjdk11
 

--- a/bundle-hdfs/src/main/scala/ml/bundle/hdfs/HadoopBundleFileSystem.scala
+++ b/bundle-hdfs/src/main/scala/ml/bundle/hdfs/HadoopBundleFileSystem.scala
@@ -30,7 +30,7 @@ object HadoopBundleFileSystem {
   }
 
   def createSchemes(config: Config): Seq[String] = if (config.hasPath("schemes")) {
-    config.getStringList("schemes").asScala
+    config.getStringList("schemes").asScala.toSeq
   } else { Seq("hdfs") }
 }
 

--- a/bundle-hdfs/src/main/scala/ml/bundle/hdfs/HadoopBundleFileSystem.scala
+++ b/bundle-hdfs/src/main/scala/ml/bundle/hdfs/HadoopBundleFileSystem.scala
@@ -10,7 +10,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 
 import scala.util.Try
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object HadoopBundleFileSystem {
   lazy val defaultSchemes: Seq[String] = Seq("hdfs")

--- a/bundle-ml/src/main/scala/ml/combust/bundle/json/JsonSupport.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/json/JsonSupport.scala
@@ -133,7 +133,7 @@ trait JsonSupport {
       obj.ds.foreach(ds => fb += ("data_shape" -> ds.toJson))
       obj.m.foreach(m => fb += ("model" -> m.toJson))
 
-      JsObject(fb.result(): _*)
+      JsObject(fb.result().toSeq: _*)
     }
 
     override def read(json: JsValue): Scalar = json match {
@@ -220,7 +220,7 @@ trait JsonSupport {
       if(obj.ds.nonEmpty) { fb += ("data_shape" -> obj.ds.toJson) }
       if(obj.m.nonEmpty) { fb += ("model" -> obj.m.toJson) }
 
-      JsObject(fb.result(): _*)
+      JsObject(fb.result().toSeq: _*)
     }
 
     override def read(json: JsValue): List = json match {

--- a/bundle-ml/src/main/scala/ml/combust/bundle/serializer/ModelSerializer.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/serializer/ModelSerializer.scala
@@ -43,7 +43,7 @@ object FormatModelSerializer {
 
 /** Object for serializing/deserializing model definitions with JSON.
   */
-case class JsonFormatModelSerializer(implicit hr: HasBundleRegistry) extends FormatModelSerializer {
+case class JsonFormatModelSerializer()(implicit hr: HasBundleRegistry) extends FormatModelSerializer {
   override def write(path: Path, model: Model): Unit = {
     Files.write(path, model.asBundle.toJson.prettyPrint.getBytes("UTF-8"))
   }
@@ -55,7 +55,7 @@ case class JsonFormatModelSerializer(implicit hr: HasBundleRegistry) extends For
 
 /** Object for serializing/deserializing model definitions with Protobuf.
   */
-case class ProtoFormatModelSerializer(implicit hr: HasBundleRegistry) extends FormatModelSerializer {
+case class ProtoFormatModelSerializer()(implicit hr: HasBundleRegistry) extends FormatModelSerializer {
   override def write(path: Path, model: Model): Unit = {
     Files.write(path, model.asBundle.toByteArray)
   }

--- a/bundle-ml/src/main/scala/ml/combust/bundle/util/FileUtil.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/util/FileUtil.scala
@@ -6,7 +6,7 @@ import java.nio.file.{FileVisitResult, Files, FileSystems, Path, SimpleFileVisit
 import java.util.Comparator
 import java.util.stream.Collectors
 import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
-import scala.jdk.CollectionConverters.iterableAsScalaIterableConverter
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try, Using}
 /**
   * Created by hollinwilkins on 12/24/16.
@@ -46,7 +46,7 @@ object FileUtil {
             .sorted(Comparator.reverseOrder())
             .collect(Collectors.toList())
             .asScala
-            .map(removeElement)
+            .map(removeElement(_))
             .toArray
       }.getOrElse(Array.empty)
     } else {

--- a/mleap-avro/src/main/scala/ml/combust/mleap/avro/DefaultFrameReader.scala
+++ b/mleap-avro/src/main/scala/ml/combust/mleap/avro/DefaultFrameReader.scala
@@ -29,11 +29,11 @@ class DefaultFrameReader extends FrameReader {
     var rows = mutable.Seq[Row]()
     while(Try(reader.hasNext).getOrElse(false)) {
       record = reader.next(record)
-      val row = ArrayRow(new Array[Any](schema.fields.length))
+      val row = ArrayRow((new Array[Any](schema.fields.length)).toSeq)
       for(i <- schema.fields.indices) { row.set(i, readers(i)(record.get(i))) }
       rows :+= row
     }
 
-    DefaultLeapFrame(schema, rows)
+    DefaultLeapFrame(schema, rows.toSeq)
   }
 }

--- a/mleap-avro/src/main/scala/ml/combust/mleap/avro/DefaultRowReader.scala
+++ b/mleap-avro/src/main/scala/ml/combust/mleap/avro/DefaultRowReader.scala
@@ -26,7 +26,7 @@ class DefaultRowReader(override val schema: StructType) extends RowReader {
   override def fromBytes(bytes: Array[Byte], charset: Charset = BuiltinFormats.charset): Try[Row] = Try {
     decoder = DecoderFactory.get().binaryDecoder(bytes, decoder)
     record = datumReader.read(record, decoder)
-    val row = ArrayRow(new Array[Any](schema.fields.length))
+    val row = ArrayRow((new Array[Any](schema.fields.length)).toSeq)
     for(i <- schema.fields.indices) { row.set(i, readers(i)(record.get(i))) }
     row
   }

--- a/mleap-avro/src/main/scala/ml/combust/mleap/avro/SchemaConverter.scala
+++ b/mleap-avro/src/main/scala/ml/combust/mleap/avro/SchemaConverter.scala
@@ -121,7 +121,7 @@ object SchemaConverter {
                           (implicit context: MleapContext): StructType = schema.getType match {
     case Schema.Type.RECORD =>
       val fields = schema.getFields.asScala.map(avroToMleapField)
-      StructType(fields).get
+      StructType(fields.toSeq).get
     case _ => throw new IllegalArgumentException("invalid avro record type")
   }
 

--- a/mleap-avro/src/main/scala/ml/combust/mleap/avro/SchemaConverter.scala
+++ b/mleap-avro/src/main/scala/ml/combust/mleap/avro/SchemaConverter.scala
@@ -9,7 +9,7 @@ import ml.combust.mleap.tensor.{ByteString, Tensor}
 import org.apache.avro.Schema
 
 import scala.language.implicitConversions
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.reflect.{ClassTag, classTag}
 import scala.util.Try
 

--- a/mleap-avro/src/main/scala/ml/combust/mleap/avro/ValueConverter.scala
+++ b/mleap-avro/src/main/scala/ml/combust/mleap/avro/ValueConverter.scala
@@ -100,21 +100,21 @@ case class ValueConverter() {
 
         tt.base match {
           case BasicType.Boolean =>
-            Tensor.create(values.asInstanceOf[java.util.List[Boolean]].asScala.toArray, dimensions, indices)
+            Tensor.create(values.asInstanceOf[java.util.List[Boolean]].asScala.toArray, dimensions.toSeq, indices.map(_.toSeq.map(_.toSeq)))
           case BasicType.Byte =>
-            Tensor.create(values.asInstanceOf[ByteBuffer].array(), dimensions, indices)
+            Tensor.create(values.asInstanceOf[ByteBuffer].array(), dimensions.toSeq, indices.map(_.toSeq.map(_.toSeq)))
           case BasicType.Short =>
-            Tensor.create(values.asInstanceOf[java.util.List[Int]].asScala.map(_.toShort).toArray, dimensions, indices)
+            Tensor.create(values.asInstanceOf[java.util.List[Int]].asScala.map(_.toShort).toArray, dimensions.toSeq, indices.map(_.toSeq.map(_.toSeq)))
           case BasicType.Int =>
-            Tensor.create(values.asInstanceOf[java.util.List[Int]].asScala.toArray, dimensions, indices)
+            Tensor.create(values.asInstanceOf[java.util.List[Int]].asScala.toArray, dimensions.toSeq, indices.map(_.toSeq.map(_.toSeq)))
           case BasicType.Long =>
-            Tensor.create(values.asInstanceOf[java.util.List[Long]].asScala.toArray, dimensions, indices)
+            Tensor.create(values.asInstanceOf[java.util.List[Long]].asScala.toArray, dimensions.toSeq, indices.map(_.toSeq.map(_.toSeq)))
           case BasicType.Float =>
-            Tensor.create(values.asInstanceOf[java.util.List[Float]].asScala.toArray, dimensions, indices)
+            Tensor.create(values.asInstanceOf[java.util.List[Float]].asScala.toArray, dimensions.toSeq, indices.map(_.toSeq.map(_.toSeq)))
           case BasicType.Double =>
-            Tensor.create(values.asInstanceOf[java.util.List[Double]].asScala.toArray, dimensions, indices)
+            Tensor.create(values.asInstanceOf[java.util.List[Double]].asScala.toArray, dimensions.toSeq, indices.map(_.toSeq.map(_.toSeq)))
           case BasicType.String =>
-            Tensor.create(values.asInstanceOf[java.util.List[String]].asScala.toArray, dimensions, indices)
+            Tensor.create(values.asInstanceOf[java.util.List[String]].asScala.toArray, dimensions.toSeq, indices.map(_.toSeq.map(_.toSeq)))
           case tpe => throw new IllegalArgumentException(s"invalid base type for tensor $tpe")
         }
       }

--- a/mleap-benchmark/src/main/scala/ml/combust/mleap/benchmark/SparkTransformBenchmark.scala
+++ b/mleap-benchmark/src/main/scala/ml/combust/mleap/benchmark/SparkTransformBenchmark.scala
@@ -9,7 +9,7 @@ import org.scalameter._
 import org.scalameter.Key._
 
 import java.nio.file.Path
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Using
 
 /**

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/FeatureHasherModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/FeatureHasherModel.scala
@@ -10,7 +10,7 @@ import org.apache.spark.ml.linalg.{Vector, Vectors}
 import scala.collection.mutable
 
 object FeatureHasherModel {
-  val seed = HashingTermFrequencyModel.seed
+  val seed: Int = HashingTermFrequencyModel.seed
 
   def murmur3(term: Any): Int = {
     term match {

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/FeatureHasherModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/FeatureHasherModel.scala
@@ -49,23 +49,23 @@ case class FeatureHasherModel(numFeatures: Int = 1 << 18,
                               inputNames: Seq[String],
                               inputTypes: Seq[DataType]
                              ) extends Model  {
-  assert(inputTypes.forall(dt ⇒ dt.shape.isScalar), "must provide scalar shapes as inputs")
+  assert(inputTypes.forall(dt => dt.shape.isScalar), "must provide scalar shapes as inputs")
 
-  val schema = inputNames.zip(inputTypes)
-  val realFields = schema.filter(t ⇒ t._2.base match {
-    case BasicType.Short if !categoricalCols.contains(t._1) ⇒ true
-    case BasicType.Double if !categoricalCols.contains(t._1) ⇒ true
-    case BasicType.Float if !categoricalCols.contains(t._1) ⇒ true
-    case BasicType.Int if !categoricalCols.contains(t._1) ⇒ true
-    case BasicType.Long if !categoricalCols.contains(t._1) ⇒ true
-    case _ ⇒ false
+  val schema: Seq[(String, DataType)] = inputNames.zip(inputTypes)
+  val realFields: Seq[String] = schema.filter(t => t._2.base match {
+    case BasicType.Short if !categoricalCols.contains(t._1) => true
+    case BasicType.Double if !categoricalCols.contains(t._1) => true
+    case BasicType.Float if !categoricalCols.contains(t._1) => true
+    case BasicType.Int if !categoricalCols.contains(t._1) => true
+    case BasicType.Long if !categoricalCols.contains(t._1) => true
+    case _ => false
   }).toMap.keys.toSeq
 
   def getDouble(x: Any): Double = {
     x match {
-      case n: java.lang.Number ⇒ n.doubleValue()
+      case n: java.lang.Number => n.doubleValue()
       // will throw ClassCastException if it cannot be cast, as would row.getDouble
-      case other ⇒ other.asInstanceOf[Double]
+      case other => other.asInstanceOf[Double]
     }
   }
 
@@ -76,7 +76,7 @@ case class FeatureHasherModel(numFeatures: Int = 1 << 18,
 
   def apply(things: Seq[Any]): Vector = {
     val map = new mutable.OpenHashMap[Int, Double]()
-    schema.zip(things).foreach { case (sc, item) ⇒
+    schema.zip(things).foreach { case (sc, item) =>
       if (item != null) {
         val (rawIdx, value) = if (realFields.contains(sc._1)) {
           // numeric values are kept as is, with vector index based on hash of "column_name"

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/OneHotEncoderModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/OneHotEncoderModel.scala
@@ -45,7 +45,7 @@ case class OneHotEncoderModel(categorySizes: Array[Int],
       throw new IllegalArgumentException(s"invalid input size: ${labels.length}, must be ${categorySizes.length}")
     }
     labels.zipWithIndex.map {
-      case (label: Double, colIdx: Int) ⇒ encoder(label, colIdx)
+      case (label: Double, colIdx: Int) => encoder(label, colIdx)
     }
   }
 

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/VectorSlicerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/VectorSlicerModel.scala
@@ -13,7 +13,7 @@ import org.apache.spark.ml.linalg.mleap.VectorUtil._
 case class VectorSlicerModel(indices: Array[Int],
                              namedIndices: Array[(String, Int)] = Array(),
                             inputSize: Int) extends Model {
-  val allIndices: Array[Int] = indices.union(namedIndices.map(_._2))
+  val allIndices: Array[Int] = indices.union(namedIndices.map(_._2)).toArray
 
   def apply(features: Vector): Vector = features match {
     case features: DenseVector => Vectors.dense(allIndices.map(features.apply))

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/WordToVectorModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/WordToVectorModel.scala
@@ -68,7 +68,7 @@ case class WordToVectorModel(wordIndex: Map[String, Int],
     wordIndex.map { case (word, ind) =>
       (word, wordVectors.slice(vectorSize * ind, vectorSize * ind + vectorSize))
     }
-  }.mapValues(Vectors.dense).map(identity)
+  }.mapValues(Vectors.dense).map(identity).toMap
 
   def apply(sentence: Seq[String]): Vector = {
     if (sentence.isEmpty) {

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/types/DataType.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/types/DataType.scala
@@ -1,6 +1,6 @@
 package ml.combust.mleap.core.types
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.language.implicitConversions
 
 object DataType {

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/types/StructType.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/types/StructType.scala
@@ -1,7 +1,7 @@
 package ml.combust.mleap.core.types
 
 import java.io.PrintStream
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import scala.util.{Failure, Success, Try}
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/FeatureHasherModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/FeatureHasherModelSpec.scala
@@ -20,7 +20,7 @@ class FeatureHasherModelSpec  extends org.scalatest.funspec.AnyFunSpec {
     )
 
     it("Has the right input schema") {
-      assert(model.inputSchema.fields == schema.zipWithIndex.map({ case (sf, idx) ⇒
+      assert(model.inputSchema.fields == schema.zipWithIndex.map({ case (sf, idx) =>
           sf.copy(name = s"input$idx")
       }))
     }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/FeatureHasherModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/FeatureHasherModelSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.funspec.AnyFunSpec
 
 class FeatureHasherModelSpec  extends org.scalatest.funspec.AnyFunSpec {
 
-  val schema = Seq(
+  val schema: Seq[StructField] = Seq(
     StructField("doubleCol", DataType(BasicType.Double, ScalarShape())),
     StructField("boolCol", DataType(BasicType.Boolean, ScalarShape())),
     StructField("intCol", DataType(BasicType.Int, ScalarShape())),

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MathUnaryModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MathUnaryModelSpec.scala
@@ -35,5 +35,5 @@ class MathUnaryModelSpec extends org.scalatest.funspec.AnyFunSpec {
   unaryLike(Logit, "logit", 0.9, LogitHelper.logit(0.9))
   unaryLike(Floor, "floor", 3.4, Math.floor(3.4))
   unaryLike(Ceil, "ceil", 4.6, Math.ceil(4.6))
-  unaryLike(Round, "round", 8.9, Math.round(8.9))
+  unaryLike(Round, "round", 8.9, Math.round(8.9).toDouble)
 }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/VectorAssemblerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/VectorAssemblerModelSpec.scala
@@ -10,7 +10,7 @@ import org.scalatest.funspec.AnyFunSpec
   * Created by hwilkins on 1/21/16.
   */
 class VectorAssemblerModelSpec extends org.scalatest.funspec.AnyFunSpec {
-  val assembler = VectorAssemblerModel(Seq(
+  val assembler: VectorAssemblerModel = VectorAssemblerModel(Seq(
     ScalarShape(), ScalarShape(),
     TensorShape(2),
     TensorShape(5)))
@@ -22,7 +22,7 @@ class VectorAssemblerModelSpec extends org.scalatest.funspec.AnyFunSpec {
       assert(assembler(Array(45.0,
         new BigDecimal(76.8),
         Vectors.dense(Array(23.0, 45.6)),
-        Vectors.sparse(5, Array(1, 2, 4), Array(22.3, 45.6, 99.3)))).toArray.sameElements(expectedArray))
+        Vectors.sparse(5, Array(1, 2, 4), Array(22.3, 45.6, 99.3))).toSeq).toArray.sameElements(expectedArray))
     }
   }
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/WordToVectorModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/WordToVectorModelSpec.scala
@@ -2,11 +2,11 @@ package ml.combust.mleap.core.feature
 
 import ml.combust.mleap.core.types.{BasicType, ListType, StructField, TensorType}
 import org.apache.spark.ml.linalg.Vectors
-import org.scalactic.TolerantNumerics
+import org.scalactic.{Equality, TolerantNumerics}
 import org.scalatest.funspec.AnyFunSpec
 
 class WordToVectorModelSpec extends org.scalatest.funspec.AnyFunSpec {
-  implicit val doubleEquality = TolerantNumerics.tolerantDoubleEquality(0.000001)
+  implicit val doubleEquality: Equality[Double] = TolerantNumerics.tolerantDoubleEquality(0.000001)
 
   describe("word to vector model") {
     val model = WordToVectorModel(Map("test" -> 1), Array(12))

--- a/mleap-databricks-runtime-testkit/src/main/scala/ml/combust/mleap/databricks/runtime/testkit/TestTensorflow.scala
+++ b/mleap-databricks-runtime-testkit/src/main/scala/ml/combust/mleap/databricks/runtime/testkit/TestTensorflow.scala
@@ -15,7 +15,7 @@ class TestTensorflow(session: SparkSession) extends Runnable {
     val model = TensorflowModel(graph = Some(graph),
       inputs = Seq(("InputA", TensorType.Float()), ("InputB", TensorType.Float())),
       outputs = Seq(("MyResult", TensorType.Float())),
-      graphBytes = graph.toGraphDef.toByteArray
+      modelBytes = graph.toGraphDef.toByteArray
     )
     val shape = NodeShape().withInput("InputA", "input_a").
       withInput("InputB", "input_b").

--- a/mleap-executor/src/main/scala/ml/combust/mleap/executor/repository/MultiRepository.scala
+++ b/mleap-executor/src/main/scala/ml/combust/mleap/executor/repository/MultiRepository.scala
@@ -57,6 +57,6 @@ object MultiRepositoryProvider extends RepositoryProvider {
       Repository.fromConfig(rConfig)
     }
 
-    new MultiRepository(repositories)
+    new MultiRepository(repositories.toSeq)
   }
 }

--- a/mleap-executor/src/main/scala/ml/combust/mleap/executor/repository/MultiRepository.scala
+++ b/mleap-executor/src/main/scala/ml/combust/mleap/executor/repository/MultiRepository.scala
@@ -8,7 +8,7 @@ import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import ml.combust.mleap.executor.error.BundleException
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.{Await, Future, Promise}
 import scala.concurrent.duration._
 import scala.util.Try

--- a/mleap-runtime/src/main/java/ml/combust/mleap/runtime/javadsl/LeapFrameBuilderSupport.scala
+++ b/mleap-runtime/src/main/java/ml/combust/mleap/runtime/javadsl/LeapFrameBuilderSupport.scala
@@ -4,7 +4,7 @@ import ml.combust.mleap.core.types.{BasicType, StructType}
 import ml.combust.mleap.core.util.VectorConverters
 import ml.combust.mleap.runtime.frame.ArrayRow
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import org.apache.spark.ml.linalg.Vector
 import ml.combust.mleap.json.JsonSupport._

--- a/mleap-runtime/src/main/java/ml/combust/mleap/runtime/javadsl/LeapFrameBuilderSupport.scala
+++ b/mleap-runtime/src/main/java/ml/combust/mleap/runtime/javadsl/LeapFrameBuilderSupport.scala
@@ -35,7 +35,7 @@ class LeapFrameBuilderSupport {
   def createByteString(): BasicType = BasicType.ByteString
 
   def createTensorDimensions(dims : java.util.List[Integer]): Option[Seq[Int]] = {
-    Some(dims.asScala.map(_.intValue()))
+    Some(dims.asScala.toSeq.map(_.intValue()))
   }
 
   def createSchema(json: String): StructType = json.parseJson.convertTo[StructType]

--- a/mleap-runtime/src/main/java/ml/combust/mleap/runtime/javadsl/LeapFrameSupport.scala
+++ b/mleap-runtime/src/main/java/ml/combust/mleap/runtime/javadsl/LeapFrameSupport.scala
@@ -12,11 +12,11 @@ class LeapFrameSupport {
   }
 
   def select(frame: DefaultLeapFrame, fieldNames: java.util.List[String]): DefaultLeapFrame = {
-    frame.select(fieldNames.asScala: _*).get
+    frame.select(fieldNames.asScala.toSeq: _*).get
   }
 
   def drop(frame: DefaultLeapFrame, names: java.util.List[String]): DefaultLeapFrame = {
-    frame.drop(names.asScala: _*).get
+    frame.drop(names.asScala.toSeq: _*).get
   }
 
   def getFields(schema: StructType): java.util.List[StructField]  = {

--- a/mleap-runtime/src/main/java/ml/combust/mleap/runtime/javadsl/LeapFrameSupport.scala
+++ b/mleap-runtime/src/main/java/ml/combust/mleap/runtime/javadsl/LeapFrameSupport.scala
@@ -3,7 +3,7 @@ package ml.combust.mleap.runtime.javadsl
 import ml.combust.mleap.core.types.{StructField, StructType}
 import ml.combust.mleap.runtime.frame.{DefaultLeapFrame, Row}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class LeapFrameSupport {
 

--- a/mleap-runtime/src/main/java/ml/combust/mleap/runtime/javadsl/TensorSupport.scala
+++ b/mleap-runtime/src/main/java/ml/combust/mleap/runtime/javadsl/TensorSupport.scala
@@ -1,7 +1,7 @@
 package ml.combust.mleap.runtime.javadsl
 
 import ml.combust.mleap.tensor.Tensor
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class TensorSupport {
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/binary/DefaultFrameReader.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/binary/DefaultFrameReader.scala
@@ -41,7 +41,7 @@ class DefaultFrameReader extends FrameReader {
         rows(i) = row
       }
 
-      DefaultLeapFrame(schema, rows)
+      DefaultLeapFrame(schema, rows.toSeq)
     }
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/binary/DefaultRowReader.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/binary/DefaultRowReader.scala
@@ -19,7 +19,7 @@ class DefaultRowReader(override val schema: StructType) extends RowReader {
   override def fromBytes(bytes: Array[Byte], charset: Charset = BuiltinFormats.charset): Try[Row] = {
     Using(new ByteArrayInputStream(bytes)) { in =>
       val din = new DataInputStream(in)
-      val row = ArrayRow(new Array[Any](schema.fields.length))
+      val row = ArrayRow((new Array[Any](schema.fields.length)).toSeq)
       var i = 0
       for(s <- serializers) {
         row.set(i, s.read(din))

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/MultiInOutMleapOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/MultiInOutMleapOp.scala
@@ -13,10 +13,10 @@ import scala.reflect.ClassTag
 abstract class MultiInOutMleapOp[N <: Transformer, M <: AnyRef](implicit ct: ClassTag[N]) extends MleapOp[N, M] {
   override def load(node: Node, model: M)(implicit context: BundleContext[MleapContext]): N = {
     val ns = node.shape.getInput(NodeShape.standardInputPort) match { // Old version need to translate serialized port names to new expectation (input -> input0)
-      case Some(_) ⇒ translateLegacyShape(node.shape)
+      case Some(_) => translateLegacyShape(node.shape)
 
       // New version
-      case None ⇒ node.shape
+      case None => node.shape
     }
     klazz.getConstructor(classOf[String], classOf[types.NodeShape], Model.klazz).newInstance(node.name, ns.asBundle: types.NodeShape, model)
   }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/FeatureHasherOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/FeatureHasherOp.scala
@@ -29,7 +29,7 @@ class FeatureHasherOp extends MleapOp[FeatureHasher, FeatureHasherModel] {
                      (implicit context: BundleContext[MleapContext]): FeatureHasherModel = {
       val shapes = model.value("input_shapes").getDataShapeList.map(bundleToMleapShape)
       val types = model.value("basic_types").getBasicTypeList.map(bundleToMleapBasicType)
-      val inputTypes = shapes.zip(types).map(tup ⇒ DataType(tup._2, tup._1))
+      val inputTypes = shapes.zip(types).map(tup => DataType(tup._2, tup._1))
 
       FeatureHasherModel(numFeatures = model.value("num_features").getLong.toInt,
         categoricalCols = model.value("categorical_cols").getStringList,

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/frame/ArrayRow.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/frame/ArrayRow.scala
@@ -24,7 +24,7 @@ case class ArrayRow(values: mutable.WrappedArray[Any]) extends Row {
   override def withValue(value: Any): ArrayRow = ArrayRow(values :+ value)
   override def withValues(values: Seq[Any]): ArrayRow = ArrayRow(this.values ++ values)
 
-  override def selectIndices(indices: Int *): ArrayRow = ArrayRow(indices.toArray.map(values))
+  override def selectIndices(indices: Int *): ArrayRow = ArrayRow(indices.toArray.map(values).toSeq)
 
   override def dropIndices(indices: Int *): ArrayRow = {
     val drops = Set(indices: _*)

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/frame/ArrayRow.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/frame/ArrayRow.scala
@@ -1,6 +1,6 @@
 package ml.combust.mleap.runtime.frame
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 
 /**

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/frame/DefaultLeapFrame.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/frame/DefaultLeapFrame.scala
@@ -5,7 +5,7 @@ import java.lang.Iterable
 import ml.combust.mleap.core.types.{BasicType, StructField, StructType}
 import ml.combust.mleap.runtime.function.{Selector, UserDefinedFunction}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Try}
 
 /** Class for storing a leap frame locally.

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/frame/Row.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/frame/Row.scala
@@ -16,7 +16,7 @@ object Row {
     * @param values values in the row
     * @return default row implementation with values
     */
-  def apply(values: Any *): Row = ArrayRow(values.toArray)
+  def apply(values: Any *): Row = ArrayRow(values.toArray.toSeq)
 }
 
 /** Base trait for row data.

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/frame/Row.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/frame/Row.scala
@@ -4,7 +4,7 @@ import ml.combust.mleap.runtime.frame.Row.RowSelector
 import ml.combust.mleap.runtime.function.UserDefinedFunction
 import ml.combust.mleap.tensor.{ByteString, Tensor}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /** Companion object for creating default rows.
   */

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/frame/RowTransformer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/frame/RowTransformer.scala
@@ -169,7 +169,7 @@ case class RowTransformer private (inputSchema: StructType,
   def transformOption(row: Row): Option[ArrayRow] = {
     val arr = new Array[Any](maxSize)
     row.toArray.copyToArray(arr)
-    val arrRow = ArrayRow(arr)
+    val arrRow = ArrayRow(arr.toSeq)
 
     val r = transforms.foldLeft(Option(arrRow)) {
       (r, transform) => r.flatMap(transform)

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/frame/RowSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/frame/RowSpec.scala
@@ -166,7 +166,7 @@ trait RowSpec[R <: Row] extends org.scalatest.funspec.AnyFunSpec {
       describe("user defined function") {
         it("adds a value using a user defined function") {
           val r2 = row.withValue(r => r.get(1), r => r.get(2)) {
-            (v1: Int, v2: Seq[Int]) => v1 + v2(0)
+            (v1: Int, v2: Seq[Int]) => v1 + v2.head
           }
 
           assert(r2.getInt(6) == 98)

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/frame/RowSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/frame/RowSpec.scala
@@ -19,7 +19,7 @@ trait RowSpec[R <: Row] extends org.scalatest.funspec.AnyFunSpec {
       42,
       45.4,
       Tensor.denseVector(Array(42.3, 65.7)),
-      33l,
+      33L,
       Seq(56, 78, 23))
     val optionRow = create(optionRowValues: _*)
 
@@ -96,7 +96,7 @@ trait RowSpec[R <: Row] extends org.scalatest.funspec.AnyFunSpec {
 
     describe("#optionLong") {
       it("gets the value at a given index as a long") {
-        assert(optionRow.optionLong(5) == Option(33l))
+        assert(optionRow.optionLong(5) == Option(33L))
       }
     }
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/javadsl/JavaDSLSpec.java
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/javadsl/JavaDSLSpec.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ml.combust.mleap.tensor.ByteString;
 import org.junit.jupiter.api.Test;
-import scala.collection.JavaConverters;
+import scala.jdk.javaapi.CollectionConverters;
 import scala.collection.immutable.ListMap;
 
 import java.io.File;
@@ -52,7 +52,7 @@ public class JavaDSLSpec {
             new NodeShape(new ListMap<>(), new ListMap<>()).
                     withInput("input0", "string").
                     withOutput("output0","string_index"),
-            new StringIndexerModel(JavaConverters.asScalaBuffer(Collections.singletonList(JavaConverters.asScalaBuffer(Collections.singletonList("hello")).toSeq())),
+            new StringIndexerModel(CollectionConverters.asScala(Collections.singletonList(CollectionConverters.asScala(Collections.singletonList("hello")).toSeq())).toSeq(),
                     HandleInvalid.Error$.MODULE$));
 
     DefaultLeapFrame buildFrame() {
@@ -101,7 +101,7 @@ public class JavaDSLSpec {
         assertEquals(row.getDouble(7), 44.5, 0.0000000000001);
         assertEquals(row.getByteString(8), new ByteString("hello_there".getBytes()));
         assertEquals(row.getList(9), Arrays.asList(23, 44, 55));
-        assertEquals(JavaConverters.mapAsJavaMap(row.getMap(10)), mapCol );
+        assertEquals(CollectionConverters.asJava(row.getMap(10)), mapCol );
         List<Double> tensorValues = tensorSupport.toArray(row.getTensor(11));
         assertEquals(tensorValues, Arrays.asList(23d, 3d, 4d));
     }
@@ -117,7 +117,7 @@ public class JavaDSLSpec {
     @Test
     public void createTensorFieldWithDimension() {
         StructField tensorField = frameBuilder.createField("tensor", frameBuilder.createTensor(frameBuilder.createBasicByte(), Arrays.asList(1, 2), true));
-        assertEquals(((TensorType)tensorField.dataType()).dimensions().get(), JavaConverters.asScalaBuffer(Arrays.asList(1, 2)).toSeq());
+        assertEquals(((TensorType)tensorField.dataType()).dimensions().get(), CollectionConverters.asScala(Arrays.asList(1, 2)).toSeq());
     }
 
     @Test

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/FeatureHasherSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/FeatureHasherSpec.scala
@@ -15,7 +15,7 @@ class FeatureHasherSpec extends org.scalatest.funspec.AnyFunSpec {
     "output" -> StructField("features", TensorType.Double(262144))
   )
 
-  val model = FeatureHasherModel(
+  val model: FeatureHasherModel = FeatureHasherModel(
     categoricalCols = Seq.empty[String],
     inputNames = inputSchema.values.map(_.name).toSeq,
     inputTypes = inputSchema.values.map(_.dataType).toSeq

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/FeatureHasherSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/FeatureHasherSpec.scala
@@ -5,14 +5,14 @@ import ml.combust.mleap.core.types._
 
 class FeatureHasherSpec extends org.scalatest.funspec.AnyFunSpec {
 
-  val inputSchema = Map(
-    "input0" → StructField("doubleCol", DataType(BasicType.Double, ScalarShape())),
-    "input1" → StructField("boolCol", DataType(BasicType.Boolean, ScalarShape())),
-    "input2" → StructField("intCol", DataType(BasicType.Int, ScalarShape())),
-    "input3" → StructField("stringCol", DataType(BasicType.String, ScalarShape()))
+  val inputSchema: Map[String, StructField] = Map(
+    "input0" -> StructField("doubleCol", DataType(BasicType.Double, ScalarShape())),
+    "input1" -> StructField("boolCol", DataType(BasicType.Boolean, ScalarShape())),
+    "input2" -> StructField("intCol", DataType(BasicType.Int, ScalarShape())),
+    "input3" -> StructField("stringCol", DataType(BasicType.String, ScalarShape()))
   )
-  val outputSchema = Map(
-    "output" → StructField("features", TensorType.Double(262144))
+  val outputSchema: Map[String, StructField] = Map(
+    "output" -> StructField("features", TensorType.Double(262144))
   )
 
   val model = FeatureHasherModel(
@@ -23,7 +23,7 @@ class FeatureHasherSpec extends org.scalatest.funspec.AnyFunSpec {
 
   describe("input/output schema") {
 
-    val shape = inputSchema.foldLeft(NodeShape()) { (acc, item) ⇒
+    val shape = inputSchema.foldLeft(NodeShape()) { (acc, item) =>
       acc.withInput(item._1, item._2.name)
     }.withOutput(outputSchema.head._1, outputSchema.head._2.name)
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/StandardScalerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/StandardScalerSpec.scala
@@ -42,8 +42,8 @@ class StandardScalerSpec extends org.scalatest.funspec.AnyFunSpec {
         bf.loadMleapBundle().get.root
       }.get.asInstanceOf[StandardScaler]
 
-      assert(transformer.model.std sameElements scaler.model.std)
-      assert(transformer.model.mean sameElements scaler.model.mean)
+      assert(transformer.model.std.iterator sameElements scaler.model.std.iterator)
+      assert(transformer.model.mean.iterator sameElements scaler.model.mean.iterator)
     }
   }
 }

--- a/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
+++ b/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
@@ -8,7 +8,7 @@ import ml.combust.mleap.core.util.VectorConverters._
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types._
 
-import scala.collection.mutable
+import scala.collection.{mutable, immutable}
 import scala.language.implicitConversions
 import scala.util.Try
 
@@ -74,10 +74,10 @@ trait TypeConverters {
         val size = getVectorSize(dataset, field)
         types.TensorType.Double(size)
       case _: MatrixUDT =>
-        val m = dataset.select(field.name).head.getAs[Matrix](0)
+        val m = dataset.select(field.name).head().getAs[Matrix](0)
         types.TensorType.Double(m.numRows, m.numCols)
       case ArrayType(elementType, _) if elementType == new VectorUDT =>
-        val a = dataset.select(field.name).head.getAs[mutable.WrappedArray[Vector]](0)
+        val a = dataset.select(field.name).head().getAs[mutable.WrappedArray[Vector]](0)
         types.TensorType.Double(a.length, a.head.size)
       case _ => throw new UnsupportedOperationException(s"Cannot convert spark field $field to mleap")
     }
@@ -197,7 +197,7 @@ trait TypeConverters {
       val size = getVectorSize(dataset, field)
       types.TensorShape(Some(Seq(size)), field.nullable)
     case mu: MatrixUDT =>
-      val m = dataset.select(field.name).head.getAs[Matrix](0)
+      val m = dataset.select(field.name).head().getAs[Matrix](0)
       types.TensorShape(Some(Seq(m.numRows, m.numCols)), field.nullable)
     case _ => throw new IllegalArgumentException(s"invalid struct field for shape: $field")
   }

--- a/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
+++ b/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/TypeConverters.scala
@@ -40,6 +40,12 @@ trait TypeConverters {
         val s = t.head.size
         val values = t.flatMap(_.toArray).toArray
         DenseTensor(values, Seq(t.size, s))
+    case at: ArrayType =>
+      (v: Any) => v match {
+          case vArr1: mutable.WrappedArray[?] => vArr1.toSeq
+          case vArr2: Array[?] => vArr2.toSeq
+          case vNonArr => vNonArr
+        }
     case _ => (v) => v
   }
 

--- a/mleap-spark-base/src/test/scala/ml/combust/mleap/spark/SparkTransformBuilderSpec.scala
+++ b/mleap-spark-base/src/test/scala/ml/combust/mleap/spark/SparkTransformBuilderSpec.scala
@@ -10,7 +10,7 @@ import ml.combust.mleap.core.types.{NodeShape, ScalarType, StructField}
 import ml.combust.mleap.runtime.frame.{FrameBuilder, Transformer}
 import org.scalatest.funspec.AnyFunSpec
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 /**

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/classification/OneVsRestOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/classification/OneVsRestOp.scala
@@ -43,7 +43,7 @@ class OneVsRestOp extends SimpleSparkOp[OneVsRestModel] {
       val labelMetadata = NominalAttribute.defaultAttr.
         withName("prediction").
         withNumValues(models.length).
-        toMetadata
+        toMetadata()
       new OneVsRestModel(uid = "", models = models, labelMetadata = labelMetadata)
     }
   }
@@ -52,7 +52,7 @@ class OneVsRestOp extends SimpleSparkOp[OneVsRestModel] {
     val labelMetadata = NominalAttribute.defaultAttr.
       withName(shape.output("prediction").name).
       withNumValues(model.models.length).
-      toMetadata
+      toMetadata()
     new OneVsRestModel(uid = uid, models = model.models, labelMetadata = labelMetadata)
   }
 

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/classification/OneVsRest.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/classification/OneVsRest.scala
@@ -22,7 +22,8 @@ import java.util.UUID
 
 import ml.combust.mleap.core.annotation.SparkCode
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
+import scala.collection.parallel.CollectionConverters._
 import scala.language.existentials
 import org.apache.hadoop.fs.Path
 import org.json4s.{DefaultFormats, JObject, _}
@@ -355,7 +356,7 @@ final class OneVsRest @Since("1.4.0") (
     }
 
     // create k columns, one for each binary classifier.
-    val models = Range(0, numClasses).par.map { index =>
+    val models = (0 until numClasses).par.map { index =>
       // generate new label metadata for the binary problem.
       val newLabelMeta = BinaryAttribute.defaultAttr.withName("label").toMetadata()
       val labelColName = "mc2b$" + index

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/FeatureHasherOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/FeatureHasherOp.scala
@@ -23,8 +23,8 @@ class FeatureHasherOp extends SimpleSparkOp[FeatureHasher] {
         Array.empty[String]
       }
       val dataset = context.context.dataset.get
-      val inputShapes = obj.getInputCols.map(i ⇒ sparkToMleapDataShape(dataset.schema(i), dataset): DataShape)
-      val basicTypes = obj.getInputCols.map(i ⇒ sparkFieldToMleapField(dataset, dataset.schema(i)).dataType.base).map(mleapToBundleBasicType)
+      val inputShapes = obj.getInputCols.map(i => sparkToMleapDataShape(dataset.schema(i), dataset): DataShape)
+      val basicTypes = obj.getInputCols.map(i => sparkFieldToMleapField(dataset, dataset.schema(i)).dataType.base).map(mleapToBundleBasicType)
 
       model.withValue("num_features", Value.long(obj.getNumFeatures))
         .withValue("categorical_cols", Value.stringList(categoricals))

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/OneHotEncoderOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/OneHotEncoderOp.scala
@@ -47,7 +47,7 @@ class OneHotEncoderOp extends MultiInOutSparkOp[OneHotEncoderModel] {
       assert(!(obj.isSet(obj.outputCol) && obj.isSet(obj.outputCols)), "OneHotEncoderModel cannot have both outputCol and outputCols set")
       val inputCols = if (obj.isSet(obj.inputCol)) Array(obj.getInputCol) else obj.getInputCols
       val df = context.context.dataset.get
-      val categorySizes = inputCols.map { f ⇒ OneHotEncoderOp.sizeForField(df.schema(f)) }
+      val categorySizes = inputCols.map { f => OneHotEncoderOp.sizeForField(df.schema(f)) }
       model.withValue("category_sizes", Value.intList(categorySizes))
         .withValue("drop_last", Value.boolean(obj.getDropLast))
         .withValue("handle_invalid", Value.string(obj.getHandleInvalid))

--- a/mleap-tensor/src/test/scala/ml/combust/mleap/tensor/TensorSpec.scala
+++ b/mleap-tensor/src/test/scala/ml/combust/mleap/tensor/TensorSpec.scala
@@ -5,7 +5,7 @@ class TensorSpec extends org.scalatest.funspec.AnyFunSpec {
 
   def combine[A](xs: Traversable[Traversable[A]]): Seq[Seq[A]] =
     xs.foldLeft(Seq(Seq.empty[A])) {
-      (x, y) => for (a <- x.view; b <- y) yield a :+ b
+      (x, y) => for (a <- x; b <- y) yield a :+ b
     }
 
   describe("Test Legacy DenseTensor Get") {

--- a/mleap-tensorflow/src/main/scala/ml/combust/mleap/tensorflow/TensorflowModel.scala
+++ b/mleap-tensorflow/src/main/scala/ml/combust/mleap/tensorflow/TensorflowModel.scala
@@ -28,7 +28,7 @@ case class TensorflowModel( @transient var graph: Option[tensorflow.Graph] = Non
                           ) extends Model with AutoCloseable {
 
   def apply(values: Tensor[_] *): Seq[Any] = {
-    val garbage: mutable.ArrayBuilder[tensorflow.Tensor] = mutable.ArrayBuilder.make[tensorflow.Tensor]()
+    val garbage: mutable.ArrayBuilder[tensorflow.Tensor] = mutable.ArrayBuilder.make[tensorflow.Tensor]
 
     val result = Try {
       val tensors = values.zip(inputs).map {

--- a/mleap-tensorflow/src/test/scala/ml/combust/mleap/tensorflow/TensorflowModelSpec.scala
+++ b/mleap-tensorflow/src/test/scala/ml/combust/mleap/tensorflow/TensorflowModelSpec.scala
@@ -12,7 +12,7 @@ import org.tensorflow.types.TFloat32
 import java.io.ByteArrayOutputStream
 import java.nio.file.Files
 import java.util.zip.ZipOutputStream
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
   * Created by hollinwilkins on 1/12/17.

--- a/mleap-tensorflow/src/test/scala/ml/combust/mleap/tensorflow/TensorflowTransformerSpec.scala
+++ b/mleap-tensorflow/src/test/scala/ml/combust/mleap/tensorflow/TensorflowTransformerSpec.scala
@@ -19,7 +19,7 @@ import java.io.{ByteArrayOutputStream, File}
 import java.net.URI
 import java.nio.file.{Files, Paths}
 import java.util.zip.ZipOutputStream
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.{Success, Try, Using}
 
 /**

--- a/mleap-tensorflow/src/test/scala/ml/combust/mleap/tensorflow/converter/MleapConverterSpec.scala
+++ b/mleap-tensorflow/src/test/scala/ml/combust/mleap/tensorflow/converter/MleapConverterSpec.scala
@@ -17,7 +17,7 @@ class MleapConverterSpec extends org.scalatest.funspec.AnyFunSpec {
 
   def combine[A](xs: Traversable[Traversable[A]]): Seq[Seq[A]] =
     xs.foldLeft(Seq(Seq.empty[A])) {
-      (x, y) => for (a <- x.view; b <- y) yield a :+ b
+      (x, y) => for (a <- x; b <- y) yield a :+ b
     }
 
   describe("round trip from mleap tensor to tensorflow tensor") {

--- a/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/struct/FVecFactory.scala
+++ b/mleap-xgboost-runtime/src/main/scala/ml/combust/mleap/xgboost/runtime/struct/FVecFactory.scala
@@ -6,7 +6,7 @@ import biz.k11i.xgboost.util.FVec
 import ml.combust.mleap.tensor.{SparseTensor, Tensor}
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector}
 
-import scala.collection.JavaConverters.mapAsJavaMapConverter
+import scala.jdk.CollectionConverters._
 
 
 object FVecFactory {

--- a/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/testing/CachedDatasetUtils.scala
+++ b/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/testing/CachedDatasetUtils.scala
@@ -88,7 +88,7 @@ trait CachedDatasetUtils {
         array(labelColumnIndex) = row.getDouble(labelColumnIndex)
         array(featureColumnIndex) = row.getTensor[Double](featureColumnIndex).toDense
 
-        ArrayRow(array)
+        ArrayRow(array.toSeq)
       }
     }
 

--- a/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/testing/CachedDatasetUtils.scala
+++ b/mleap-xgboost-runtime/src/test/scala/ml/combust/mleap/xgboost/runtime/testing/CachedDatasetUtils.scala
@@ -18,10 +18,10 @@ trait CachedDatasetUtils {
 
   // indexing_mode is necessary to tell xgboost that features start from 1, not 0 (xgboost default is 0)
   val binomialDataset: DMatrix =
-    new DMatrix(this.getClass.getClassLoader.getResource(TrainDataFilePath).getFile + "?indexing_mode=1")
+    new DMatrix(this.getClass.getClassLoader.getResource(TrainDataFilePath).getFile + "?format=libsvm#indexing_mode=1")
 
   val multinomialDataset: DMatrix =
-    new DMatrix(this.getClass.getClassLoader.getResource(TrainDataMultinomialFilePath).getFile + "?indexing_mode=1")
+    new DMatrix(this.getClass.getClassLoader.getResource(TrainDataMultinomialFilePath).getFile + "?format=libsvm#indexing_mode=1")
 
   lazy val leapFrameBinomial: DefaultLeapFrame = leapFrameFromCSVFile(TrainDataFilePathCSV)
   lazy val leapFrameMultinomial: DefaultLeapFrame = leapFrameFromLibSVMFile(TrainDataMultinomialFilePath)

--- a/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
+++ b/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostClassificationModelOp.scala
@@ -32,7 +32,7 @@ class XGBoostClassificationModelOp extends SimpleSparkOp[XGBoostClassificationMo
 
       val out = Files.newOutputStream(context.file("xgboost.model"))
       obj._booster.saveModel(out)
-      val numFeatures = context.context.dataset.get.select(obj.getFeaturesCol).first.getAs[Vector](0).size
+      val numFeatures = context.context.dataset.get.select(obj.getFeaturesCol).first().getAs[Vector](0).size
       model.withValue("thresholds", thresholds.map(_.toSeq).map(Value.doubleList)).
         withValue("num_classes", Value.int(obj.numClasses)).
         withValue("num_features", Value.int(numFeatures)).

--- a/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelOp.scala
+++ b/mleap-xgboost-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/mleap/XGBoostRegressionModelOp.scala
@@ -28,7 +28,7 @@ class XGBoostRegressionModelOp extends SimpleSparkOp[XGBoostRegressionModel] {
 
       Files.write(context.file("xgboost.model"), obj._booster.toByteArray)
 
-      val numFeatures = context.context.dataset.get.select(obj.getFeaturesCol).first.getAs[Vector](0).size
+      val numFeatures = context.context.dataset.get.select(obj.getFeaturesCol).first().getAs[Vector](0).size
       model.withValue("num_features", Value.int(numFeatures)).
         withValue("tree_limit", Value.int(obj.getOrDefault(obj.treeLimit))).
         withValue("missing", Value.float(obj.getOrDefault(obj.missing))).

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -17,7 +17,7 @@ object Common {
   lazy val defaultSettings = buildSettings ++ sonatypeSettings
 
   lazy val buildSettings: Seq[Def.Setting[_]] = Seq(
-    scalaVersion := "2.12.18",
+    crossScalaVersions := Seq("2.12.20", "2.13.15"),
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
     ThisBuild / libraryDependencySchemes +=
       "org.scala-lang.modules" %% "scala-collection-compat" % VersionScheme.Always,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,9 +17,9 @@ object Dependencies {
   lazy val loggingVersion = "3.9.5"
   lazy val slf4jVersion = "2.0.6"
   lazy val awsSdkVersion = "1.12.470"
-  lazy val scalaCollectionCompat = "2.8.1"
+  lazy val scalaCollectionCompat = "2.12.0"
   val tensorflowJavaVersion = "0.5.0" // Match Tensorflow 2.10.1 https://github.com/tensorflow/java/#tensorflow-version-support
-  val xgboostVersion = "1.7.6"
+  val xgboostVersion = "2.0.3"
   val breezeVersion = "2.1.0"
   val hadoopVersion = "3.3.4" // matches spark version
   val platforms = "windows-x86_64,linux-x86_64,macosx-x86_64"
@@ -80,8 +80,8 @@ object Dependencies {
 
     val breeze = "org.scalanlp" %% "breeze" % breezeVersion
 
-    val xgboostDep = "ml.dmlc" %% "xgboost4j" % xgboostVersion
-    val xgboostSparkDep = "ml.dmlc" %% "xgboost4j-spark" % xgboostVersion
+    val xgboostDep = "ml.dmlc" %% "xgboost4j" % xgboostVersion exclude("org.scala-lang.modules", "scala-collection-compat_2.12")
+    val xgboostSparkDep = "ml.dmlc" %% "xgboost4j-spark" % xgboostVersion exclude("org.scala-lang.modules", "scala-collection-compat_2.12") exclude("ml.dmlc", "xgboost4j_2.12")
     val xgboostPredictorDep = "ai.h2o" % "xgboost-predictor" % "0.3.18" exclude("com.esotericsoftware.kryo", "kryo")
 
     val hadoop = "org.apache.hadoop" % "hadoop-client" % hadoopVersion
@@ -136,7 +136,7 @@ object Dependencies {
 
   val xgboostRuntime = l ++= Seq(xgboostDep) ++ Seq(xgboostPredictorDep) ++ Test.spark ++ Test.sparkTest ++ Seq(Test.scalaTest)
 
-  val xgboostSpark = l ++= Seq(xgboostSparkDep) ++ Provided.spark ++ Test.spark ++ Test.sparkTest
+  val xgboostSpark = l ++= Seq(xgboostDep) ++ Seq(xgboostSparkDep) ++ Provided.spark ++ Test.spark ++ Test.sparkTest
 
   val serving = l ++= Seq(akkaHttp, akkaHttpSprayJson, config, Test.scalaTest, Test.akkaHttpTestkit)
 

--- a/python/mleap/pyspark/feature/string_map.py
+++ b/python/mleap/pyspark/feature/string_map.py
@@ -39,7 +39,7 @@ class StringMap(JavaTransformer, HasInputCol, HasOutputCol, JavaMLReadable, Java
         labels_scala_map = _jvm() \
             .scala \
             .collection \
-            .JavaConverters \
+            .CollectionConverters \
             .mapAsScalaMapConverter(labels) \
             .asScala() \
             .toMap(_jvm().scala.Predef.conforms())


### PR DESCRIPTION
Let's enter 2025 with Scala 2.13 support! 😊 Happy new year! :christmas_tree::fireworks::christmas_tree::tada::christmas_tree::gift::christmas_tree:

Second take on Scala 2.13, based on unfinished PR #860. Related to #811.

1. Some sort of hand-made cross-compilation inside:

Scala 2.13: compiles and passes all tests (as far as I understand).
 - But many warnings left in code to maintain compatibility with 2.12
 - And also it blows IntelliJ Idea's mind: it detects some strange errors

Scala 2.12: compiles and passes all tests (as far as I understand).
 - But in requires to comment `import scala.collection.parallel.CollectionConverters._` in [OneVsRest.scala](https://github.com/combust/mleap/compare/master...amivanoff:mleap:scala-2.13-2nd-take?expand=1#diff-3be34f4fe15c2806a337b26e71bdb427d7169287e761bfece3861ad4e0596c16).

2. Due to immutable Seq in transformers in 2.13, there was a problem with MinMaxScalerPipelineParitySpec test -- Array values in `ArrayRow`s should be immutable. I made some fix in [TypeConverters.scala](https://github.com/combust/mleap/compare/master...amivanoff:mleap:scala-2.13-2nd-take?expand=1#diff-26ecd6d303ee73f799b7bbd1c15167d7dc724e7ab4fd4bc93160dc826313a427) to ensure immutability. Not sure if it is the right place.

3. No automatic cross-compilation in Travis due to 2. Don't know what is the best practice to handle cross-compilation in the Scala world.

There are at least two variants:
- Conditional Compilation [Some hacks, no official way](https://github.com/scala/scala-dev/issues/640)
  - We need hardcore low level ifdefs "before parser" preprocessor which works with TEXT LINES inclusion/exclusion (imports lines, etc,). Not high-level "type annotations" and types inclusion/exclusion.
- Separate branches -- it seems it's an overkill
- Separate folders -- also too clunky