### PR TITLE
docs: sync and clean up module READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ import scala.util.Using
     .load(datasetName)
     .withColumn("test_double", col("test_double").cast("double"))
 
-  // User out-of-the-box Spark transformers like you normally would
+  // Use out-of-the-box Spark transformers like you normally would
   val stringIndexer = new StringIndexer().
     setInputCol("test_string").
     setOutputCol("test_index")

--- a/mleap-benchmark/README.md
+++ b/mleap-benchmark/README.md
@@ -84,8 +84,8 @@ Linear Regression: ~23.7 microseconds (237/10000)
 
 MLeap row transformers take a lot of overhead out of transforming data
 by predefining the input and output schema of the rows you are
-transforming. This is the fastest execution mode MLeap provides, and it
-roughly 4x faster than the default transorms for our example pipelines.
+transforming. This is the fastest execution mode MLeap provides, and it is
+roughly 4x faster than the default transforms for our example pipelines.
 
 ```scala
 // For random forest pipeline

--- a/mleap-databricks-runtime-fat/README.md
+++ b/mleap-databricks-runtime-fat/README.md
@@ -8,22 +8,18 @@ to maven repos.
 
 ## Installation
 
-Requirements:
-
-1. `xgboost4j-spark` must be in the local M2 repository to build. [xgboost4j-spark installation](http://xgboost.readthedocs.io/en/latest/jvm/)
-
-After making sure `xgboost` is available to compilation, get a local copy of MLeap and build the Databricks ML Runtime Fat JAR.
+Get a local copy of MLeap and build the Databricks ML Runtime Fat JAR.
 
 ```
 # Use --recursive to get the submodule with MLeap protobuf definitions
 git clone --recursive https://github.com/combust/mleap.git
 cd mleap
 
-# Compile the Databrics Runtime Assembly JAR
+# Compile the Databricks Runtime assembly JAR
 sbt mleap-databricks-runtime-fat/assembly
 
-# Verify that it worked, you should see a file like: mleap-databricks-runtime-fat-assembly-<mleap version>-SNAPSHOT.jar
-ls mleap-databricks-runtime-fat/target/scala-2.11
+# Verify that it worked. You should see a file like: mleap-databricks-runtime-fat-assembly-<mleap version>.jar
+ls mleap-databricks-runtime-fat/target/scala-2.13
 ```
 
 ## Usage

--- a/mleap-databricks-runtime-testkit/README.md
+++ b/mleap-databricks-runtime-testkit/README.md
@@ -1,9 +1,13 @@
 # Submitting Tests to Spark
 
+Build the fat JAR and the testkit assembly, then submit the testkit to Spark.
+Replace the version and dependency versions to match the release you are
+building (see the compatibility matrix in the top-level README).
+
 ```
 sbt mleap-databricks-runtime-fat/assembly mleap-databricks-runtime-testkit/assembly
 
