### PR TITLE
CI: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,11 @@ jobs:
   publish-scala:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: recursive
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -28,11 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: recursive
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - run: pip install twine wheel setuptools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: MLeap executor tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       
@@ -36,7 +36,7 @@ jobs:
     name: MLeap benchmark tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       
@@ -61,7 +61,7 @@ jobs:
     name: All other sbt tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       
@@ -86,7 +86,7 @@ jobs:
     name: Python 3.9 tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       
@@ -111,7 +111,7 @@ jobs:
     name: Python 3.10 tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       
@@ -136,7 +136,7 @@ jobs:
     name: Python 3.11 tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       
@@ -161,7 +161,7 @@ jobs:
     name: Python 3.12 tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       
@@ -186,7 +186,7 @@ jobs:
     name: Python 3.13 tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       
@@ -222,7 +222,7 @@ jobs:
     needs: [ci-completion]
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       


### PR DESCRIPTION
Silences the Node 20 deprecation warning seen in the publish jobs by upgrading actions to the majors that run on Node 24 by default:

- `actions/checkout` v3/v4 → v5
- `actions/setup-python` v5 → v6
- `actions/setup-java` v4 → v5

Non-functional CI hygiene; independent of the Spark migration. `docker/*` and `sbt/setup-sbt` were not flagged and are left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)