### PR TITLE
Validate zip directory entries during extraction

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/util/FileUtil.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/util/FileUtil.scala
@@ -2,7 +2,7 @@ package ml.combust.bundle.util
 
 import java.io.{IOException, InputStream, OutputStream}
 import java.nio.file.attribute.BasicFileAttributes
-import java.nio.file.{FileVisitResult, Files, FileSystems, Path, SimpleFileVisitor}
+import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
 import java.util.Comparator
 import java.util.stream.Collectors
 import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
@@ -67,19 +67,23 @@ object FileUtil {
     var entry = in.getNextEntry
     while (entry != null) {
       val filePath = dest.resolve(entry.getName)
+      validateZipEntry(dest, filePath, entry)
       if (entry.isDirectory) {
         Files.createDirectories(filePath)
       } else {
-        val destCanonical = dest.toRealPath()
-        val entryCanonical = filePath.toAbsolutePath().normalize()
-        if (!entryCanonical.startsWith(destCanonical.toString() + FileSystems.getDefault().getSeparator())) {
-          throw new Exception("Entry is outside of the target dir: " + entry.getName)
-        }
         Using(Files.newOutputStream(filePath)) {
           out => writeData(in, out)
         }
       }
       entry = in.getNextEntry
+    }
+  }
+
+  private def validateZipEntry(dest: Path, filePath: Path, entry: ZipEntry): Unit = {
+    val destCanonical = dest.toRealPath()
+    val entryCanonical = filePath.toAbsolutePath().normalize()
+    if (!entryCanonical.startsWith(destCanonical)) {
+      throw new Exception("Entry is outside of the target dir: " + entry.getName)
     }
   }
 

--- a/bundle-ml/src/test/scala/ml/combust/bundle/serializer/BundleFileSystemSpec.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/serializer/BundleFileSystemSpec.scala
@@ -2,11 +2,13 @@ package ml.combust.bundle.serializer
 
 import java.net.URI
 import java.nio.file.Files
+import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import ml.combust.bundle.test.TestSupport._
 import ml.combust.bundle.{BundleFile, BundleRegistry}
 import ml.combust.bundle.test.ops._
 import ml.combust.bundle.test.{TestBundleFileSystem, TestContext}
+import ml.combust.bundle.util.FileUtil
 import org.scalatest.funspec.AnyFunSpec
 import scala.util.Using
 
@@ -32,6 +34,27 @@ class BundleFileSystemSpec extends org.scalatest.funspec.AnyFunSpec {
       val loaded = uri.loadBundle().get
 
       assert(loaded.root == lr)
+    }
+  }
+
+  describe("extracting zip files") {
+    it("rejects directory entries outside of the target directory") {
+      val tmpDir = Files.createTempDirectory("BundleFileSystemSpec")
+      val zipFile = tmpDir.resolve("malicious.zip")
+      val dest = tmpDir.resolve("dest")
+      val outside = tmpDir.resolve("outside")
+
+      Using(new ZipOutputStream(Files.newOutputStream(zipFile))) { out =>
+        out.putNextEntry(new ZipEntry("../outside/"))
+        out.closeEntry()
+      }.get
+
+      intercept[Exception] {
+        FileUtil.extract(zipFile, dest)
+      }
+
+      assert(!Files.exists(outside))
+      FileUtil.rmRF(tmpDir)
     }
   }
 }


### PR DESCRIPTION
## Summary
- validate zip entry paths before creating directory entries during extraction
- keep the same containment check for file entries
- add a regression test for `../` directory entries that previously could create directories outside the extraction target

## Why
`FileUtil.extract` checked normalized paths for file entries, but directory entries were created before any containment validation. A crafted archive with a directory entry such as `../outside/` could therefore create directories outside the intended extraction root.

## Testing
- `git diff --check`

I could not run the Scala test suite locally because this Windows environment does not have `sbt`, `scala`, `scalac`, or `java` on PATH.