-spark-submit --jars $PWD/mleap-databricks-runtime-fat/target/scala-2.12/mleap-databricks-runtime-fat-assembly-0.24.0.jar \
-  --packages org.tensorflow:tensorflow-core-api:0.5.0,ml.dmlc:xgboost4j-spark:1.7.6 \
-  mleap-databricks-runtime-testkit/target/scala-2.12/mleap-databricks-runtime-testkit-assembly-0.24.0.jar
+spark-submit --jars $PWD/mleap-databricks-runtime-fat/target/scala-2.13/mleap-databricks-runtime-fat-assembly-0.25.1.jar \
+  --packages org.tensorflow:tensorflow-core-api:1.0.0,ml.dmlc:xgboost4j-spark_2.13:2.0.3 \
+  mleap-databricks-runtime-testkit/target/scala-2.13/mleap-databricks-runtime-testkit-assembly-0.25.1.jar
 ```

--- a/mleap-executor-testkit/README.md
+++ b/mleap-executor-testkit/README.md
@@ -1,0 +1,14 @@
+# MLeap Executor Testkit
+
+This module provides shared test utilities for verifying implementations of the
+MLeap `TransformService` trait.
+
+The main entry point is the `TransformServiceSpec` trait. Mix it into your own
+spec and implement the required methods, and it will run a full suite of tests
+that exercise loading, unloading, transforming, and streaming against your
+`TransformService` implementation. `TestUtil` provides sample models and leap
+frames used by the suite.
+
+This testkit is used by `mleap-executor-tests` and `mleap-grpc-server` to
+validate their executors. See the `mleap-executor` README for a description of
+the `TransformService` API.

--- a/mleap-executor-tests/README.md
+++ b/mleap-executor-tests/README.md
@@ -1,0 +1,17 @@
+# MLeap Executor Tests
+
+This module holds the integration tests for the `mleap-executor` module. It is
+kept separate from `mleap-executor` to avoid a circular dependency, since the
+tests rely on the shared `TransformServiceSpec` trait from
+`mleap-executor-testkit`.
+
+The tests cover the `MleapExecutor` and `LocalTransformService` implementations,
+along with the file and HTTP repositories that back them.
+
+Run them with:
+
+```bash
+sbt mleap-executor-tests/test
+```
+
+See the `mleap-executor` README for a description of the components under test.

--- a/mleap-executor/README.md
+++ b/mleap-executor/README.md
@@ -2,7 +2,7 @@
 
 The MLeap Executor handles the following tasks:
 
-1. Loading bundles from the local file system and HTTP sources (as well as other sources by implementing the `Repository` trait.
+1. Loading bundles from the local file system and HTTP sources (as well as other sources by implementing the `Repository` trait).
 2. Loading models into memory for execution and unloading them when not being used.
 3. Single transform requests of leap frames.
 4. Streaming frame transforms with support for transform delays, throttling, idle timeouts, parallelism and buffering.
@@ -195,7 +195,7 @@ val rowStream = Await.result(transformService.createRowStream(CreateRowStreamReq
 
 ### Transforming Rows with a Row Flow
 
-A Row Flow attaches to a Row Stream in order to start executing transforms. The idle timeout, throttle, transform delay, and parallelism of the flow are all limited by the underlying stream. A row flow is represented by an Akka `Flow[(StreamTransformRowRequest, Tag), (Try[Option[Row]], Tag)]`. The Tag is an arbitrary object used to associate the request with the response, as they can be returns out of order.
+A Row Flow attaches to a Row Stream in order to start executing transforms. The idle timeout, throttle, transform delay, and parallelism of the flow are all limited by the underlying stream. A row flow is represented by an Akka `Flow[(StreamTransformRowRequest, Tag), (Try[Option[Row]], Tag)]`. The Tag is an arbitrary object used to associate the request with the response, as they can be returned out of order.
 
 ```scala
 val flow = executor.createRowFlow[Int](

--- a/mleap-grpc-server/README.md
+++ b/mleap-grpc-server/README.md
@@ -1,0 +1,17 @@
+# MLeap gRPC Server
+
+This module provides the server side of the MLeap gRPC protocol. It exposes an
+`MleapExecutor` over gRPC so that remote clients can load, unload, transform,
+and stream data against MLeap models.
+
+The server is backed by the `mleap-executor` module and is paired with the
+`mleap-grpc` module, which provides the matching `GrpcClient`.
+
+## Running the Server
+
+The entry point is `ml.combust.mleap.grpc.server.Boot`. The server reads its
+settings from Typesafe configuration, including the listen port and the
+executor defaults. See `GrpcServerConfig.scala` for the available options.
+
+See the `mleap-serving` README for how to start both the gRPC server and the
+HTTP server from a single MLeap executor.

--- a/mleap-grpc/README.md
+++ b/mleap-grpc/README.md
@@ -1,0 +1,14 @@
+# MLeap gRPC
+
+This module provides the client side of the MLeap gRPC protocol. It contains
+`GrpcClient`, an implementation of the `TransformService` trait that executes
+models against a remote MLeap gRPC server, along with the type converters and
+Akka stream helpers used to translate between MLeap types and their Protobuf
+representations.
+
+Use this module when you want to load, unload, transform, and stream data
+against an MLeap model that is hosted by a separate `mleap-grpc-server`
+process. The server side is provided by the `mleap-grpc-server` module.
+
+See the `mleap-executor` README for a description of the `TransformService`
+API that `GrpcClient` implements.

--- a/mleap-repository-s3/README.md
+++ b/mleap-repository-s3/README.md
@@ -1,0 +1,34 @@
+# MLeap Repository S3
+
+This module provides an S3-backed `Repository` implementation for the MLeap
+executor. It lets the executor download MLeap bundles directly from Amazon S3
+using `s3://` URIs.
+
+This support is early and lightly tested. See `S3Repository.scala` for the
+current implementation.
+
+## Configuration
+
+Register the S3 repository with the executor by adding it to the executor
+repository configuration. The provider is
+`ml.combust.mleap.repository.s3.S3RepositoryProvider`.
+
+```hocon
+ml.combust.mleap.executor {
+  repository {
+    class = "ml.combust.mleap.executor.repository.MultiRepositoryProvider$"
+
+    repositories = [{
+      class = "ml.combust.mleap.executor.repository.FileRepositoryProvider$"
+    }, {
+      class = "ml.combust.mleap.executor.repository.HttpRepositoryProvider$"
+    }, {
+      class = "ml.combust.mleap.repository.s3.S3RepositoryProvider"
+    }]
+  }
+}
+```
+
+Credentials and region are resolved using the standard AWS default credential
+provider chain. See the `mleap-executor` README for more on repositories and
+the `TransformService` API.

--- a/mleap-serving/README.md
+++ b/mleap-serving/README.md
@@ -1,5 +1,11 @@
 # MLeap Serving
 
-Starts both the gRPC server and HTTP server, using a single MLeap executor.
+This module starts both the gRPC server and the HTTP server backed by a single
+MLeap executor, so you can serve models over both protocols from one process.
 
-See ```ml.combust.mleap.serving.RunServer.scala``` for more details.
+The gRPC server is provided by `mleap-grpc-server` and the HTTP server is
+provided by `mleap-spring-boot`. Both share the same `MleapExecutor`, so a model
+loaded through one interface is available through the other.
+
+The entry point is `ml.combust.mleap.serving.RunServer`. See that file for the
+available configuration and startup details.

--- a/mleap-tensorflow/README.md
+++ b/mleap-tensorflow/README.md
@@ -1,18 +1,28 @@
-# Tensorflow
+# MLeap TensorFlow
+
+This module provides TensorFlow support for MLeap, allowing TensorFlow graphs
+to be executed as transformers inside an MLeap pipeline.
+
 ## Build
-Environment variable `TENSORFLOW_PLATFORMS` can be used to reduce the number of tensorflow shared library downloaded
-The possible values are `windows-x86_64,linux-x86_64,macosx-x86_64`, and can be multiple.
-If it's not set, all three platform shared library will be downloaded.
+
+The `TENSORFLOW_PLATFORMS` environment variable controls which TensorFlow native
+shared libraries are downloaded at build time. The possible values are
+`windows-x86_64`, `linux-x86_64`, and `macosx-x86_64`, and multiple values can be
+comma-separated. If it is not set, all three platform libraries are downloaded.
 
 ## Test
 
-```
-sbt mleap-tensorflow/test 
+```bash
+sbt mleap-tensorflow/test
 ```
 
 ## Usage
-SBT
+
+Add the MLeap TensorFlow dependency along with the TensorFlow native library for
+your platform. Match the TensorFlow version to the one listed in the
+compatibility matrix in the top-level README.
+
 ```scala
 "ml.combust.mleap" %% "mleap-tensorflow" % mleapVersion
-"org.tensorflow" % "tensorflow-core-api" %  "0.3.1" classifier "linux-x86_64"
+"org.tensorflow" % "tensorflow-core-native" % "1.0.0" classifier "linux-x86_64"
 ```

--- a/mleap-xgboost-runtime/README.md
+++ b/mleap-xgboost-runtime/README.md
@@ -1,11 +1,11 @@
 # MLeap XGBoost Runtime
 
-We provide two implementation of XGboost for use at runtime:
-- XGboost4j (from `ml.dmlc.xgboost4j`): this is the official C++ implementation.
-- XGBoost-Predictor (from `biz.k11i.xgboost-predictor`): this is a much faster implementation written directly in Java.
+We provide two implementations of XGBoost for use at runtime:
+- XGBoost4j (from `ml.dmlc.xgboost4j`): this is the official implementation backed by the native XGBoost library.
+- XGBoost-Predictor (from `ai.h2o.xgboost-predictor`): this is a much faster implementation written directly in Java.
 
-By default, MLeap Bundles are de-serialized into XGboost4j Booster objects.
-In order to use the Predictor implementation, you may:
+By default, MLeap bundles are deserialized into XGBoost4j Booster objects.
+To use the Predictor implementation instead:
 
 1. Create a `resources/reference.conf` file in your project, like this:
     ```
@@ -14,7 +14,7 @@ In order to use the Predictor implementation, you may:
       "ml.combust.mleap.xgboost.runtime.bundle.ops.XGBoostPredictorRegressionOp"
     ]
     ```
-2. add this to your project's pom file:
+2. Add this to your project's pom file so the shade plugin appends our `reference.conf` into MLeap's, registering our Ops:
     ```
     <!-- Append our reference.conf into MLeap's reference.conf so our Ops are registered -->
       <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">

--- a/mleap-xgboost-spark/README.md
+++ b/mleap-xgboost-spark/README.md
@@ -1,8 +1,8 @@
 # MLeap XGBoost Spark
 
-This is the XGBoost Spark integration for MLeap. It provides Bundle Ops for serializing/deserialize XGBoostClassificationModel and XGBoostRegressionModel to a Bundle.ML file.
+This is the XGBoost Spark integration for MLeap. It provides Bundle Ops for serializing and deserializing `XGBoostClassificationModel` and `XGBoostRegressionModel` to a Bundle.ML file.
 
-Make sure to set `ml.combust.mleap.version` to the desired MLeap version.
+Add the dependency to your project, setting `ml.combust.mleap.version` and `scala.binary.version` to the values you need.
 
 ```
 <dependency>
@@ -12,7 +12,7 @@ Make sure to set `ml.combust.mleap.version` to the desired MLeap version.
 </dependency>
 ```
 
-Once you have added `mleap-xgboost-spark` as a dependency to your project, you should be able to train an `XGBoostClassificationModel` or `XGBoostRegressionModel` using the `XGBoostEstimator`. You will then be able to export the classifier or regression to MLeap along with the rest of your Spark pipeline.
+Once you have added `mleap-xgboost-spark` as a dependency, train an `XGBoostClassificationModel` or `XGBoostRegressionModel` using the `XGBoostClassifier` or `XGBoostRegressor` estimator. You can then export the fitted model to MLeap along with the rest of your Spark pipeline.
 
 [Exporting Spark pipelines with MLeap](https://combust.github.io/mleap-docs/spark/)
 

--- a/python/README.md
+++ b/python/README.md
@@ -3,6 +3,7 @@
 This package contains libraries to integrate MLeap with:
 * PySpark
 * Scikit-Learn
+* gensim (optional, Word2Vec serialization)
 * TensorFlow (coming soon)
 
 # Installation
@@ -93,6 +94,19 @@ A simple example is the `StandardScaler` transformer that normalizes the data gi
 Scikit-Learn pipelines, just like Spark Pipelines, can be serialized to an MLeap Bundle and deployed to an [MLeap runtime environment](https://combust.github.io/mleap-docs/mleap-runtime/).
 
 You can also take your scikit pipelines and deploy them to your Spark cluster, because MLeap can de-serialize them into a Spark ML Pipeline and execute them on data frames.
+
+## gensim Integration
+
+MLeap provides an optional integration that serializes a gensim `Word2Vec` model to Bundle.ML. `gensim` is not installed as a dependency of this package, so install it yourself if you want to use this integration.
+
+```python
+from gensim.models import Word2Vec
+import mleap.gensim.word2vec
+
+model = Word2Vec(sentences, vector_size=100)
+model.mlinit(input_features='sentence', prediction_column='word_vectors')
+model.serialize_to_bundle('/tmp', 'word2vec-pipeline')
+```
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Brings all 18 `README.md` files into sync, fixes stale facts, and fills in the empty ones.

- **Filled 5 empty READMEs**: `mleap-grpc`, `mleap-grpc-server`, `mleap-repository-s3`, `mleap-executor-testkit`, `mleap-executor-tests`.
- **Corrected stale versions** against the current build (MLeap 0.25.1, Scala 2.13.17, Spark 4.1.1, TensorFlow Java 1.0.0, XGBoost 2.0.3) in the TensorFlow, Databricks runtime fat, and Databricks testkit READMEs.
- **Fixed outdated APIs and coordinates**: `XGBoostClassifier`/`XGBoostRegressor` (was the removed `XGBoostEstimator`), `ai.h2o` xgboost-predictor group (was `biz.k11i`), assembly output paths (`scala-2.13`).
- **Polish**: expanded the sparse `mleap-serving` README, fixed typos, and cross-linked related modules.

No em-dashes or prose semicolons. Only README files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)